### PR TITLE
Update pdf2htmlEX-Android to 0.18.17 (CVE-2020-13790)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -119,7 +119,7 @@ dependencies {
         exclude group: 'com.android.support'
     })
 
-    implementation 'com.viliussutkus89:pdf2htmlex-android:0.18.16'
+    implementation 'com.viliussutkus89:pdf2htmlex-android:0.18.17'
     implementation 'com.viliussutkus89:wvware-android:1.2.4'
     implementation 'com.github.huzongyao:AndroidMagic:v1.1.2'
 


### PR DESCRIPTION
Hello,

Turns out one of our transitive dependencies has a CVE - libjpeg-turbo until 2.10.0 was affected by [CVE-2020-13790](https://nvd.nist.gov/vuln/detail/CVE-2020-13790).

pdf2htmlEX-Android-0.18.16 used affected libjpeg-turbo-2.0.4 .
pdf2htmlEX-Android-0.18.17 uses fixed libjpeg-turbo-2.1.3 .

Not sure if we actually hit the exploitable code path, but this update should fix it.

pdf2htmlEX-Android issue 59

Vilius