### PR TITLE
Log odrcore version and commit hash during initialize

### DIFF
--- a/app/src/main/cpp/core_wrapper.cpp
+++ b/app/src/main/cpp/core_wrapper.cpp
@@ -79,6 +79,12 @@ namespace {
 
 std::optional<odr::Document> s_document;
 
+JNIEXPORT jstring JNICALL
+Java_at_tomtasche_reader_background_CoreWrapper_versionStringNative(JNIEnv *env, jclass clazz) {
+    std::string versionString = "odrcore " + odr::identify();
+    return env->NewStringUTF(versionString.c_str());
+}
+
 JNIEXPORT void JNICALL
 Java_at_tomtasche_reader_background_CoreWrapper_setGlobalParams(JNIEnv *env, jclass clazz,
                                                                 jobject params) {

--- a/app/src/main/cpp/core_wrapper.hpp
+++ b/app/src/main/cpp/core_wrapper.hpp
@@ -4,6 +4,9 @@
 
 extern "C" {
 
+JNIEXPORT jstring JNICALL
+Java_at_tomtasche_reader_background_CoreWrapper_versionStringNative(JNIEnv *env, jclass clazz);
+
 JNIEXPORT void JNICALL
 Java_at_tomtasche_reader_background_CoreWrapper_setGlobalParams(JNIEnv *env, jclass clazz,
                                                                 jobject params);

--- a/app/src/main/java/at/tomtasche/reader/background/CoreWrapper.java
+++ b/app/src/main/java/at/tomtasche/reader/background/CoreWrapper.java
@@ -1,6 +1,7 @@
 package at.tomtasche.reader.background;
 
 import android.content.Context;
+import android.util.Log;
 
 import com.viliussutkus89.android.assetextractor.AssetExtractor;
 
@@ -22,7 +23,15 @@ public class CoreWrapper {
 
     public static native void setGlobalParams(GlobalParams params);
 
+    public static String versionString() {
+        return versionStringNative();
+    }
+
+    private static native String versionStringNative();
+
     public static void initialize(Context context) {
+        Log.i("CoreWrapper", versionString());
+
         File assetsDirectory = new File(context.getFilesDir(), "assets");
         File odrCoreDataDirectory = new File(assetsDirectory, "odrcore");
         File libmagicDataDirectory = new File(assetsDirectory, "libmagic");


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Exposes the odrcore library identification (version, commit hash, dirty/debug flags) to Java through a single JNI function, `CoreWrapper.versionString()`, which returns `"odrcore " + odr::identify()`. The string is composed on the C++ side, so no per-field wrappers are needed.

`CoreWrapper.initialize()` now logs it to logcat, e.g.:

```
I/CoreWrapper: odrcore 5.5.0 (unknown)
```

Note: the commit hash currently reports `unknown` because the conan package is built from the GitHub tag tarball (no `.git`) and the recipe does not define `GIT_HEAD_SHA1`. Injecting the real hash is a follow-up in conan-odr-index.