### PR TITLE
Update conan install tasks in gradle (allows running ./gradlew clean without running conan install)

### DIFF
--- a/.github/workflows/android_main.yml
+++ b/.github/workflows/android_main.yml
@@ -53,10 +53,11 @@ jobs:
     - name: conan profile
       run: conan profile detect
 
-    - name: conan login
-      run: conan remote login odr admin --password ${{ secrets.ARTIFACTORY }}
     - name: gradle
       run: ./gradlew assembleDebug lintProDebug lintLiteDebug --stacktrace
+
+    - name: conan login
+      run: conan remote login odr admin --password ${{ secrets.ARTIFACTORY }}
 
     - name: upload binaries to conan repo
       run: conan upload "*" --check --confirm --remote odr

--- a/.github/workflows/android_main.yml
+++ b/.github/workflows/android_main.yml
@@ -50,11 +50,11 @@ jobs:
 
     - name: conan remote
       run: conan remote add --index 0 odr https://artifactory.opendocument.app/artifactory/api/conan/conan
-    - name: conan login
-      run: conan remote login odr admin --password ${{ secrets.ARTIFACTORY }}
     - name: conan profile
       run: conan profile detect
 
+    - name: conan login
+      run: conan remote login odr admin --password ${{ secrets.ARTIFACTORY }}
     - name: gradle
       run: ./gradlew assembleDebug lintProDebug lintLiteDebug --stacktrace
 
@@ -118,8 +118,6 @@ jobs:
 
     - name: conan remote
       run: conan remote add --index 0 odr https://artifactory.opendocument.app/artifactory/api/conan/conan
-    - name: conan login
-      run: conan remote login odr admin --password ${{ secrets.ARTIFACTORY }}
     - name: conan profile
       run: conan profile detect
 

--- a/.github/workflows/android_main.yml
+++ b/.github/workflows/android_main.yml
@@ -172,8 +172,8 @@ jobs:
 
           test ! -f sorry_but_tests_are_failing
 
-    - name: conan remote
-      run: conan remote add --index 0 odr https://artifactory.opendocument.app/artifactory/api/conan/conan
+    - name: conan login
+      run: conan remote login odr admin --password ${{ secrets.ARTIFACTORY }}
 
     - name: upload binaries to conan repo
       run: conan upload "*" --check --confirm --remote odr

--- a/.github/workflows/android_main.yml
+++ b/.github/workflows/android_main.yml
@@ -172,6 +172,9 @@ jobs:
 
           test ! -f sorry_but_tests_are_failing
 
+    - name: conan remote
+      run: conan remote add --index 0 odr https://artifactory.opendocument.app/artifactory/api/conan/conan
+
     - name: upload binaries to conan repo
       run: conan upload "*" --check --confirm --remote odr
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -170,3 +170,9 @@ dependencies {
     implementation 'androidx.test.espresso:espresso-idling-resource:3.5.1'
     implementation 'androidx.annotation:annotation:1.8.0'
 }
+
+tasks.named("clean") {
+    doLast {
+        delete(new File(projectDir, ".cxx"))
+    }
+}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,21 +8,21 @@ android {
     ndkVersion "26.3.11579264"
 }
 
-task conanProfile {
-    file("build").mkdirs()
+task conanProfile(type: Copy) {
+    from "conanprofile.txt"
+    into "build/"
 
-    copy {
-        from "conanprofile.txt"
-        into "build"
-    }
-
+    doLast {
     def file = file("build/conanprofile.txt")
     def content = file.text
     content = content.replace("<NDK_PATH>", android.ndkDirectory.toString())
     file.write(content)
+    }
 }
 
 task conanInstall {
+    dependsOn(conanProfile)
+    doFirst {
     ["armv7", "armv8", "x86", "x86_64"].each { String arch ->
         exec {
             commandLine(
@@ -37,7 +37,9 @@ task conanInstall {
             )
         }
     }
+    }
 }
+preBuild.dependsOn conanInstall
 
 android {
     defaultConfig {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,30 +13,30 @@ tasks.register('conanProfile', Copy) {
     into "build/"
 
     doLast {
-    def file = file("build/conanprofile.txt")
-    def content = file.text
-    content = content.replace("<NDK_PATH>", android.ndkDirectory.toString())
-    file.write(content)
+        def file = file("build/conanprofile.txt")
+        def content = file.text
+        content = content.replace("<NDK_PATH>", android.ndkDirectory.toString())
+        file.write(content)
     }
 }
 
 tasks.register('conanInstall') {
     dependsOn(conanProfile)
     doFirst {
-    ["armv7", "armv8", "x86", "x86_64"].each { String arch ->
-        exec {
-            commandLine(
-                "conan", "install", ".",
-                "--output-folder=build/conan/" + arch,
-                "--build=missing",
-                "--profile:host=build/conanprofile.txt",
-                "-s", "arch=" + arch,
-                "-s", "build_type=Release",
-                "-s", "&:build_type=RelWithDebInfo",
-                "-s", "odrcore/*:build_type=RelWithDebInfo",
-            )
+        ["armv7", "armv8", "x86", "x86_64"].each { String arch ->
+            exec {
+                commandLine(
+                    "conan", "install", ".",
+                    "--output-folder=build/conan/" + arch,
+                    "--build=missing",
+                    "--profile:host=build/conanprofile.txt",
+                    "-s", "arch=" + arch,
+                    "-s", "build_type=Release",
+                    "-s", "&:build_type=RelWithDebInfo",
+                    "-s", "odrcore/*:build_type=RelWithDebInfo",
+                )
+            }
         }
-    }
     }
 }
 preBuild.dependsOn conanInstall

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -176,3 +176,25 @@ tasks.named("clean") {
         delete(new File(projectDir, ".cxx"))
     }
 }
+
+// This is needed because task "clean" depends on these tasks:
+//:app:externalNativeBuildCleanLiteDebug
+//:app:externalNativeBuildCleanLiteRelease
+//:app:externalNativeBuildCleanProDebug
+//:app:externalNativeBuildCleanProRelease
+// And these tasks expect to find build/conan/[ABI]/conan_toolchain.cmake files
+//
+// If build folder is malformed, we can't run `gradle clean` without this workaround.
+// This is because we supply our (conan's) CMAKE_TOOLCHAIN_FILE.
+// This workaround removes these "clean" task dependencies if conan_toolchain.cmake is not found (malformed build dir)
+project.afterEvaluate {
+    ["armv7", "armv8", "x86", "x86_64"].each { String arch ->
+        if (!new File(projectDir, 'build/conan/' + arch + 'conan_toolchain.cmake').exists()) {
+            def cleanTask = tasks.named("clean").get()
+            cleanTask.dependsOn -= tasks.named('externalNativeBuildCleanLiteDebug')
+            cleanTask.dependsOn -= tasks.named('externalNativeBuildCleanLiteRelease')
+            cleanTask.dependsOn -= tasks.named('externalNativeBuildCleanProDebug')
+            cleanTask.dependsOn -= tasks.named('externalNativeBuildCleanProRelease')
+        }
+    }
+}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
     ndkVersion "26.3.11579264"
 }
 
-task conanProfile(type: Copy) {
+tasks.register('conanProfile', Copy) {
     from "conanprofile.txt"
     into "build/"
 
@@ -20,7 +20,7 @@ task conanProfile(type: Copy) {
     }
 }
 
-task conanInstall {
+tasks.register('conanInstall') {
     dependsOn(conanProfile)
     doFirst {
     ["armv7", "armv8", "x86", "x86_64"].each { String arch ->

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -171,6 +171,8 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.8.0'
 }
 
+// Without removing .cxx dir on cleanup, double gradle clean is erroring out.
+// Before removing this workaround, check if "./gradlew assembleDebug; ./gradlew clean; ./gradlew clean" works
 tasks.named("clean") {
     doFirst {
         delete getLayout().getProjectDirectory().dir(".cxx")

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ tasks.register('conanProfile', Copy) {
 }
 
 tasks.register('conanInstall') {
-    dependsOn(conanProfile)
+    dependsOn(tasks.named("conanProfile"))
     doFirst {
         ["armv7", "armv8", "x86", "x86_64"].each { String arch ->
             exec {
@@ -39,7 +39,9 @@ tasks.register('conanInstall') {
         }
     }
 }
-preBuild.dependsOn conanInstall
+tasks.named("preBuild").configure { preBuildTask ->
+    preBuildTask.dependsOn(tasks.named("conanInstall"))
+}
 
 android {
     defaultConfig {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -172,29 +172,7 @@ dependencies {
 }
 
 tasks.named("clean") {
-    doLast {
-        delete(new File(projectDir, ".cxx"))
-    }
-}
-
-// This is needed because task "clean" depends on these tasks:
-//:app:externalNativeBuildCleanLiteDebug
-//:app:externalNativeBuildCleanLiteRelease
-//:app:externalNativeBuildCleanProDebug
-//:app:externalNativeBuildCleanProRelease
-// And these tasks expect to find build/conan/[ABI]/conan_toolchain.cmake files
-//
-// If build folder is malformed, we can't run `gradle clean` without this workaround.
-// This is because we supply our (conan's) CMAKE_TOOLCHAIN_FILE.
-// This workaround removes these "clean" task dependencies if conan_toolchain.cmake is not found (malformed build dir)
-project.afterEvaluate {
-    ["armv7", "armv8", "x86", "x86_64"].each { String arch ->
-        if (!new File(projectDir, 'build/conan/' + arch + 'conan_toolchain.cmake').exists()) {
-            def cleanTask = tasks.named("clean").get()
-            cleanTask.dependsOn -= tasks.named('externalNativeBuildCleanLiteDebug')
-            cleanTask.dependsOn -= tasks.named('externalNativeBuildCleanLiteRelease')
-            cleanTask.dependsOn -= tasks.named('externalNativeBuildCleanProDebug')
-            cleanTask.dependsOn -= tasks.named('externalNativeBuildCleanProRelease')
-        }
+    doFirst {
+        delete getLayout().getProjectDirectory().dir(".cxx")
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,3 +3,10 @@ plugins {
     id 'com.google.gms.google-services'version '4.4.1' apply false
     id 'com.google.firebase.crashlytics' version '3.0.1' apply false
 }
+
+// Android Studio's sync task expects CMake to work properly
+// Proper CMake, due to our supplied conan_toolchain.cmake, requires conan to be
+// done as a dependency of Android Studio sync
+tasks.named('prepareKotlinBuildScriptModel').configure { prepareKotlinBuildScriptModelTask ->
+    prepareKotlinBuildScriptModelTask.dependsOn(project("app").tasks.named("conanInstall"))
+}


### PR DESCRIPTION
Hello,

I've updated conan tasks in [build.gradle](app/build.gradle). Now they only execute only when invoked. Gradle tasks are not exactly functions, the body of each task is executed when loading gradle file. Tasks can also contain `doFirst` and `doLast` which are executed only when the task is invoked, not just loaded. Changed `conanProfile` task type to `Copy`, which takes `from` and `into` arguments and executes them in it's `doFirst` stage. Can't change `conanInstall` task type to Exec, because Exec type usually only executes once.

Made the `conanInstall` task as a dependency of task `preBuild` and `conanProfile` task as a dependency of task `conanInstall`.

Long story short - this allows running `./gradlew clean` without executing those tasks.

As a bonus, I've added additional task to clean `.cxx` directory during `gradle clean`. `.cxx` is an additional build directory, no idea why regular `gradle clean` is not cleaning it up.