### PR TITLE
Go back to landing screen instead of closing the app

### DIFF
--- a/app/src/main/java/at/tomtasche/reader/ui/activity/DocumentFragment.java
+++ b/app/src/main/java/at/tomtasche/reader/ui/activity/DocumentFragment.java
@@ -72,6 +72,11 @@ public class DocumentFragment extends Fragment implements LoaderService.LoaderLi
     private FileLoader.Result resultOnStart;
     private Throwable errorOnStart;
 
+    // loads cannot be canceled once running, so results of abandoned loads
+    // (e.g. user navigated back while the document was still loading) are
+    // identified by their uri and dropped
+    private Uri lastRequestedUri;
+
     private int lastSelectedTab = -1;
 
     private LoaderServiceQueue serviceQueue;
@@ -237,6 +242,8 @@ public class DocumentFragment extends Fragment implements LoaderService.LoaderLi
     public void loadUri(Uri uri, boolean persistentUri, boolean editable) {
         initializePageView();
 
+        lastRequestedUri = uri;
+
         FileLoader.Options options = new FileLoader.Options();
         options.originalUri = uri;
         options.persistentUri = persistentUri;
@@ -369,6 +376,12 @@ public class DocumentFragment extends Fragment implements LoaderService.LoaderLi
     }
 
     private boolean isActivityReadyForResult(FileLoader.Result result) {
+        if (lastRequestedUri != null && !lastRequestedUri.equals(result.options.originalUri)) {
+            crashManager.log("dropping result of abandoned load: " + result.options.originalUri);
+
+            return false;
+        }
+
         Activity activity = getActivity();
         if (activity == null || isStateSaved()) {
             resultOnStart = result;

--- a/app/src/main/java/at/tomtasche/reader/ui/activity/MainActivity.java
+++ b/app/src/main/java/at/tomtasche/reader/ui/activity/MainActivity.java
@@ -31,6 +31,7 @@ import android.widget.LinearLayout;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
+import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.SwitchCompat;
@@ -75,6 +76,7 @@ public class MainActivity extends AppCompatActivity implements MenuProvider {
     }
 
     private static final String SAVED_KEY_LAST_CACHE_URI = "LAST_CACHE_URI";
+    private static final String SAVED_KEY_OPENED_EXTERNALLY = "OPENED_EXTERNALLY";
     private static final boolean IS_TESTING = isTesting();
     private static final int GOOGLE_REQUEST_CODE = 1993;
     private static final String DOCUMENT_FRAGMENT_TAG = "document_fragment";
@@ -101,6 +103,11 @@ public class MainActivity extends AppCompatActivity implements MenuProvider {
     private Uri lastUri;
     private Uri loadOnStart;
     private Uri lastSaveUri;
+
+    // documents opened from another app keep the default back behavior (returning
+    // to that app), while documents opened from within the app go back to the
+    // landing screen instead of closing the app
+    private boolean documentOpenedExternally;
 
     @Nullable
     private CountingIdlingResource openFileIdlingResource;
@@ -167,6 +174,10 @@ public class MainActivity extends AppCompatActivity implements MenuProvider {
 
         documentFragment = (DocumentFragment) getSupportFragmentManager().findFragmentByTag(DOCUMENT_FRAGMENT_TAG);
 
+        if (savedInstanceState != null) {
+            documentOpenedExternally = savedInstanceState.getBoolean(SAVED_KEY_OPENED_EXTERNALLY, false);
+        }
+
         if (documentFragment != null && documentFragment.hasLastResult()) {
             // nothing else to do
 
@@ -182,6 +193,7 @@ public class MainActivity extends AppCompatActivity implements MenuProvider {
             // (i.e. after bringing app back from background)
             if (getIntent().getData() != null) {
                 loadOnStart = getIntent().getData();
+                documentOpenedExternally = true;
 
                 analyticsManager.report(AnalyticsConstants.EVENT_SELECT_CONTENT, AnalyticsConstants.PARAM_CONTENT_TYPE, "other");
             } else {
@@ -210,7 +222,9 @@ public class MainActivity extends AppCompatActivity implements MenuProvider {
         crashManager.log("onStart");
 
         if (loadOnStart != null) {
-            loadUri(loadOnStart);
+            // loadOnStart either came from an external intent or from a restored
+            // instance state, in which case documentOpenedExternally was restored too
+            loadUri(loadOnStart, documentOpenedExternally);
 
             loadOnStart = null;
         }
@@ -260,6 +274,7 @@ public class MainActivity extends AppCompatActivity implements MenuProvider {
         super.onSaveInstanceState(outState);
 
         outState.putParcelable(SAVED_KEY_LAST_CACHE_URI, lastUri);
+        outState.putBoolean(SAVED_KEY_OPENED_EXTERNALLY, documentOpenedExternally);
     }
 
     @Override
@@ -330,7 +345,7 @@ public class MainActivity extends AppCompatActivity implements MenuProvider {
         if (intent.getData() != null) {
             crashManager.log("onNewIntent loadUri");
 
-            loadUri(intent.getData());
+            loadUri(intent.getData(), true);
 
             analyticsManager.report(AnalyticsConstants.EVENT_SELECT_CONTENT, AnalyticsConstants.PARAM_CONTENT_TYPE, "other");
         }
@@ -370,6 +385,12 @@ public class MainActivity extends AppCompatActivity implements MenuProvider {
     }
 
     public void loadUri(Uri uri) {
+        loadUri(uri, false);
+    }
+
+    private void loadUri(Uri uri, boolean openedExternally) {
+        documentOpenedExternally = openedExternally;
+
         lastSaveUri = null;
         lastUri = uri;
 
@@ -564,6 +585,43 @@ public class MainActivity extends AppCompatActivity implements MenuProvider {
         }
 
         return super.onKeyDown(keyCode, event);
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (documentFragment != null && !documentOpenedExternally) {
+            analyticsManager.report("back_to_landing");
+
+            closeDocument();
+
+            return;
+        }
+
+        super.onBackPressed();
+    }
+
+    private void closeDocument() {
+        if (documentFragment != null) {
+            removeMenuProvider(documentFragment);
+
+            getSupportFragmentManager()
+                    .beginTransaction()
+                    .remove(documentFragment)
+                    .commitNow();
+
+            documentFragment = null;
+        }
+
+        ActionBar bar = getSupportActionBar();
+        bar.removeAllTabs();
+        bar.setNavigationMode(ActionBar.NAVIGATION_MODE_STANDARD);
+
+        lastUri = null;
+
+        documentContainer.setVisibility(View.GONE);
+        landingContainer.setVisibility(View.VISIBLE);
+
+        analyticsManager.setCurrentScreen(this, "screen_main");
     }
 
     public void findDocument() {


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

When a document is open and the user presses back, the app used to just close. That was intentional for the "opened from another app" case (back should return to the calling app), but it's bad UX when the document was opened from within the app.

This keeps both behaviors:
- Document opened via the in-app picker or recents: back now closes the document and returns to the landing screen.
- Document opened from another app (VIEW intent / `onNewIntent`): back still returns to the calling app, unchanged.

Implementation notes:
- `MainActivity` tracks `documentOpenedExternally`; it is saved/restored via instance state so rotation doesn't lose it.
- `closeDocument()` removes the `DocumentFragment` (and its menu provider, so the document menu items disappear), resets the action bar tabs, and shows the landing container again.
- Fullscreen back handling is untouched (`onKeyDown` still leaves fullscreen first).