### PR TITLE
Only show per-page tabs for spreadsheets

### DIFF
--- a/app/src/main/cpp/core_wrapper.cpp
+++ b/app/src/main/cpp/core_wrapper.cpp
@@ -13,6 +13,7 @@
 
 #include <android/log.h>
 
+#include <algorithm>
 #include <string>
 #include <optional>
 #include <filesystem>
@@ -284,18 +285,24 @@ Java_at_tomtasche_reader_background_CoreWrapper_hostFileNative(JNIEnv *env, jcla
             s_server->connect_service(service, prefixCpp);
             odr::HtmlViews htmlViews = service.list_views();
 
+            // spreadsheets show one tab per sheet; every other format only shows
+            // the full "document" view without tabs (if the service provides one -
+            // e.g. plain text and image files only have a single differently named view)
+            bool isSpreadsheet = file.is_document_file() &&
+                                 (file.as_document_file().document_type() ==
+                                  odr::DocumentType::spreadsheet);
+            bool hasDocumentView = std::any_of(
+                    htmlViews.begin(), htmlViews.end(),
+                    [](const odr::HtmlView &view) { return view.name() == "document"; });
+
             for (const auto &view: htmlViews) {
                 __android_log_print(ANDROID_LOG_INFO, "smn", "view name=%s path=%s",
                                     view.name().c_str(), view.path().c_str());
-                if (file.is_document_file() && (
-                        (((file.as_document_file().document_type() ==
-                           odr::DocumentType::presentation) ||
-                          (file.as_document_file().document_type() ==
-                           odr::DocumentType::drawing)) &&
-                         (view.name() != "document")) ||
-                        ((file.as_document_file().document_type() ==
-                          odr::DocumentType::spreadsheet) &&
-                         (view.name() == "document")))) {
+                if (isSpreadsheet) {
+                    if (view.name() == "document") {
+                        continue;
+                    }
+                } else if (hasDocumentView && (view.name() != "document")) {
                     continue;
                 }
 


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

The view filter in `core_wrapper.cpp` only special-cased presentations, drawings, and spreadsheets, so any other multi-view format fell through and got one action-bar tab per page — visible with PDFs since the switch to the odr-only engine.

New logic:
- Spreadsheets: unchanged — one tab per sheet, the combined "document" view is skipped.
- Everything else (PDF, text documents, presentations, drawings, …): only the full "document" view is kept, so no tabs appear.
- Services without a "document" view (plain text renders a "text" view, images an "image" view) keep their single view as-is instead of ending up with no views at all.

Verified the file compiles against the odrcore 5.5.0 headers with the NDK toolchain (`-fsyntax-only`).