### PR TITLE
Make CI independent of artifactory and add JVM unit tests

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -5,7 +5,7 @@ on:
   push:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -14,6 +14,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    outputs:
+      conan-cache-key: ${{ steps.conan-cache-key.outputs.key }}
     steps:
     - name: checkout
       uses: actions/checkout@v4
@@ -46,11 +48,27 @@ jobs:
     - name: export conan-odr-index
       run: python conan-odr-index/scripts/conan_export_all_packages.py
 
+    - name: conan cache key
+      id: conan-cache-key
+      run: echo "key=conan2-${{ runner.os }}-ndk${{ env.ndk_version }}-index$(git rev-parse HEAD:conan-odr-index)-${{ hashFiles('app/conanfile.txt', 'app/conanprofile.txt') }}" >> "$GITHUB_OUTPUT"
+
+    - name: conan cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.conan2/p
+        key: ${{ steps.conan-cache-key.outputs.key }}
+        restore-keys: |
+          conan2-${{ runner.os }}-ndk${{ env.ndk_version }}-
+
     - name: Gradle cache
-      uses: gradle/actions/setup-gradle@v3
+      uses: gradle/actions/setup-gradle@v4
 
     - name: gradle
-      run: ./gradlew assembleDebug lintProDebug lintLiteDebug --stacktrace
+      run: ./gradlew assembleDebug testProDebugUnitTest lintProDebug lintLiteDebug --stacktrace
+
+    # drop temporary download/source/build folders so only built packages get cached
+    - name: clean conan cache
+      run: conan cache clean "*"
 
     - name: conan cache size
       run: du -h -d1 ~/.conan2/p
@@ -69,6 +87,14 @@ jobs:
         name: lint-report
         path: app/build/reports/lint-results-*.html
         if-no-files-found: error
+
+    - name: Artifact unit test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: unit-test-results
+        path: app/build/reports/tests/
+        if-no-files-found: warn
 
   test:
     runs-on: ubuntu-24.04
@@ -97,14 +123,6 @@ jobs:
         distribution: 'zulu'
         java-version: 17
 
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: '3.3'
-        bundler-cache: true
-
-    - name: install fastlane
-      run: bundle install
-
     - name: setup python 3.12
       uses: actions/setup-python@v5
       with:
@@ -115,16 +133,28 @@ jobs:
     - name: install ndk
       run: yes | ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --install "ndk;${{ env.ndk_version }}"
 
-    - name: conan remote
-      run: |
-        conan remote remove "*"
-        conan remote add odr https://artifactory.opendocument.app/artifactory/api/conan/conan
-        conan remote add conancenter https://center2.conan.io
     - name: conan profile
       run: conan profile detect
 
+    - name: checkout conan-index
+      run: git submodule update --init --depth 1 conan-odr-index
+
+    - name: export conan-odr-index
+      run: python conan-odr-index/scripts/conan_export_all_packages.py
+
+    # restore the packages built by the build job. on a cache hit no conan
+    # package needs to be rebuilt or downloaded; on a miss everything is
+    # built from source via the exported recipes (slow but reliable)
+    - name: conan cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/.conan2/p
+        key: ${{ needs.build.outputs.conan-cache-key }}
+        restore-keys: |
+          conan2-${{ runner.os }}-ndk${{ env.ndk_version }}-
+
     - name: Gradle cache
-      uses: gradle/actions/setup-gradle@v3
+      uses: gradle/actions/setup-gradle@v4
 
     - name: AVD cache
       uses: actions/cache@v4
@@ -165,10 +195,10 @@ jobs:
         script: |
           # Clear logcat before tests
           adb logcat -c
-          
+
           # Run tests
           ./gradlew connectedCheck
-          
+
           # Dump logcat after tests
           adb logcat -d > logcat.txt
 
@@ -181,7 +211,7 @@ jobs:
           app/build/reports/androidTests/
           app/build/outputs/androidTest-results/
         if-no-files-found: warn
-        
+
     - name: Upload test logs
       if: always()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -45,13 +45,12 @@ jobs:
     - name: checkout conan-index
       run: git submodule update --init --depth 1 conan-odr-index
 
-    - name: export conan-odr-index
-      run: python conan-odr-index/scripts/conan_export_all_packages.py
-
     - name: conan cache key
       id: conan-cache-key
       run: echo "key=conan2-${{ runner.os }}-ndk${{ env.ndk_version }}-index$(git rev-parse HEAD:conan-odr-index)-${{ hashFiles('app/conanfile.txt', 'app/conanprofile.txt') }}" >> "$GITHUB_OUTPUT"
 
+    # restore before exporting the recipes: the export must run on top of the
+    # restored cache so current recipes win over stale ones from the archive
     - name: conan cache
       uses: actions/cache@v4
       with:
@@ -59,6 +58,9 @@ jobs:
         key: ${{ steps.conan-cache-key.outputs.key }}
         restore-keys: |
           conan2-${{ runner.os }}-ndk${{ env.ndk_version }}-
+
+    - name: export conan-odr-index
+      run: python conan-odr-index/scripts/conan_export_all_packages.py
 
     - name: Gradle cache
       uses: gradle/actions/setup-gradle@v4
@@ -139,12 +141,11 @@ jobs:
     - name: checkout conan-index
       run: git submodule update --init --depth 1 conan-odr-index
 
-    - name: export conan-odr-index
-      run: python conan-odr-index/scripts/conan_export_all_packages.py
-
     # restore the packages built by the build job. on a cache hit no conan
     # package needs to be rebuilt or downloaded; on a miss everything is
-    # built from source via the exported recipes (slow but reliable)
+    # built from source via the exported recipes (slow but reliable).
+    # restore before exporting the recipes so current recipes win over
+    # stale ones from the archive
     - name: conan cache
       uses: actions/cache/restore@v4
       with:
@@ -152,6 +153,9 @@ jobs:
         key: ${{ needs.build.outputs.conan-cache-key }}
         restore-keys: |
           conan2-${{ runner.os }}-ndk${{ env.ndk_version }}-
+
+    - name: export conan-odr-index
+      run: python conan-odr-index/scripts/conan_export_all_packages.py
 
     - name: Gradle cache
       uses: gradle/actions/setup-gradle@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `./build-test.sh` - Convenience script to build Pro debug and test APKs
 
 ### Testing
+- `./gradlew testProDebugUnitTest` - Run JVM unit tests (no device needed)
 - `./gradlew connectedAndroidTest` - Run instrumented tests on connected device
 - `fastlane android tests` - Alternative way to run connected tests
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -142,6 +142,8 @@ dependencies {
 
     implementation 'com.viliussutkus89:assetextractor-android:1.3.3'
 
+    testImplementation 'junit:junit:4.13.2'
+
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
     androidTestImplementation 'androidx.test:rules:1.7.0'
     androidTestImplementation 'androidx.test:runner:1.7.0'

--- a/app/conanprofile.txt
+++ b/app/conanprofile.txt
@@ -15,3 +15,6 @@ build_type=RelWithDebInfo
 tools.android:ndk_path=@NDK_PATH@
 tools.build:skip_test=True
 tools.graph:skip_binaries=False
+# parallel per-arch conanInstall tasks race on the shared app/CMakeUserPresets.json;
+# the android build passes the toolchain file explicitly, so presets are unused
+tools.cmake.cmaketoolchain:user_presets=

--- a/app/src/test/java/at/tomtasche/reader/background/RawLoaderTest.java
+++ b/app/src/test/java/at/tomtasche/reader/background/RawLoaderTest.java
@@ -1,0 +1,49 @@
+package at.tomtasche.reader.background;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RawLoaderTest {
+
+    private RawLoader rawLoader;
+
+    @Before
+    public void setUp() {
+        rawLoader = new RawLoader(null);
+    }
+
+    private boolean isSupported(String fileType) {
+        FileLoader.Options options = new FileLoader.Options();
+        options.fileType = fileType;
+        return rawLoader.isSupported(options);
+    }
+
+    @Test
+    public void supportsWhitelistedMimeTypes() {
+        Assert.assertTrue(isSupported("text/plain"));
+        Assert.assertTrue(isSupported("image/png"));
+        Assert.assertTrue(isSupported("video/mp4"));
+        Assert.assertTrue(isSupported("audio/mpeg"));
+        Assert.assertTrue(isSupported("application/json"));
+        Assert.assertTrue(isSupported("application/xml"));
+        Assert.assertTrue(isSupported("application/zip"));
+    }
+
+    @Test
+    public void rejectsBlacklistedMimeTypes() {
+        Assert.assertFalse(isSupported("image/vnd.dwg"));
+        Assert.assertFalse(isSupported("image/tiff"));
+        Assert.assertFalse(isSupported("audio/amr"));
+        Assert.assertFalse(isSupported("video/quicktime"));
+        Assert.assertFalse(isSupported("text/rtf"));
+        Assert.assertFalse(isSupported("text/calendar"));
+    }
+
+    @Test
+    public void rejectsUnknownMimeTypes() {
+        Assert.assertFalse(isSupported("application/pdf"));
+        Assert.assertFalse(isSupported("application/vnd.oasis.opendocument.text"));
+        Assert.assertFalse(isSupported("application/octet-stream"));
+    }
+}

--- a/app/src/test/java/at/tomtasche/reader/background/StreamUtilTest.java
+++ b/app/src/test/java/at/tomtasche/reader/background/StreamUtilTest.java
@@ -1,0 +1,100 @@
+package at.tomtasche.reader.background;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+public class StreamUtilTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void copyStreamToStream() throws IOException {
+        byte[] data = "hello world".getBytes(StandardCharsets.UTF_8);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        StreamUtil.copy(new ByteArrayInputStream(data), out);
+
+        Assert.assertArrayEquals(data, out.toByteArray());
+    }
+
+    @Test
+    public void copyLargeStream() throws IOException {
+        // larger than the internal 1024 byte buffer
+        byte[] data = new byte[10000];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) (i % 256);
+        }
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        StreamUtil.copy(new ByteArrayInputStream(data), out);
+
+        Assert.assertArrayEquals(data, out.toByteArray());
+    }
+
+    @Test
+    public void copyEmptyStream() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        StreamUtil.copy(new ByteArrayInputStream(new byte[0]), out);
+
+        Assert.assertEquals(0, out.size());
+    }
+
+    @Test
+    public void copyStreamToFile() throws IOException {
+        byte[] data = "file content".getBytes(StandardCharsets.UTF_8);
+        File target = temporaryFolder.newFile();
+
+        StreamUtil.copy(new ByteArrayInputStream(data), target);
+
+        Assert.assertArrayEquals(data, Files.readAllBytes(target.toPath()));
+    }
+
+    @Test
+    public void copyFileToFile() throws IOException {
+        byte[] data = "copy me".getBytes(StandardCharsets.UTF_8);
+        File source = temporaryFolder.newFile();
+        Files.write(source.toPath(), data);
+        File target = temporaryFolder.newFile();
+
+        StreamUtil.copy(source, target);
+
+        Assert.assertArrayEquals(data, Files.readAllBytes(target.toPath()));
+    }
+
+    @Test
+    public void readFullyReturnsUtf8String() throws IOException {
+        String text = "umlauts: äöü, emoji: 😀";
+        InputStream in = new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+
+        Assert.assertEquals(text, StreamUtil.readFully(in));
+    }
+
+    @Test
+    public void copyClosesInputStream() throws IOException {
+        File source = temporaryFolder.newFile();
+        Files.write(source.toPath(), "x".getBytes(StandardCharsets.UTF_8));
+        FileInputStream in = new FileInputStream(source);
+
+        StreamUtil.copy(in, new ByteArrayOutputStream());
+
+        try {
+            in.read();
+            Assert.fail("input stream should be closed after copy");
+        } catch (IOException expected) {
+            // expected
+        }
+    }
+}


### PR DESCRIPTION
## Why CI has been red

Every failing run of the past weeks (checked logs back to early July) fails the same way: the **test job** resolves conan packages from `artifactory.opendocument.app`, which keeps timing out:

```
ERROR: Package 'odrcore/5.5.0' not resolved: HTTPSConnectionPool(host='artifactory.opendocument.app', port=443): Read timed out.
> Task :app:conanInstall-armv8 FAILED
```

The tests themselves are fine — the last run where dependencies resolved (July 14, #480) was fully green on all four API levels. The build job never hits this because it exports recipes from the `conan-odr-index` submodule and builds from source instead of using the artifactory remote.

## Changes

- **Test job no longer uses artifactory at all** (finishing what the `kill-artifactory` branch started): it exports the recipes from the submodule like the build job does.
- **Conan package cache shared between jobs** (`actions/cache` on `~/.conan2/p`, keyed on NDK version + index submodule commit + conanfile/profile hash). The build job populates it; test jobs restore it, so they never rebuild or download native packages — on a warm cache the build job skips the native builds too. `conan cache clean` before saving keeps only the built packages.
- **Removed unused ruby/fastlane setup** from the test job — its script invokes gradle directly.
- **Fixed the concurrency group**: `github.head_ref` is empty for push events, so superseded pushes were never cancelled. Now keyed on `github.ref`.
- **Bumped `gradle/actions/setup-gradle` v3 → v4** (node20 deprecation).
- **First JVM unit tests** (`StreamUtil`, `RawLoader.isSupported`, 10 tests) run in the build job via `testProDebugUnitTest` — verified passing locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YipcjaY5h5f1CQjGwCgGV