### PR TITLE
Fix Pro users seeing upgrade prompts

### DIFF
--- a/app/src/main/java/at/tomtasche/reader/nonfree/BillingManager.java
+++ b/app/src/main/java/at/tomtasche/reader/nonfree/BillingManager.java
@@ -16,10 +16,10 @@ public class BillingManager {
     public void initialize(Context context, AnalyticsManager analyticsManager, AdManager adManager) {
         this.adManager = adManager;
 
-        // Handle Pro flavor first, regardless of enabled state
+        billingPreferences = new BillingPreferences(context);
+
         if (BuildConfig.FLAVOR.equals("pro")) {
-            adManager.removeAds();
-            return;
+            billingPreferences.setPurchased(true);
         }
 
         if (!enabled) {
@@ -27,7 +27,6 @@ public class BillingManager {
             return;
         }
 
-        billingPreferences = new BillingPreferences(context);
         enforceAds();
     }
 

--- a/app/src/main/java/at/tomtasche/reader/nonfree/BillingManager.java
+++ b/app/src/main/java/at/tomtasche/reader/nonfree/BillingManager.java
@@ -16,18 +16,18 @@ public class BillingManager {
     public void initialize(Context context, AnalyticsManager analyticsManager, AdManager adManager) {
         this.adManager = adManager;
 
+        // Handle Pro flavor first, regardless of enabled state
+        if (BuildConfig.FLAVOR.equals("pro")) {
+            adManager.removeAds();
+            return;
+        }
+
         if (!enabled) {
             adManager.showGoogleAds();
-
             return;
         }
 
         billingPreferences = new BillingPreferences(context);
-
-        if (BuildConfig.FLAVOR.equals("pro")) {
-            billingPreferences.setPurchased(true);
-        }
-
         enforceAds();
     }
 


### PR DESCRIPTION
Based on a user review: "Terrible app! I bought the pro version, and yet the app keeps trying to force another payment."

Pro users were incorrectly seeing payment prompts because BillingManager initialization would return early when enabled=false, skipping the Pro flavor check. This left billingPreferences=null, causing hasPurchased() to return false.

Moved Pro flavor handling before the enabled check to ensure Pro users always get ads removed regardless of billing manager state.

Fixes user reports of "app keeps trying to force another payment" in Pro version.

🤖 Generated with [Claude Code](https://claude.ai/code)