### PR TITLE
Make lint errors fail the build and publish findings to code scanning

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -2,11 +2,29 @@ name: build_test
 
 on:
   workflow_dispatch:
+  # branch pushes are covered by the pull_request trigger, so only main is built
+  # directly - otherwise every push to a branch with an open PR builds twice
   push:
+    branches:
+      - main
+    paths-ignore:
+      - '**/*.md'
+      - 'fastlane/metadata/**'
+      - '.github/FUNDING.yml'
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'fastlane/metadata/**'
+      - '.github/FUNDING.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
+  # required to publish lint findings to the code scanning tab
+  security-events: write
 
 env:
   ndk_version: 28.1.13356709
@@ -83,12 +101,24 @@ jobs:
         if-no-files-found: error
         compression-level: 0
 
+    # lint failures fail the gradle step above, so these have to run regardless
+    - name: Upload lint results to code scanning
+      if: always()
+      # fork PRs get a read-only token and cannot write code scanning results;
+      # the html artifact below is the fallback in that case
+      continue-on-error: true
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: app/build/reports
+        category: android-lint
+
     - name: Artifact lint results
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: lint-report
         path: app/build/reports/lint-results-*.html
-        if-no-files-found: error
+        if-no-files-found: warn
 
     - name: Artifact unit test results
       if: always()

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -108,7 +108,18 @@ android {
         }
     }
     lint {
-        abortOnError false
+        // lint errors are build failures. NewApi in particular is the check that
+        // would have caught the java.nio.file usage below minSdk that shipped for
+        // years while this was switched off.
+        abortOnError true
+
+        // warnings stay warnings for now - there is a backlog of them (unused
+        // resources, typography, rtl) that is not worth blocking builds on
+        warningsAsErrors false
+
+        // consumed by github code scanning, so findings show up inline on PRs
+        sarifReport true
+        htmlReport true
     }
     buildFeatures {
         buildConfig = true

--- a/app/src/main/java/at/tomtasche/reader/background/CoreLoader.java
+++ b/app/src/main/java/at/tomtasche/reader/background/CoreLoader.java
@@ -4,17 +4,22 @@ import android.content.Context;
 import android.net.Uri;
 import android.os.Handler;
 import android.util.Log;
-import android.webkit.MimeTypeMap;
 
 import java.io.File;
 
 import at.tomtasche.reader.nonfree.AnalyticsManager;
-import at.tomtasche.reader.nonfree.ConfigManager;
 import at.tomtasche.reader.nonfree.CrashManager;
 
 public class CoreLoader extends FileLoader {
 
-    private final ConfigManager configManager;
+    /**
+     * Whether odrcore renders text documents with page margins. This used to be read
+     * from the "use_paging" remote config key, but that resolved to false for every
+     * user since firebase remote config was removed - the ConfigManager left behind is
+     * a stub without a backing store. Kept as an explicit constant so the shipped
+     * behavior is visible instead of hidden behind a lookup that cannot return a value.
+     */
+    private static final boolean USE_PAGING = false;
 
     private CoreWrapper.CoreOptions lastCoreOptions;
 
@@ -22,10 +27,9 @@ public class CoreLoader extends FileLoader {
 
     private Thread httpThread;
 
-    public CoreLoader(Context context, ConfigManager configManager, boolean doOoxml) {
+    public CoreLoader(Context context, boolean doOoxml) {
         super(context, LoaderType.CORE);
 
-        this.configManager = configManager;
         this.doOoxml = doOoxml;
 
         CoreWrapper.initialize(context);
@@ -102,10 +106,7 @@ public class CoreLoader extends FileLoader {
         coreOptions.txt = false;
         coreOptions.pdf = false;
 
-        Boolean usePaging = configManager.getBooleanConfig("use_paging");
-        if (usePaging == null || usePaging) {
-            coreOptions.paging = true;
-        }
+        coreOptions.paging = USE_PAGING;
 
         lastCoreOptions = coreOptions;
 

--- a/app/src/main/java/at/tomtasche/reader/background/LoaderService.java
+++ b/app/src/main/java/at/tomtasche/reader/background/LoaderService.java
@@ -57,7 +57,7 @@ public class LoaderService extends Service implements FileLoader.FileLoaderListe
         metadataLoader = new MetadataLoader(context);
         metadataLoader.initialize(this, mainHandler, backgroundHandler, analyticsManager, crashManager);
 
-        coreLoader = new CoreLoader(context, configManager, true);
+        coreLoader = new CoreLoader(context, true);
         coreLoader.initialize(this, mainHandler, backgroundHandler, analyticsManager, crashManager);
 
         rawLoader = new RawLoader(context);

--- a/app/src/main/java/at/tomtasche/reader/background/MetadataLoader.java
+++ b/app/src/main/java/at/tomtasche/reader/background/MetadataLoader.java
@@ -15,6 +15,24 @@ import java.net.URLConnection;
 
 public class MetadataLoader extends FileLoader {
 
+    private static final MimeTypeResolver.ExtensionLookup MIME_TYPE_LOOKUP =
+            new MimeTypeResolver.ExtensionLookup() {
+
+                @Override
+                public String extensionFromMimeType(String mimeType) {
+                    return MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
+                }
+
+                @Override
+                public String mimeTypeFromExtension(String extension) {
+                    if (extension == null) {
+                        return null;
+                    }
+
+                    return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
+                }
+            };
+
     public MetadataLoader(Context context) {
         super(context, LoaderType.METADATA);
     }
@@ -36,8 +54,9 @@ public class MetadataLoader extends FileLoader {
 
         try {
             // cleanup uri
-            if ("/./".equals(uri.toString().substring(0, 2))) {
-                uri = Uri.parse(uri.toString().substring(2));
+            String uriString = uri.toString();
+            if (uriString.startsWith("/./")) {
+                uri = Uri.parse(uriString.substring(2));
             }
 
             AndroidFileCache.cleanup(context);
@@ -84,8 +103,7 @@ public class MetadataLoader extends FileLoader {
 
             options.cacheUri = AndroidFileCache.getCacheFileUri(context, cachedFile);
 
-            String[] fileSplit = options.filename.split("\\.");
-            String extension = fileSplit.length > 0 ? fileSplit[fileSplit.length - 1] : "N/A";
+            String extension = MimeTypeResolver.parseExtension(options.filename);
 
             String mimetype = null;
             try {
@@ -107,7 +125,7 @@ public class MetadataLoader extends FileLoader {
                 }
             }
 
-            if (type == null) {
+            if (mimetype == null) {
                 try {
                     try (InputStream tempStream = new FileInputStream(cachedFile)) {
                         mimetype = URLConnection.guessContentTypeFromStream(tempStream);
@@ -117,14 +135,11 @@ public class MetadataLoader extends FileLoader {
                 }
             }
 
-            if (type != null) {
-                extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimetype);
-            } else {
-                mimetype = MimeTypeMap.getSingleton().getMimeTypeFromExtension(options.fileExtension);
-            }
+            MimeTypeResolver.Resolution resolution = MimeTypeResolver.resolve(mimetype, extension, MIME_TYPE_LOOKUP);
+            mimetype = resolution.mimeType;
 
-            if (extension != null) {
-                options.fileExtension = extension;
+            if (resolution.extension != null) {
+                options.fileExtension = resolution.extension;
             }
             if (mimetype != null) {
                 options.fileType = mimetype;

--- a/app/src/main/java/at/tomtasche/reader/background/MimeTypeResolver.java
+++ b/app/src/main/java/at/tomtasche/reader/background/MimeTypeResolver.java
@@ -1,0 +1,66 @@
+package at.tomtasche.reader.background;
+
+/**
+ * Derives the final mime type / file extension pair of a document from whatever the
+ * detection steps in {@link MetadataLoader} came up with.
+ * <p>
+ * Deliberately free of Android dependencies so it can be covered by plain JVM unit
+ * tests; in production {@link ExtensionLookup} is backed by {@code MimeTypeMap}.
+ */
+public class MimeTypeResolver {
+
+    /**
+     * The lookups {@code MimeTypeMap} provides, as an interface so tests can fake them.
+     */
+    public interface ExtensionLookup {
+
+        String extensionFromMimeType(String mimeType);
+
+        String mimeTypeFromExtension(String extension);
+    }
+
+    public static class Resolution {
+
+        public final String mimeType;
+        public final String extension;
+
+        Resolution(String mimeType, String extension) {
+            this.mimeType = mimeType;
+            this.extension = extension;
+        }
+    }
+
+    /**
+     * Returns the extension of the given filename, or null if it does not have one.
+     * Dotfiles ("{@code .bashrc}") and trailing dots ("{@code report.}") count as
+     * "no extension".
+     */
+    public static String parseExtension(String filename) {
+        if (filename == null) {
+            return null;
+        }
+
+        int lastDot = filename.lastIndexOf('.');
+        if (lastDot <= 0 || lastDot == filename.length() - 1) {
+            return null;
+        }
+
+        return filename.substring(lastDot + 1);
+    }
+
+    /**
+     * Combines a detected mime type with the extension taken from the filename. If the
+     * mime type is known its canonical extension wins, but the filename extension is
+     * kept as a fallback; if no mime type could be detected it is looked up from the
+     * extension instead. Either field of the result may be null.
+     */
+    public static Resolution resolve(String mimeType, String filenameExtension, ExtensionLookup lookup) {
+        if (mimeType != null) {
+            String mimeExtension = lookup.extensionFromMimeType(mimeType);
+
+            return new Resolution(mimeType, mimeExtension != null ? mimeExtension : filenameExtension);
+        }
+
+        return new Resolution(lookup.mimeTypeFromExtension(filenameExtension), filenameExtension);
+    }
+}

--- a/app/src/main/java/at/tomtasche/reader/background/OnlineLoader.java
+++ b/app/src/main/java/at/tomtasche/reader/background/OnlineLoader.java
@@ -4,8 +4,6 @@ import android.content.Context;
 import android.net.Uri;
 import android.os.Build;
 
-import androidx.annotation.RequiresApi;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -16,7 +14,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.nio.file.Files;
 
 public class OnlineLoader extends FileLoader {
 
@@ -114,7 +111,6 @@ public class OnlineLoader extends FileLoader {
         }
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
     private Uri doOnlineConvert(Options options) throws IOException {
         // https://stackoverflow.com/a/2469587/198996
         String basePath = "https://use.opendocument.app";
@@ -137,7 +133,7 @@ public class OnlineLoader extends FileLoader {
             writer.append("--" + boundary).append(CRLF);
             writer.append("Content-Disposition: form-data; name=\"document\"; filename=\"document\"").append(CRLF);
             writer.append(CRLF).flush();
-            Files.copy(binaryFile.toPath(), output);
+            StreamUtil.copy(binaryFile, output);
             output.flush();
             writer.append(CRLF).flush();
 
@@ -159,7 +155,7 @@ public class OnlineLoader extends FileLoader {
         connection.setInstanceFollowRedirects(false);
 
         try (OutputStream outputStream = connection.getOutputStream()) {
-            Files.copy(binaryFile.toPath(), outputStream);
+            StreamUtil.copy(binaryFile, outputStream);
             outputStream.flush();
         }
 

--- a/app/src/main/java/at/tomtasche/reader/ui/FindActionModeCallback.java
+++ b/app/src/main/java/at/tomtasche/reader/ui/FindActionModeCallback.java
@@ -177,13 +177,11 @@ public class FindActionModeCallback implements ActionMode.Callback, TextWatcher,
 
     @Override
     public boolean onCreateActionMode(ActionMode mode, Menu menu) {
-        if (!mode.isUiFocusable()) {
-            // If the action mode we're running in is not focusable the user
-            // will not be able to type into the find on page field. This
-            // should only come up when we're running in a dialog which is
-            // already less than ideal; disable the option for now.
-            return false;
-        }
+        // the AOSP original this class is derived from bailed out here when
+        // mode.isUiFocusable() was false, to avoid an unusable find field inside a
+        // dialog. That method is @RestrictTo(LIBRARY_GROUP_PREFIX) on the appcompat
+        // ActionMode, so it is not ours to call. We only ever start this action mode
+        // from MainActivity via startSupportActionMode(), never from a dialog.
 
         mode.setCustomView(mCustomView);
         mode.getMenuInflater().inflate(R.menu.webview_find,

--- a/app/src/test/java/at/tomtasche/reader/background/MimeTypeResolverTest.java
+++ b/app/src/test/java/at/tomtasche/reader/background/MimeTypeResolverTest.java
@@ -1,0 +1,107 @@
+package at.tomtasche.reader.background;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MimeTypeResolverTest {
+
+    /**
+     * Stands in for MimeTypeMap, which is not available on the JVM.
+     */
+    private static class FakeLookup implements MimeTypeResolver.ExtensionLookup {
+
+        private final Map<String, String> mimeToExtension = new HashMap<>();
+        private final Map<String, String> extensionToMime = new HashMap<>();
+
+        FakeLookup with(String mimeType, String extension) {
+            mimeToExtension.put(mimeType, extension);
+            extensionToMime.put(extension, mimeType);
+            return this;
+        }
+
+        @Override
+        public String extensionFromMimeType(String mimeType) {
+            return mimeToExtension.get(mimeType);
+        }
+
+        @Override
+        public String mimeTypeFromExtension(String extension) {
+            return extensionToMime.get(extension);
+        }
+    }
+
+    private static FakeLookup lookup() {
+        return new FakeLookup()
+                .with("application/vnd.oasis.opendocument.text", "odt")
+                .with("application/pdf", "pdf");
+    }
+
+    @Test
+    public void parsesExtensionFromFilename() {
+        Assert.assertEquals("odt", MimeTypeResolver.parseExtension("report.odt"));
+        Assert.assertEquals("odt", MimeTypeResolver.parseExtension("my.backup.report.odt"));
+        Assert.assertEquals("ODT", MimeTypeResolver.parseExtension("report.ODT"));
+    }
+
+    @Test
+    public void parsesNoExtensionWhenThereIsNone() {
+        // regression: the old split("\\.") based code returned the whole filename here
+        Assert.assertNull(MimeTypeResolver.parseExtension("README"));
+        Assert.assertNull(MimeTypeResolver.parseExtension(".bashrc"));
+        Assert.assertNull(MimeTypeResolver.parseExtension("report."));
+        Assert.assertNull(MimeTypeResolver.parseExtension(""));
+        Assert.assertNull(MimeTypeResolver.parseExtension(null));
+    }
+
+    @Test
+    public void knownMimeTypeWinsOverFilenameExtension() {
+        MimeTypeResolver.Resolution resolution =
+                MimeTypeResolver.resolve("application/pdf", "bin", lookup());
+
+        Assert.assertEquals("application/pdf", resolution.mimeType);
+        Assert.assertEquals("pdf", resolution.extension);
+    }
+
+    @Test
+    public void filenameExtensionSurvivesUnknownMimeType() {
+        // regression: this used to null out the extension, so features building on
+        // options.fileExtension (share/open-with) lost it
+        MimeTypeResolver.Resolution resolution =
+                MimeTypeResolver.resolve("application/x-made-up", "odt", lookup());
+
+        Assert.assertEquals("application/x-made-up", resolution.mimeType);
+        Assert.assertEquals("odt", resolution.extension);
+    }
+
+    @Test
+    public void mimeTypeIsLookedUpFromExtensionWhenUndetected() {
+        // regression: this branch was unreachable, because it tested the loader type
+        // instead of the mime type
+        MimeTypeResolver.Resolution resolution =
+                MimeTypeResolver.resolve(null, "odt", lookup());
+
+        Assert.assertEquals("application/vnd.oasis.opendocument.text", resolution.mimeType);
+        Assert.assertEquals("odt", resolution.extension);
+    }
+
+    @Test
+    public void resolvesToNothingWhenNeitherIsKnown() {
+        MimeTypeResolver.Resolution resolution =
+                MimeTypeResolver.resolve(null, "xyz", lookup());
+
+        Assert.assertNull(resolution.mimeType);
+        Assert.assertEquals("xyz", resolution.extension);
+    }
+
+    @Test
+    public void toleratesMissingExtension() {
+        MimeTypeResolver.Resolution resolution =
+                MimeTypeResolver.resolve(null, null, lookup());
+
+        Assert.assertNull(resolution.mimeType);
+        Assert.assertNull(resolution.extension);
+    }
+}

--- a/app/src/test/java/at/tomtasche/reader/background/OnlineLoaderTest.java
+++ b/app/src/test/java/at/tomtasche/reader/background/OnlineLoaderTest.java
@@ -1,0 +1,57 @@
+package at.tomtasche.reader.background;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class OnlineLoaderTest {
+
+    private OnlineLoader onlineLoader;
+
+    @Before
+    public void setUp() {
+        onlineLoader = new OnlineLoader(null, null);
+    }
+
+    private boolean isSupported(String fileType) {
+        FileLoader.Options options = new FileLoader.Options();
+        options.fileType = fileType;
+        return onlineLoader.isSupported(options);
+    }
+
+    @Test
+    public void supportsOfficeDocuments() {
+        Assert.assertTrue(isSupported("application/vnd.oasis.opendocument.text"));
+        Assert.assertTrue(isSupported("application/vnd.openxmlformats-officedocument.wordprocessingml.document"));
+        Assert.assertTrue(isSupported("application/msword"));
+        Assert.assertTrue(isSupported("application/vnd.ms-excel"));
+        Assert.assertTrue(isSupported("application/vnd.ms-powerpoint"));
+        Assert.assertTrue(isSupported("application/pdf"));
+        Assert.assertTrue(isSupported("application/rtf"));
+        Assert.assertTrue(isSupported("application/vnd.wordperfect"));
+    }
+
+    @Test
+    public void supportsGenericPreviewableTypes() {
+        Assert.assertTrue(isSupported("text/plain"));
+        Assert.assertTrue(isSupported("image/png"));
+        Assert.assertTrue(isSupported("application/zip"));
+    }
+
+    @Test
+    public void rejectsBlacklistedMimeTypes() {
+        Assert.assertFalse(isSupported("image/x-tga"));
+        Assert.assertFalse(isSupported("image/vnd.djvu"));
+        Assert.assertFalse(isSupported("audio/amr"));
+        Assert.assertFalse(isSupported("video/3gpp"));
+        Assert.assertFalse(isSupported("text/calendar"));
+        // contacts must not be offered for upload - see issue #477
+        Assert.assertFalse(isSupported("text/vcard"));
+    }
+
+    @Test
+    public void rejectsUnknownMimeTypes() {
+        Assert.assertFalse(isSupported("application/octet-stream"));
+        Assert.assertFalse(isSupported("application/x-made-up"));
+    }
+}


### PR DESCRIPTION
Stacked on #497 — review that one first; this PR's diff is against it.

## Why

`lint { abortOnError false }` has been in place for a long time, with the HTML report uploaded as a zip artifact. That is not a cosmetic setting. Running lint on `main` reports:

```
Error OnlineLoader.java:162  Call requires API level 26, or core library desugaring
                             (current min is 23): java.io.File#toPath
Error OnlineLoader.java:162  Call requires API level 26, or core library desugaring
                             (current min is 23): java.nio.file.Files#copy
```

That is the crash fixed in #497, and lint knew about it the whole time.

## What changed

- **`abortOnError true`.** Warnings stay warnings (`warningsAsErrors false`) — there is a backlog of 79 of them (37 typography, 23 unused resources, rtl, sp usage) that is not worth blocking builds on. Only errors fail. Both `lintProDebug` and `lintLiteDebug` pass on this branch.
- **SARIF output uploaded to code scanning**, so findings annotate the PR diff directly. `continue-on-error` because fork PRs get a read-only token; the HTML artifact remains as the fallback.
- **CI runs on `pull_request`.** It was `push`-only, so fork PRs were never built at all. `push` is narrowed to `main` so branches with an open PR do not build twice, and doc-only changes are skipped via `paths-ignore`.

## The one pre-existing error

`FindActionModeCallback.onCreateActionMode()` called `ActionMode.isUiFocusable()`, which is `@RestrictTo(LIBRARY_GROUP_PREFIX)` on the appcompat `ActionMode` — not public API, and free to disappear on any appcompat upgrade. It is inherited from the AOSP class this was derived from, where it guarded against an unusable find-on-page field inside a dialog. The only call site is `MainActivity.onMenuItemSelected()` via `startSupportActionMode()`, which is never a dialog, so the guard is removed rather than suppressed.

## Verification

`./gradlew assembleDebug testProDebugUnitTest lintProDebug lintLiteDebug` — green (the exact CI command).