### PR TITLE
Bump wvware

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -118,7 +118,7 @@ dependencies {
     })
 
     implementation 'com.viliussutkus89:pdf2htmlex-android:0.18.15'
-    implementation 'com.viliussutkus89:wvware-android:1.2.4'
+    implementation 'com.viliussutkus89:wvware-android:1.2.6'
     implementation 'com.github.huzongyao:AndroidMagic:v1.1.2'
 
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/src/main/cpp/CoreWrapper.cpp
+++ b/app/src/main/cpp/CoreWrapper.cpp
@@ -70,19 +70,26 @@ Java_at_tomtasche_reader_background_CoreWrapper_parseNative(JNIEnv *env, jobject
         jboolean paging = env->GetBooleanField(options, pagingField);
 
         try {
-            // __android_log_print(ANDROID_LOG_VERBOSE, "smn", "%s", outputPathCpp.c_str());
+            __android_log_print(ANDROID_LOG_VERBOSE, "smn", "%s", "test0");
 
             odr::DecodedFile file(inputPathCpp);
-            const auto fileCategory = odr::OpenDocumentReader::category_by_type(file.file_type());
+__android_log_print(ANDROID_LOG_VERBOSE, "smn", "%s", "test1");
+
+const auto fileCategory = odr::OpenDocumentReader::category_by_type(file.file_type());
+__android_log_print(ANDROID_LOG_VERBOSE, "smn", "%s", "test2");
 
             {
-                const auto extensionCpp = odr::OpenDocumentReader::type_to_string(file.file_type());
+__android_log_print(ANDROID_LOG_VERBOSE, "smn", "%s", "test3");
+
+const auto extensionCpp = odr::OpenDocumentReader::type_to_string(file.file_type());
                 const auto extensionC = extensionCpp.c_str();
                 jstring extension = env->NewStringUTF(extensionC);
 
                 jfieldID extensionField = env->GetFieldID(resultClass, "extension",
                                                           "Ljava/lang/String;");
                 env->SetObjectField(result, extensionField, extension);
+
+                __android_log_print(ANDROID_LOG_VERBOSE, "smn", "%s", extensionCpp.c_str());
             }
 
             if (!ooxml &&


### PR DESCRIPTION
Fails to build locally:

> 2 files found with path 'lib/arm64-v8a/libtmpfile.so' from inputs:
>  - /home/tom/.gradle/caches/transforms-3/513a48b0e16f651df7eea76973bbe8b7/transformed/jetified-pdf2htmlex-android-0.18.15/jni/arm64-v8a/libtmpfile.so
>  - /home/tom/.gradle/caches/transforms-3/1b3eba609759e77dce95c63ab6ce581f/transformed/jetified-wvware-android-1.2.6/jni/arm64-v8a/libtmpfile.so
> If you are using jniLibs and CMake IMPORTED targets, see
> https://developer.android.com/r/tools/jniLibs-vs-imported-targets

FYI, has to be something you changed since 1.2.4 @ViliusSutkus89 

(obviously didn't mean to commit those debug logs :facepalm: )