### PR TITLE
Update dependencies and modernize gradle setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Document Processing Pipeline:**
 - `CoreLoader` - Primary document processor using the native C++ ODR core library
-- `WvwareDocLoader` - MS Word document processor using wvware library
 - `RawLoader` - Plain text and other raw file processor  
 - `OnlineLoader` - Remote document fetcher
 - `MetadataLoader` - Document metadata extractor
@@ -57,7 +56,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 **Native Dependencies:**
 - Uses Conan package manager for C++ dependencies
 - CMake build system for native C++ core library (`odr-core`)
-- NDK version 26.3.11579264 required
+- NDK version 28.1.13356709 required
 - C++20 standard
 
 **Core Library Integration:**
@@ -77,11 +76,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Core Android:**
 - AndroidX libraries (AppCompat, Core, Material, WebKit)
-- Firebase (Analytics, Crashlytics, Storage, Auth, Remote Config)
 - Google Play Services (Ads, Review, User Messaging Platform)
 
 **Document Processing:**
-- `app.opendocument:wvware-android` - MS Word document support
 - Custom ODR core library via Conan
 
 **Testing:**
@@ -91,8 +88,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Configuration Notes
 
-- Minimum SDK: 23, Target SDK: 34
-- MultiDex enabled for large dependency set
+- Minimum SDK: 23, Target SDK: 36
 - R8/ProGuard enabled for release builds with resource shrinking
 - Configuration cache enabled for parallel Conan installs
 - Custom lint configuration allows non-fatal errors

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,15 +29,10 @@ android {
     defaultConfig {
         applicationId "at.tomtasche.reader"
         minSdkVersion 23
-        compileSdkVersion 35
-        targetSdkVersion 35
+        targetSdkVersion 36
 
         testApplicationId "at.tomtasche.reader.test"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-
-        multiDexEnabled true
-
-        vectorDrawables.useSupportLibrary true
 
         externalNativeBuild {
             cmake {
@@ -95,11 +90,15 @@ android {
         }
     }
 
-    android.bundle.language.enableSplit false
+    bundle {
+        language {
+            enableSplit = false
+        }
+    }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     externalNativeBuild {
@@ -114,7 +113,7 @@ android {
     buildFeatures {
         buildConfig = true
     }
-    packagingOptions {
+    packaging {
         jniLibs {
             // No need to pickFirst libc++_shared.so if all files are identical.
             // They will be identical if NDK major version matches.
@@ -124,32 +123,33 @@ android {
         }
     }
     namespace 'at.tomtasche.reader'
-    compileSdk 35
+    compileSdk 36
 
     // TODO can and should this be architecture dependent?
     sourceSets.main.assets.srcDirs += "build/conan/armv8/assets"
 }
 
 dependencies {
-    implementation 'com.google.android.gms:play-services-ads:24.3.0'
+    implementation 'com.google.android.gms:play-services-ads:25.4.0'
     implementation 'com.google.android.play:review:2.0.2'
-    implementation 'com.google.android.ump:user-messaging-platform:3.1.0'
+    implementation 'com.google.android.ump:user-messaging-platform:4.0.0'
 
-    implementation 'androidx.appcompat:appcompat:1.7.0'
-    implementation 'androidx.core:core:1.15.0'
-    implementation 'com.google.android.material:material:1.12.0'
-    implementation 'androidx.webkit:webkit:1.12.1'
+    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation 'androidx.core:core:1.18.0'
+    implementation 'com.google.android.material:material:1.14.0'
+    // webkit 1.16.0+ requires minSdk 24
+    implementation 'androidx.webkit:webkit:1.15.0'
 
     implementation 'com.viliussutkus89:assetextractor-android:1.3.3'
 
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
-    androidTestImplementation 'androidx.test:rules:1.6.1'
-    androidTestImplementation 'androidx.test:runner:1.6.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.6.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
+    androidTestImplementation 'androidx.test:rules:1.7.0'
+    androidTestImplementation 'androidx.test:runner:1.7.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.7.0'
     // espresso-idling-resource is used in main sourceSet as well. cannot be just androidTestImplementation
-    implementation 'androidx.test.espresso:espresso-idling-resource:3.6.1'
-    implementation 'androidx.annotation:annotation:1.9.1'
+    implementation 'androidx.test.espresso:espresso-idling-resource:3.7.0'
+    implementation 'androidx.annotation:annotation:1.10.0'
 }
 
 // Without removing .cxx dir on cleanup, double gradle clean is erroring out.

--- a/app/src/main/java/at/tomtasche/reader/ui/activity/MainActivity.java
+++ b/app/src/main/java/at/tomtasche/reader/ui/activity/MainActivity.java
@@ -19,15 +19,14 @@ import android.os.Handler;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
 import android.view.ActionMode;
-import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.WindowManager;
 import android.widget.CompoundButton;
 import android.widget.LinearLayout;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -35,7 +34,12 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.SwitchCompat;
+import androidx.core.graphics.Insets;
 import androidx.core.view.MenuProvider;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.test.espresso.IdlingResource;
@@ -90,6 +94,32 @@ public class MainActivity extends AppCompatActivity implements MenuProvider {
     private DocumentFragment documentFragment;
 
     private boolean fullscreen;
+    // With targetSdk 36 predictive back is enabled by default and neither KEYCODE_BACK
+    // nor onBackPressed() are delivered anymore, so back is intercepted via the
+    // OnBackPressedDispatcher instead.
+    private final OnBackPressedCallback backCallback = new OnBackPressedCallback(true) {
+        @Override
+        public void handleOnBackPressed() {
+            if (fullscreen) {
+                leaveFullscreen();
+
+                return;
+            }
+
+            if (documentFragment != null && !documentOpenedExternally) {
+                analyticsManager.report("back_to_landing");
+
+                closeDocument();
+
+                return;
+            }
+
+            // fall through to the default behavior (close the activity)
+            setEnabled(false);
+            getOnBackPressedDispatcher().onBackPressed();
+            setEnabled(true);
+        }
+    };
     private TtsActionModeCallback ttsActionMode;
     private EditActionModeCallback editActionMode;
 
@@ -138,7 +168,20 @@ public class MainActivity extends AppCompatActivity implements MenuProvider {
 
         setContentView(R.layout.main);
 
+        // Edge-to-edge is enforced from targetSdk 35 on: pad the root view so content
+        // stays clear of the system bars, display cutouts and the keyboard. On older
+        // devices the window does not extend under the bars and the insets are zero.
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main_root), (view, windowInsets) -> {
+            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars()
+                    | WindowInsetsCompat.Type.displayCutout()
+                    | WindowInsetsCompat.Type.ime());
+            view.setPadding(insets.left, insets.top, insets.right, insets.bottom);
+            return WindowInsetsCompat.CONSUMED;
+        });
+
         setTitle("");
+
+        getOnBackPressedDispatcher().addCallback(this, backCallback);
 
         serviceQueue = new LoaderServiceQueue();
         Intent intent = new Intent(this, LoaderService.class);
@@ -476,9 +519,11 @@ public class MainActivity extends AppCompatActivity implements MenuProvider {
             } else {
                 analyticsManager.report("menu_fullscreen_enter");
 
-                getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
-                        WindowManager.LayoutParams.FLAG_FULLSCREEN);
-                getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+                WindowInsetsControllerCompat insetsController = WindowCompat
+                        .getInsetsController(getWindow(), getWindow().getDecorView());
+                insetsController.setSystemBarsBehavior(
+                        WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+                insetsController.hide(WindowInsetsCompat.Type.statusBars());
 
                 getSupportActionBar().hide();
 
@@ -567,37 +612,12 @@ public class MainActivity extends AppCompatActivity implements MenuProvider {
 
         getSupportActionBar().show();
 
-        getWindow().setFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN,
-                WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
-        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+        WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView())
+                .show(WindowInsetsCompat.Type.statusBars());
 
         fullscreen = false;
 
         analyticsManager.report("fullscreen_end");
-    }
-
-    @Override
-    public boolean onKeyDown(int keyCode, KeyEvent event) {
-        if (fullscreen && keyCode == KeyEvent.KEYCODE_BACK) {
-            leaveFullscreen();
-
-            return true;
-        }
-
-        return super.onKeyDown(keyCode, event);
-    }
-
-    @Override
-    public void onBackPressed() {
-        if (documentFragment != null && !documentOpenedExternally) {
-            analyticsManager.report("back_to_landing");
-
-            closeDocument();
-
-            return;
-        }
-
-        super.onBackPressed();
     }
 
     private void closeDocument() {

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -2,6 +2,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         xmlns:tools="http://schemas.android.com/tools"
+        android:id="@+id/main_root"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_gravity="start|top"

--- a/app/src/main/res/values-v35/themes.xml
+++ b/app/src/main/res/values-v35/themes.xml
@@ -8,6 +8,10 @@
         <item name="android:textColorPrimary">#6b6b6b</item>
         <item name="android:textColorSecondary">#b5b5b5</item>
         <item name="android:forceDarkAllowed">true</item>
-        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+        <!-- Edge-to-edge is enforced from targetSdk 35 on; system bars are transparent
+             over the app's light UI, so request dark icons. Insets are handled in
+             MainActivity. -->
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowLightNavigationBar">true</item>
     </style>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
 plugins {
-    id 'com.android.application' version '8.13.1' apply false
+    id 'com.android.application' version '8.13.2' apply false
     id 'app.opendocument.conanandroidgradleplugin' version '0.9.6' apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,18 +1,4 @@
-## For more details on how to configure your build environment visit
-# http://www.gradle.org/docs/current/userguide/build_environment.html
-#
-# Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
-# Default value: -Xmx1024m -XX:MaxPermSize=256m
-# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-#
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
-#Fri Oct 08 18:22:20 CEST 2021
-org.gradle.jvmargs=-Xmx1536M -Dkotlin.daemon.jvm.options\="-Xmx1536M"
-android.enableJetifier=false
+org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 android.nonFinalResIds=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,7 +10,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven { url 'https://jitpack.io' }
     }
 }
 


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary

Reviewed all declared dependencies: **everything is still in use** (ads/review/UMP in `nonfree`, assetextractor in `CoreWrapper`, espresso-idling-resource in `MainActivity`), so nothing was removed from `dependencies` — but every library was checked against Google Maven / Maven Central for the newest version usable **without raising minSdk 23** (verified by inspecting each AAR's `minSdkVersion` and `aar-metadata`).

### Dependency updates
| Library | From | To |
|---|---|---|
| play-services-ads | 24.3.0 | 25.4.0 |
| user-messaging-platform | 3.1.0 | 4.0.0 |
| androidx.core | 1.15.0 | 1.18.0 |
| androidx.appcompat | 1.7.0 | 1.7.1 |
| material | 1.12.0 | 1.14.0 |
| androidx.webkit | 1.12.1 | 1.15.0 |
| androidx.annotation | 1.9.1 | 1.10.0 |
| espresso / runner / rules / ext-junit | 3.6.1 / 1.6.2 / 1.6.1 / 1.2.1 | 3.7.0 / 1.7.0 / 1.7.0 / 1.3.0 |

Deliberately **not** taken: webkit 1.16.0 (needs minSdk 24), androidx.core 1.19.0 (needs compileSdk 37 + AGP 9), AGP 9.x / Gradle 9 (major migration, conan plugin compatibility unverified). `review` 2.0.2 and `assetextractor-android` 1.3.3 are already the latest.

### Build setup
- **compileSdk/targetSdk 35 → 36** — required by androidx.core 1.17+; Play requires targetSdk 36 by Aug 2026 anyway
- Gradle 8.13 → 8.14.5, AGP 8.13.1 → 8.13.2
- Java source/target 1.8 → 17

### Cleanup
- Removed jitpack repo — nothing resolves from it anymore (assetextractor is on Maven Central)
- Removed `multiDexEnabled` and `vectorDrawables.useSupportLibrary` (no-ops with minSdk ≥ 21)
- Removed `android.enableJetifier=false` (default), stale kotlin daemon jvmargs, and 2021 boilerplate comments from gradle.properties
- `packagingOptions` → `packaging`, proper `bundle {}` DSL block
- CLAUDE.md: dropped stale Firebase / wvware / NDK 26 / targetSdk 34 references

## Test plan
- [x] `./gradlew assembleProDebug` — builds
- [x] `./gradlew assembleProDebugAndroidTest` — builds
- [x] `./gradlew assembleLiteDebug` — builds
- [ ] Smoke-test ads + consent flow in Lite (UMP 3→4 and ads 24→25 are major bumps)
- [ ] Smoke-test on an Android 16 device/emulator (targetSdk 36 behavior changes)