### PR TITLE
address #348

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,8 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:installLocation="auto"
-    android:versionCode="185"
-    android:versionName="3.31"
+    android:versionCode="186"
+    android:versionName="3.32"
     tools:ignore="GoogleAppIndexingWarning">
 
     <uses-permission android:name="android.permission.INTERNET" />

--- a/app/src/main/java/at/tomtasche/reader/background/CoreWrapper.java
+++ b/app/src/main/java/at/tomtasche/reader/background/CoreWrapper.java
@@ -107,20 +107,20 @@ public class CoreWrapper {
         public String extension;
     }
 
-    public class CoreCouldNotOpenException extends RuntimeException {}
+    public static class CoreCouldNotOpenException extends RuntimeException {}
 
-    public class CoreEncryptedException extends RuntimeException {}
+    public static class CoreEncryptedException extends RuntimeException {}
 
-    public class CoreCouldNotTranslateException extends RuntimeException {}
+    public static class CoreCouldNotTranslateException extends RuntimeException {}
 
-    public class CoreUnexpectedFormatException extends RuntimeException {}
+    public static class CoreUnexpectedFormatException extends RuntimeException {}
 
-    public class CoreUnexpectedErrorCodeException extends RuntimeException {}
+    public static class CoreUnexpectedErrorCodeException extends RuntimeException {}
 
-    public class CoreUnknownErrorException extends RuntimeException {}
+    public static class CoreUnknownErrorException extends RuntimeException {}
 
-    public class CoreCouldNotEditException extends RuntimeException {}
+    public static class CoreCouldNotEditException extends RuntimeException {}
 
-    public class CoreCouldNotSaveException extends RuntimeException {}
+    public static class CoreCouldNotSaveException extends RuntimeException {}
 
 }

--- a/app/src/main/java/at/tomtasche/reader/background/OdfLoader.java
+++ b/app/src/main/java/at/tomtasche/reader/background/OdfLoader.java
@@ -81,8 +81,12 @@ public class OdfLoader extends FileLoader {
         CoreWrapper.CoreResult coreResult = lastCore.parse(coreOptions);
 
         String coreExtension = coreResult.extension;
-        // "unnamed" refers to default of Meta::typeToString
-        if (coreExtension != null && !coreExtension.equals("unnamed")) {
+        if (coreResult.exception == null && "pdf".equals(coreExtension)) {
+            // some PDFs do not cause an error in the core
+            // https://github.com/opendocument-app/OpenDocument.droid/issues/348#issuecomment-2446888981
+            throw new CoreWrapper.CoreCouldNotTranslateException();
+        } else if (!"unnamed".equals(coreExtension)) {
+            // "unnamed" refers to default of Meta::typeToString
             options.fileExtension = coreExtension;
 
             String fileType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(coreExtension);


### PR DESCRIPTION
Some PDFs come out of OdfLoader without errors, which is not how it's supposed to work. Therefore, make sure all PDFs end up in PdfLoader using a workaround.