### PR TITLE
Default to strict file-type registration (fixes #477)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -77,6 +77,7 @@
 
         <activity-alias
             android:name="at.tomtasche.reader.ui.activity.MainActivity.CATCH_ALL"
+            android:enabled="false"
             android:exported="true"
             android:label="@string/app_title"
             android:targetActivity="at.tomtasche.reader.ui.activity.MainActivity"
@@ -208,6 +209,7 @@
         </activity-alias>
         <activity-alias
             android:name="at.tomtasche.reader.ui.activity.MainActivity.STRICT_CATCH"
+            android:enabled="true"
             android:exported="true"
             android:label="@string/app_title"
             android:targetActivity="at.tomtasche.reader.ui.activity.MainActivity"
@@ -225,10 +227,18 @@
                 <data android:mimeType="application/vnd.oasis.opendocument.spreadsheet-template" />
                 <data android:mimeType="application/vnd.oasis.opendocument.presentation" />
                 <data android:mimeType="application/vnd.oasis.opendocument.presentation-template" />
+                <data android:mimeType="application/vnd.oasis.opendocument.graphics" />
+                <data android:mimeType="application/vnd.oasis.opendocument.graphics-template" />
                 <data android:mimeType="application/octet-stream" />
                 <data android:mimeType="application/pdf" />
                 <data android:mimeType="application/vnd.openxmlformats-officedocument.wordprocessingml.document" />
+                <data android:mimeType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" />
                 <data android:mimeType="application/msword" />
+                <!-- raw types handled by RawLoader; text/plain (not text/*) avoids re-matching text/vcard contacts (#477) -->
+                <data android:mimeType="text/plain" />
+                <data android:mimeType="text/csv" />
+                <data android:mimeType="image/*" />
+                <data android:mimeType="application/zip" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -288,6 +298,34 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.doc" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.doc" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.doc" />
+                <data android:pathPattern=".*\\.xlsx" />
+                <data android:pathPattern=".*\\..*\\.xlsx" />
+                <data android:pathPattern=".*\\..*\\..*\\.xlsx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.xlsx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xlsx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xlsx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xlsx" />
+                <data android:pathPattern=".*\\.txt" />
+                <data android:pathPattern=".*\\..*\\.txt" />
+                <data android:pathPattern=".*\\..*\\..*\\.txt" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.txt" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.txt" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.txt" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.txt" />
+                <data android:pathPattern=".*\\.csv" />
+                <data android:pathPattern=".*\\..*\\.csv" />
+                <data android:pathPattern=".*\\..*\\..*\\.csv" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.csv" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.csv" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.csv" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.csv" />
+                <data android:pathPattern=".*\\.zip" />
+                <data android:pathPattern=".*\\..*\\.zip" />
+                <data android:pathPattern=".*\\..*\\..*\\.zip" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.zip" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.zip" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.zip" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.zip" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -348,6 +386,34 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.doc" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.doc" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.doc" />
+                <data android:pathPattern=".*\\.xlsx" />
+                <data android:pathPattern=".*\\..*\\.xlsx" />
+                <data android:pathPattern=".*\\..*\\..*\\.xlsx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.xlsx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xlsx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xlsx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xlsx" />
+                <data android:pathPattern=".*\\.txt" />
+                <data android:pathPattern=".*\\..*\\.txt" />
+                <data android:pathPattern=".*\\..*\\..*\\.txt" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.txt" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.txt" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.txt" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.txt" />
+                <data android:pathPattern=".*\\.csv" />
+                <data android:pathPattern=".*\\..*\\.csv" />
+                <data android:pathPattern=".*\\..*\\..*\\.csv" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.csv" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.csv" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.csv" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.csv" />
+                <data android:pathPattern=".*\\.zip" />
+                <data android:pathPattern=".*\\..*\\.zip" />
+                <data android:pathPattern=".*\\..*\\..*\\.zip" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.zip" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.zip" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.zip" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.zip" />
             </intent-filter>
         </activity-alias>
 

--- a/app/src/main/java/at/tomtasche/reader/ui/activity/MainActivity.java
+++ b/app/src/main/java/at/tomtasche/reader/ui/activity/MainActivity.java
@@ -216,11 +216,18 @@ public class MainActivity extends AppCompatActivity implements MenuProvider {
         }
     }
 
+    private static final String PREF_CATCH_ALL_ENABLED = "catch_all_enabled";
+
     private void initializeCatchAllSwitch() {
         ComponentName catchAllComponent = new ComponentName(this, "at.tomtasche.reader.ui.activity.MainActivity.CATCH_ALL");
         ComponentName strictCatchComponent = new ComponentName(this, "at.tomtasche.reader.ui.activity.MainActivity.STRICT_CATCH");
 
-        boolean isCatchAllEnabled = getPackageManager().getComponentEnabledSetting(catchAllComponent) != PackageManager.COMPONENT_ENABLED_STATE_DISABLED;
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
+
+        // catch-all is only active if the user explicitly opted in. new installs and
+        // existing users who never touched the switch default to STRICT_CATCH, so we
+        // no longer volunteer to open unrelated file types like contacts (issue #477).
+        boolean isCatchAllEnabled = preferences.getBoolean(PREF_CATCH_ALL_ENABLED, false);
 
         // retoggle components for users upgrading to latest version of app
         toggleComponent(catchAllComponent, isCatchAllEnabled);
@@ -231,6 +238,8 @@ public class MainActivity extends AppCompatActivity implements MenuProvider {
         catchAllSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                preferences.edit().putBoolean(PREF_CATCH_ALL_ENABLED, isChecked).apply();
+
                 toggleComponent(catchAllComponent, isChecked);
                 toggleComponent(strictCatchComponent, !isChecked);
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,7 +45,7 @@
     <string name="landing_intro_view">OpenDocument Reader allows you to view documents that are stored in OpenDocument format (.odt, .ods, .odp and .odg) wherever you are.</string>
     <string name="landing_intro_search">With OpenDocument Reader you can read and search through your documents in a breeze.</string>
     <string name="landing_intro_edit">Found one last typo left to fix ahead of your big presentation? It now supports modifications too!</string>
-    <string name="landing_intro_open_all">This app registers to open all file types by default in order to support apps like \"Samsung My Files\". You may turn this feature off here if it causes problems for you.</string>
+    <string name="landing_intro_open_all">By default this app only offers to open document files. If another app like \"Samsung My Files\" won\'t let you open a document here, turn this on to register for all file types.</string>
     <string name="tts_status_reading">Reading…</string>
     <string name="tts_status_initializing">Initializing TTS…</string>
     <string name="tts_status_ready">Ready!</string>


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Problem

The app registered a **true catch-all** `VIEW` intent-filter (`content`/`file` scheme with no MIME/extension constraint, plus `*/*`). As a result the OS offered OpenDocument Reader for completely unrelated content — including vCard/contact URIs, as reported in #477.

## Root cause

A narrower `STRICT_CATCH` activity-alias (specific document MIME types + extension patterns) and a landing-screen toggle to switch between them **already existed**. The real issue was that `CATCH_ALL` was the *default*, and the old code force-enabled it on every launch — so narrowing was never a blocker, it just wasn't the default.

## Changes

- **Manifest**: `CATCH_ALL` → `android:enabled="false"`, `STRICT_CATCH` → `android:enabled="true"`, so fresh installs are strict from the very first launch (even a cold VIEW-intent launch).
- **`MainActivity`**: the alias choice is now driven by a `SharedPreferences` flag instead of unreliable component state. New installs and existing users who never touched the switch default to strict; an explicit toggle is remembered. Users who genuinely want catch-all can still opt in via the landing-screen switch.
- **Landing-screen string**: reworded for the inverted default (opt *in* to all-file-types, rather than opt out).

## MIME/extension list renewal

Audited the `STRICT_CATCH` list against what the app actually opens (`CoreLoader.isSupported`, `RawLoader` whitelist/blacklist, PDF via pdf2htmlEX) and updated it.

**Document types (`CoreLoader`) — fixed gaps:**
- Added ODF **graphics** MIME types (`…opendocument.graphics` / `…graphics-template`) — the `.odg` *extension* patterns were already registered but the MIME type was missing, so `.odg` content URIs didn't match.
- Added **xlsx** (`…spreadsheetml.sheet`) MIME type + `.xlsx` extension patterns — supported by `CoreLoader` with OOXML enabled (the default), previously unreachable in strict mode except via `application/octet-stream`.
- `pptx` intentionally left out — the core still has it disabled (TODO in `CoreLoader`).

**Raw types (`RawLoader`) — kept openable by default:**
- Registered `text/plain`, `text/csv`, `image/*` and `application/zip`, plus `.txt` / `.csv` / `.zip` extension patterns, so plain text, images, CSV and zip still offer the app by default.
- **`text/plain` is used deliberately instead of `text/*`** — a `text/*` wildcard would re-match `text/vcard` and reintroduce the exact contacts bug from #477. (`RawLoader` also blacklists `text/vcard`, so the app never wanted them anyway.)

## Behavior change note

Existing users who relied on the catch-all default now only get offered for the types above by default. They can re-enable all-file-types with the landing-screen switch. This is the intended fix for #477.

## Testing

- `./gradlew :app:compileProDebugJavaWithJavac` — passes
- `./gradlew :app:processProDebugMainManifest` — manifest merges cleanly