### PR TITLE
Remove upload hint snackbar after loading a document

### DIFF
--- a/app/src/main/java/at/tomtasche/reader/ui/activity/DocumentFragment.java
+++ b/app/src/main/java/at/tomtasche/reader/ui/activity/DocumentFragment.java
@@ -425,8 +425,6 @@ public class DocumentFragment extends Fragment implements LoaderService.LoaderLi
 
         if (result.loaderType == FileLoader.LoaderType.RAW || result.loaderType == FileLoader.LoaderType.ONLINE) {
             offerReopen(activity, options, R.string.toast_hint_unsupported_file, false);
-        } else if (result.loaderType == FileLoader.LoaderType.CORE) {
-            offerUpload(activity, options, false);
         }
 
         dismissProgress();
@@ -521,7 +519,7 @@ public class DocumentFragment extends Fragment implements LoaderService.LoaderLi
 
         if (result.loaderType == FileLoader.LoaderType.CORE) {
             if (serviceQueue.getService().isOnlineSupported(options)) {
-                offerUpload(activity, options, true);
+                offerUpload(activity, options);
             } else {
                 offerReopen(activity, options, R.string.toast_error_illegal_file_reopen, true);
             }
@@ -546,50 +544,40 @@ public class DocumentFragment extends Fragment implements LoaderService.LoaderLi
         SnackbarHelper.show(getActivity(), R.string.toast_error_save_failed, null, true, true);
     }
 
-    private void offerUpload(Activity activity, FileLoader.Options options, boolean invasive) {
+    private void offerUpload(Activity activity, FileLoader.Options options) {
         String fileType = options.fileType;
-        if (invasive) {
-            analyticsManager.report("upload_offer_invasive", AnalyticsConstants.PARAM_CONTENT_TYPE, fileType, AnalyticsConstants.PARAM_CONTENT, options.originalUri);
 
-            AlertDialog.Builder builder = new AlertDialog.Builder(activity);
-            builder.setTitle(R.string.toast_error_illegal_file);
-            builder.setMessage(R.string.dialog_upload_file);
+        analyticsManager.report("upload_offer_invasive", AnalyticsConstants.PARAM_CONTENT_TYPE, fileType, AnalyticsConstants.PARAM_CONTENT, options.originalUri);
 
-            builder.setPositiveButton(getString(R.string.action_upload),
-                    new DialogInterface.OnClickListener() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+        builder.setTitle(R.string.toast_error_illegal_file);
+        builder.setMessage(R.string.dialog_upload_file);
 
-                        @Override
-                        public void onClick(DialogInterface dialog,
-                                            int whichButton) {
-                            analyticsManager.report("load_upload", AnalyticsConstants.PARAM_CONTENT_TYPE, fileType);
+        builder.setPositiveButton(getString(R.string.action_upload),
+                new DialogInterface.OnClickListener() {
 
-                            loadWithType(FileLoader.LoaderType.ONLINE, options);
+                    @Override
+                    public void onClick(DialogInterface dialog,
+                                        int whichButton) {
+                        analyticsManager.report("load_upload", AnalyticsConstants.PARAM_CONTENT_TYPE, fileType);
 
-                            dialog.dismiss();
-                        }
-                    });
-            builder.setNegativeButton(getString(android.R.string.cancel), new DialogInterface.OnClickListener() {
-                @Override
-                public void onClick(DialogInterface dialog, int i) {
-                    analyticsManager.report("load_upload_cancel", AnalyticsConstants.PARAM_CONTENT_TYPE, fileType);
+                        loadWithType(FileLoader.LoaderType.ONLINE, options);
 
-                    offerReopen(activity, options, R.string.toast_error_illegal_file_reopen, true);
+                        dialog.dismiss();
+                    }
+                });
+        builder.setNegativeButton(getString(android.R.string.cancel), new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int i) {
+                analyticsManager.report("load_upload_cancel", AnalyticsConstants.PARAM_CONTENT_TYPE, fileType);
 
-                    dialog.dismiss();
-                }
-            });
+                offerReopen(activity, options, R.string.toast_error_illegal_file_reopen, true);
 
-            builder.show();
-        } else {
-            analyticsManager.report("upload_offer_subtle", AnalyticsConstants.PARAM_CONTENT_TYPE, fileType, AnalyticsConstants.PARAM_CONTENT, options.originalUri);
+                dialog.dismiss();
+            }
+        });
 
-            SnackbarHelper.show(activity, R.string.toast_hint_upload_file, new Runnable() {
-                @Override
-                public void run() {
-                    loadWithType(FileLoader.LoaderType.ONLINE, options);
-                }
-            }, false, false);
-        }
+        builder.show();
     }
 
     private void offerReopen(Activity activity, FileLoader.Options options, int description, boolean isIndefinite) {

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -3,7 +3,6 @@
     <string name="toast_error_generic">Etwas schlimmes ist passiert. Datei konnte nicht geöffnet werden.</string>
     <string name="toast_error_find_file">Datei konnte nicht gefunden werden.</string>
     <string name="toast_error_illegal_file">Diese Datei scheint keines der unterstützten Formate zu haben.</string>
-    <string name="toast_hint_upload_file">Nicht zufrieden damit wie die Datei angezeigt wird? Lade sie vorübergehend hoch um die Formatierung zu verbessern.</string>
     <string name="toast_error_save_nofile">Kein Ort zum Speichern der Datei ausgewählt.</string>
     <string name="toast_error_save_failed">Datei konnte nicht gespeichert werden. Bitte kontaktiere support@opendocument.app</string>
     <string name="toast_error_out_of_memory">Speicher geht zur Neige! Zu viele Bilder oder eine zu große Datei.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -3,7 +3,6 @@
     <string name="toast_error_generic">Etwas Schlimmes ist passiert. Datei konnte nicht geöffnet werden.</string>
     <string name="toast_error_find_file">Datei konnte nicht gefunden werden.</string>
     <string name="toast_error_illegal_file">Diese Datei scheint keines der unterstützten Formate zu haben.</string>
-    <string name="toast_hint_upload_file">Nicht zufrieden damit wie die Datei angezeigt wird? Lade sie vorübergehend hoch um die Formatierung zu verbessern.</string>
     <string name="toast_error_save_nofile">Kein Ort zum Speichern der Datei ausgewählt.</string>
     <string name="toast_error_save_failed">Datei konnte nicht gespeichert werden. Bitte kontaktiere support@opendocument.app</string>
     <string name="toast_error_out_of_memory">Speicher geht zur Neige! Zu viele Bilder oder eine zu große Datei.</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -4,7 +4,6 @@
     <string name="toast_error_find_file">Ha sido imposible encontrar el archivo. ¿Seguro que no se ha eliminado?</string>
     <string name="toast_error_illegal_file">Parece que este formato de archivo no es compatible.</string>
     <string name="toast_hint_unsupported_file">¿No está contento con cómo se muestra el archivo? Abrir en su lugar en otra aplicación.</string>
-    <string name="toast_hint_upload_file">¿No está satisfecho con cómo se muestra el archivo? Subirlo temporalmente para mejorar el formato.</string>
     <string name="toast_error_out_of_memory">¡El teléfono se ha quedado sin memoria! Hay demasiadas imágenes o el archivo es demasiado grande.</string>
     <string name="toast_error_password_protected">El documento está protegido con contraseña.</string>
     <string name="dialog_recent_title">Documentos recientes</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -4,7 +4,6 @@
     <string name="toast_error_find_file">Ha sido imposible encontrar el archivo. ¿Seguro que no se ha eliminado?</string>
     <string name="toast_error_illegal_file">Parece que este formato de archivo no es compatible.</string>
     <string name="toast_hint_unsupported_file">¿No está contento con cómo se muestra el archivo? Abrir en su lugar en otra aplicación.</string>
-    <string name="toast_hint_upload_file">¿No está satisfecho con cómo se muestra el archivo? Subirlo temporalmente para mejorar el formato.</string>
     <string name="toast_error_reopen_noapp">No se ha encontrado ninguna aplicación en el dispositivo que soporte este tipo de archivo.</string>
     <string name="toast_error_out_of_memory">¡El teléfono se ha quedado sin memoria! Hay demasiadas imágenes o el archivo es demasiado grande.</string>
     <string name="toast_error_password_protected">El documento está protegido con contraseña.</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -6,7 +6,6 @@
     <string name="toast_error_illegal_file">Ce format de fichier ne semble pas être supporté.</string>
     <string name="toast_error_illegal_file_reopen">Le format de ce fichier n\'est pas pris en charge. Essayez de l\'ouvrir avec une autre application.</string>
     <string name="toast_hint_unsupported_file">Vous n\'êtes pas satisfaits de l\'affichage du fichier ? Ouvrez-le avec une autre application.</string>
-    <string name="toast_hint_upload_file">Vous n\'êtes pas satisfait de la façon dont le fichier est affiché ? Téléchargez-le pour améliorer son rendu.</string>
     <string name="toast_error_save_nofile">Aucun dossier pour enregistrer le fichier sélectionné.</string>
     <string name="toast_error_save_failed">Le fichier n\'a pas pu être enregistré. Veuillez contacter support@opendocument.app</string>
     <string name="toast_error_out_of_memory">Place insuffisante dans la mémoire de l\'appareil ! Il y a trop d\'images ou les fichiers sont trop volumineux.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -6,7 +6,6 @@
     <string name="toast_error_illegal_file">Ce format de fichier ne semble pas être supporté.</string>
     <string name="toast_error_illegal_file_reopen">Le format de ce fichier n\'est pas pris en charge. Essayez de l\'ouvrir avec une autre application.</string>
     <string name="toast_hint_unsupported_file">Vous n\'êtes pas satisfaits de l\'affichage du fichier ? Ouvrez-le avec une autre application.</string>
-    <string name="toast_hint_upload_file">Vous n\'êtes pas satisfait de la façon dont le fichier est affiché ? Téléchargez-le pour améliorer son rendu.</string>
     <string name="toast_error_reopen_noapp">Aucune application sur l\'appareil ne gère ce type de fichier.</string>
     <string name="toast_error_save_nofile">Aucun dossier pour enregistrer le fichier sélectionné.</string>
     <string name="toast_error_save_failed">Le fichier n\'a pas pu être enregistré. Veuillez contacter support@opendocument.app</string>

--- a/app/src/main/res/values-ga-rIE/strings.xml
+++ b/app/src/main/res/values-ga-rIE/strings.xml
@@ -5,7 +5,6 @@
     <string name="toast_error_illegal_file">Tá an dealramh air nach dtugtar tacaíocht den chineál comhad sin.</string>
     <string name="toast_error_illegal_file_reopen">Formáid chomhaid nach dtugtar tacaíocht di. Féach í a oscailt i bhfeidhmchláirín eile.</string>
     <string name="toast_hint_unsupported_file">An é nach bhfuil tú sásta leis an mbealach ina thaispeántar an comhad? Oscail le feidhmchlár eile é ina ionad sin.</string>
-    <string name="toast_hint_upload_file">An é nach bhfuil tú sásta leis an mbealach ina thaispeántar an comhad? Uasluchtaigh go sealadach é chun an formáidiú a fheabhsú.</string>
     <string name="toast_error_save_nofile">Níl aon áit chun an comhad a chur i dtaisce.</string>
     <string name="toast_error_save_failed">Níorbh fhéidir an comhad a chur i dtaisce. Déan teagmháil le support@opendocument.app</string>
     <string name="toast_error_out_of_memory">Níl cuimhne fágtha sa ghuthán! Tá an iomarca grianghraif ann nó tá an comhad rómhór.</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -4,7 +4,6 @@
     <string name="toast_error_find_file">Níorbh fhéidir an comhad a fháil. B\'fhéidir nach ann dó a thuilleadh?</string>
     <string name="toast_error_illegal_file">Tá an dealramh air nach dtugtar tacaíocht den chineál comhad sin.</string>
     <string name="toast_hint_unsupported_file">An é nach bhfuil tú sásta leis an mbealach ina thaispeántar an comhad? Oscail le feidhmchlár eile é ina ionad sin.</string>
-    <string name="toast_hint_upload_file">An é nach bhfuil tú sásta leis an mbealach ina thaispeántar an comhad? Uasluchtaigh go sealadach é chun an formáidiú a fheabhsú.</string>
     <string name="toast_error_reopen_noapp">Níor aimsíodh aon fheidhmchlár ar an ngléas a thugann tacaíocht don chineál comhad sin.</string>
     <string name="toast_error_out_of_memory">Níl cuimhne fágtha sa ghuthán! Tá an iomarca grianghraif ann nó tá an comhad rómhór.</string>
     <string name="toast_error_password_protected">Tá an cháipéis faoi chosaint focal faire</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -5,7 +5,6 @@
     <string name="toast_error_illegal_file">यह एक समर्थित file format नहीं है।</string>
     <string name="toast_error_illegal_file_reopen">असमर्थित फ़ाइल format। इसे किसी अन्य app में खोलने का प्रयास करें।</string>
     <string name="toast_hint_unsupported_file">आप इसे प्रदर्शित किए जाने के तरीके से खुश नहीं हैं। इसे किसी दूसरे एप्प में खोले।</string>
-    <string name="toast_hint_upload_file">आप इसे प्रदर्शित किए जाने के तरीके से खुश नहीं हैं। सुधार के लिए इसे अस्थायी रूप से अपलोड करें।</string>
     <string name="toast_error_save_nofile">फ़ाइल को save करने के लिए कोई स्थान नहीं चुना गया है।</string>
     <string name="toast_error_save_failed">फ़ाइल save नहीं हो पाया। कृपया support@opendocument.app पर संपर्क करें</string>
     <string name="toast_error_out_of_memory">फ़ोन मे मेमोरी नही है। फ़ोन में बहुत अधिक चित्र हैं, या फ़ाइल बहुत बड़ी है।</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -5,7 +5,6 @@
     <string name="toast_error_illegal_file">Questo non sembra essere un formato di file supportato.</string>
     <string name="toast_error_illegal_file_reopen">Formato file non supportato. Prova ad aprirlo in un\'altra app.</string>
     <string name="toast_hint_unsupported_file">Non sei soddisfatto di come viene visualizzato il documento? Aprilo in un\'altra app.</string>
-    <string name="toast_hint_upload_file">Non sei soddisfatto di come viene visualizzato il file? Caricalo temporaneamente per migliorare la formattazione.</string>
     <string name="toast_error_save_nofile">Nessun posto in cui salvare il file da scegliere.</string>
     <string name="toast_error_save_failed">Impossibile salvare il file. Si prega di contattare support@opendocument.app</string>
     <string name="toast_error_out_of_memory">Memoria del telefono esaurita! Troppe immagini o file troppo grandi.</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -5,7 +5,6 @@
     <string name="toast_error_illegal_file">これはサポートされているファイル形式ではないようです。</string>
     <string name="toast_error_illegal_file_reopen">サポートしないファイル形式です。別のアプリで開いてみてください。</string>
     <string name="toast_hint_unsupported_file">ファイルの表示方法に満足できませんか？ 代わりに別のアプリで開きます。</string>
-    <string name="toast_hint_upload_file">ファイルの表示方法に満足できませんか? 一時的にアップロードして、形式を改善します。</string>
     <string name="toast_error_save_nofile">選択したファイルを保存する場所がありません。</string>
     <string name="toast_error_save_failed">ファイルを保存できませんでした。support@opendoocument.app にお問い合わせください</string>
     <string name="toast_error_out_of_memory">デバイスのメモリ不足です! 写真が多すぎるかファイルが大きすぎます。</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -5,7 +5,6 @@
     <string name="toast_error_illegal_file">これはサポートされているファイル形式ではないようです。</string>
     <string name="toast_error_illegal_file_reopen">サポートしないファイル形式です。別のアプリで開いてみてください。</string>
     <string name="toast_hint_unsupported_file">ファイルの表示方法に満足できませんか？ 代わりに別のアプリで開きます。</string>
-    <string name="toast_hint_upload_file">ファイルの表示方法に満足できませんか? 一時的にアップロードして、形式を改善します。</string>
     <string name="toast_error_reopen_noapp">お使いのデバイスで、このファイル形式をサポートするアプリが見つかりませんでした。</string>
     <string name="toast_error_out_of_memory">デバイスのメモリ不足です! 写真が多すぎるかファイルが大きすぎます。</string>
     <string name="toast_error_password_protected">ドキュメントがパスワードで保護されています</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -5,7 +5,6 @@
     <string name="toast_error_illegal_file">지원하지 않는 파일입니다. </string>
     <string name="toast_error_illegal_file_reopen">지원하지 않는 파일입니다. 다른 앱에서 열어 보세요. </string>
     <string name="toast_hint_unsupported_file">열린 파일이 제대로 보여지지 않습니까? 다른 앱에서 여시겠습니까?</string>
-    <string name="toast_hint_upload_file">파일이 잘 보여지지 않는다면, 포맷을 제대로 보여주기 위해서 임시로 업로드하세요.</string>
     <string name="toast_error_save_nofile">선택한 파일을 저장할 위치가 없습니다.</string>
     <string name="toast_error_save_failed">파일이 저장되지 않았습니다. support@opendocument.app 으로 문의하세요.</string>
     <string name="toast_error_out_of_memory">메모리가 부족합니다! 사진이 너무 많거나 파일이 너무 큽니다.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -5,7 +5,6 @@
     <string name="toast_error_illegal_file">Parece que este formato de arquivo não é suportado.</string>
     <string name="toast_error_illegal_file_reopen">Formato de arquivo não suportado. Tente abri-lo em outro aplicativo.</string>
     <string name="toast_hint_unsupported_file">Não está satisfeito com a forma como o arquivo é exibido? Abra em outro aplicativo.</string>
-    <string name="toast_hint_upload_file">Não está feliz com como o arquivo é exibido? Faça o upload temporariamente para melhorar a formatação.</string>
     <string name="toast_error_save_nofile">Não há lugar para salvar o arquivo a escolher.</string>
     <string name="toast_error_save_failed">Arquivo não pôde ser salvo. Por favor, contate support@opendocument.app</string>
     <string name="toast_error_out_of_memory">Telefone sem memória! Muitas fotos ou arquivo muito grande.</string>

--- a/app/src/main/res/values-sl-rSI/strings.xml
+++ b/app/src/main/res/values-sl-rSI/strings.xml
@@ -5,7 +5,6 @@
     <string name="toast_error_illegal_file">Videti je, da ta oblika datoteke ni podprta.</string>
     <string name="toast_error_illegal_file_reopen">Nepodprta oblika datoteke. Poizkusite jo odpreti v drugem programu.</string>
     <string name="toast_hint_unsupported_file">Niste zadovoljni z načinom prikaza datoteke? Odprite jo v drugem programu.</string>
-    <string name="toast_hint_upload_file">Vam ni všeč, kako je datoteka prikazana? Začasno jo pošljite, da izboljšate oblikovanje.</string>
     <string name="toast_error_save_nofile">Mesto za shranjevanje datoteke ni izbrano.</string>
     <string name="toast_error_save_failed">Datoteke ni bilo mogoče shraniti. Prosimo, pišite na support@opendocument.app.</string>
     <string name="toast_error_out_of_memory">Telefonu je zmanjkalo pomnilnika! Preveč slik ali prevelika datoteka.</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -5,7 +5,6 @@
     <string name="toast_error_illegal_file">Videti je, da ta oblika datoteke ni podprta.</string>
     <string name="toast_error_illegal_file_reopen">Nepodprta oblika datoteke. Poizkusite jo odpreti v drugem programu.</string>
     <string name="toast_hint_unsupported_file">Niste zadovoljni z načinom prikaza datoteke? Odprite jo v drugem programu.</string>
-    <string name="toast_hint_upload_file">Vam ni všeč, kako je datoteka prikazana? Začasno jo pošljite, da izboljšate oblikovanje.</string>
     <string name="toast_error_reopen_noapp">Na napravi ni bilo najdenega programa, ki podpira to vrsto datotek.</string>
     <string name="toast_error_save_nofile">Mesto za shranjevanje datoteke ni izbrano.</string>
     <string name="toast_error_save_failed">Datoteke ni bilo mogoče shraniti. Prosimo, pišite na support@opendocument.app.</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -5,7 +5,6 @@
     <string name="toast_error_illegal_file">Bu, desteklenen bir dosya biçimi gibi görünmüyor.</string>
     <string name="toast_error_illegal_file_reopen">Desteklenmeyen dosya biçimi. Başka bir uygulamada açmayı deneyin.</string>
     <string name="toast_hint_unsupported_file">Dosyanın görüntüsünden memnun değil misiniz? Bunun yerine başka bir uygulamada açın.</string>
-    <string name="toast_hint_upload_file">Dosyanın görüntülenme biçiminden memnun değil misiniz? Biçimi iyileştirmek için geçici olarak yükleyin.</string>
     <string name="toast_error_save_nofile">Seçilen dosyayı kaydetmek için yer yok.</string>
     <string name="toast_error_save_failed">Dosya kaydedilemedi. Lütfen support@opendocument.app ile iletişime geçin</string>
     <string name="toast_error_out_of_memory">Aygıt belleği yetersiz! Çok fazla resim var veya dosya çok büyük.</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -5,7 +5,6 @@
     <string name="toast_error_illegal_file">Bu, desteklenen bir dosya biçimi gibi görünmüyor.</string>
     <string name="toast_error_illegal_file_reopen">Desteklenmeyen dosya biçimi. Başka bir uygulamada açmayı deneyin.</string>
     <string name="toast_hint_unsupported_file">Dosyanın görüntüsünden memnun değil misiniz? Bunun yerine başka bir uygulamada açın.</string>
-    <string name="toast_hint_upload_file">Dosyanın görüntülenme biçiminden memnun değil misiniz? Biçimi iyileştirmek için geçici olarak yükleyin.</string>
     <string name="toast_error_reopen_noapp">Aygıtda bu tür dosyaları destekleyen uygulama bulunamadı.</string>
     <string name="toast_error_save_nofile">Seçilen dosyayı kaydetmek için yer yok.</string>
     <string name="toast_error_save_failed">Dosya kaydedilemedi. Lütfen support@opendocument.app ile iletişime geçin</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -5,7 +5,6 @@
     <string name="toast_error_illegal_file">此文件格式似乎不受支持。</string>
     <string name="toast_error_illegal_file_reopen">不受支持的文件格式。请尝试在另一个应用程序中打开它。</string>
     <string name="toast_hint_unsupported_file">对文件的显示效果不满意？在另一个应用中打开它。</string>
-    <string name="toast_hint_upload_file">对文件的显示效果不满意？将其临时上传到云端服务器中，以改善其格式。</string>
     <string name="toast_error_save_nofile">没有地方保存选中的文件。</string>
     <string name="toast_error_save_failed">无法保存文件。请联系 support@opendocument.app</string>
     <string name="toast_error_out_of_memory">设备内存不足！可能是因为文件中的图片太多了，也可能是文件体积过大。</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -4,7 +4,6 @@
     <string name="toast_error_find_file">找不到此文件。或许它已经不在那里了？</string>
     <string name="toast_error_illegal_file">此文件格式似乎不受支持。</string>
     <string name="toast_hint_unsupported_file">对文件的显示效果不满意？在另一个应用中打开它。</string>
-    <string name="toast_hint_upload_file">对文件的显示效果不满意？将其临时上传到云端服务器中，以改善其格式。</string>
     <string name="toast_error_reopen_noapp">在本设备上找不到支持此类型的文件的应用。</string>
     <string name="toast_error_out_of_memory">设备内存不足！可能是因为文件中的图片太多了，也可能是文件体积过大。</string>
     <string name="toast_error_password_protected">此文档受密码保护。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,7 +7,6 @@
     <string name="toast_error_illegal_file">This doesn\'t seem to be a supported file format.</string>
     <string name="toast_error_illegal_file_reopen">Unsupported file format. Try opening it in another app.</string>
     <string name="toast_hint_unsupported_file">Not happy with how the file is displayed? Open it in another app instead.</string>
-    <string name="toast_hint_upload_file">Not happy with how the file is displayed? Upload it temporarily to improve formatting.</string>
     <string name="toast_error_save_nofile">No place to save the file to chosen.</string>
     <string name="toast_error_save_failed">File could not be saved. Please contact support@opendocument.app</string>
     <string name="toast_error_out_of_memory">Device out of memory! Too many pictures, or file too big.</string>


### PR DESCRIPTION
Every document successfully loaded by the core showed a snackbar hinting at the temporary-upload alternative ("Not happy with how the file is displayed? Upload it temporarily…"). It reads like something the user has to act on and is just annoying.

- Drop the snackbar from `onLoadSuccess`.
- `offerUpload` loses its `invasive` parameter — only the dialog flavor remains, still shown from `onUnsupported` when the format can't be handled locally but the online converter supports it.
- Remove the now-unused `toast_hint_upload_file` string from all locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YipcjaY5h5f1CQjGwCgGV