### PR TITLE
Raise minSdk to 26 and drop the guards it makes dead

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -228,8 +228,9 @@ jobs:
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: true
         script: |
-          # Clear logcat before tests
-          adb logcat -c
+          # Clear logcat before tests. Fails with "failed to clear the 'main' log"
+          # on some system images (api 26 among them) and must not abort the run.
+          adb logcat -c || true
 
           # Run tests
           ./gradlew connectedCheck

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -135,9 +135,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # broken for unknown reasons. needs some offline debugging
-          # https://github.com/opendocument-app/OpenDocument.droid/issues/390
-          # - { arch: x86_64, api-level: 23 }
+          # api 26 is minSdk - the floor was previously untested, which is part of
+          # why an API 26+ only call could ship in a path only old devices took.
+          # (the old api 23 entry was disabled for issue #390 and is now moot)
+          - { arch: x86_64, api-level: 26 }
           - { arch: x86_64, api-level: 29 }
           - { arch: x86_64, api-level: 30 }
           - { arch: x86_64, api-level: 32 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,8 +28,8 @@ tasks.register('conanProfile', Copy) {
 android {
     defaultConfig {
         applicationId "at.tomtasche.reader"
-        minSdkVersion 23
-        targetSdkVersion 36
+        minSdk 26
+        targetSdk 36
 
         testApplicationId "at.tomtasche.reader.test"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -146,10 +146,10 @@ dependencies {
     implementation 'com.google.android.ump:user-messaging-platform:4.0.0'
 
     implementation 'androidx.appcompat:appcompat:1.7.1'
+    // core 1.19.0+ requires AGP 9.1+, bumped together with the toolchain
     implementation 'androidx.core:core:1.18.0'
     implementation 'com.google.android.material:material:1.14.0'
-    // webkit 1.16.0+ requires minSdk 24
-    implementation 'androidx.webkit:webkit:1.15.0'
+    implementation 'androidx.webkit:webkit:1.16.0'
 
     implementation 'com.viliussutkus89:assetextractor-android:1.3.3'
 

--- a/app/conanprofile.txt
+++ b/app/conanprofile.txt
@@ -2,7 +2,7 @@ include(default)
 
 [settings]
 os=Android
-os.api_level=23
+os.api_level=26
 compiler=clang
 compiler.version=17
 compiler.cppstd=20

--- a/app/src/main/java/at/tomtasche/reader/background/CoreLoader.java
+++ b/app/src/main/java/at/tomtasche/reader/background/CoreLoader.java
@@ -31,12 +31,15 @@ public class CoreLoader extends FileLoader {
         super(context, LoaderType.CORE);
 
         this.doOoxml = doOoxml;
-
-        CoreWrapper.initialize(context);
     }
 
     @Override
     public void initialize(FileLoaderListener listener, Handler mainHandler, Handler backgroundHandler, AnalyticsManager analyticsManager, CrashManager crashManager) {
+        // loads the native library and extracts the core assets. Kept out of the
+        // constructor so that constructing a CoreLoader stays side effect free -
+        // LoaderService calls initialize() right after new CoreLoader() anyway.
+        CoreWrapper.initialize(context);
+
         File serverCacheDir = new File(context.getCacheDir(), "core/server");
         if (!serverCacheDir.isDirectory() && !serverCacheDir.mkdirs()) {
             Log.e("CoreLoader", "Failed to create cache directory for CoreWrapper server: " + serverCacheDir.getAbsolutePath());

--- a/app/src/main/java/at/tomtasche/reader/background/OnlineLoader.java
+++ b/app/src/main/java/at/tomtasche/reader/background/OnlineLoader.java
@@ -2,7 +2,6 @@ package at.tomtasche.reader.background;
 
 import android.content.Context;
 import android.net.Uri;
-import android.os.Build;
 
 import java.io.File;
 import java.io.IOException;
@@ -95,8 +94,7 @@ public class OnlineLoader extends FileLoader {
 
         try {
             Uri viewerUri;
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
-                    ("text/rtf".equals(options.fileType) || "application/vnd.wordperfect".equals(options.fileType) || coreLoader.isSupported(options) || "application/vnd.ms-excel".equals(options.fileType) || "application/msword".equals(options.fileType) || "application/vnd.ms-powerpoint".equals(options.fileType) || options.fileType.startsWith("application/vnd.openxmlformats-officedocument.") || options.fileType.equals("application/pdf"))) {
+            if (isConvertible(options)) {
                 viewerUri = doOnlineConvert(options);
             } else {
                 viewerUri = doTransferUpload(options);
@@ -109,6 +107,23 @@ public class OnlineLoader extends FileLoader {
         } catch (Throwable e) {
             callOnError(result, e);
         }
+    }
+
+    /**
+     * Whether use.opendocument.app can convert this type itself. Everything else is
+     * uploaded and handed to a third party viewer instead.
+     */
+    boolean isConvertible(Options options) {
+        String fileType = options.fileType;
+
+        return "text/rtf".equals(fileType)
+                || "application/vnd.wordperfect".equals(fileType)
+                || "application/vnd.ms-excel".equals(fileType)
+                || "application/msword".equals(fileType)
+                || "application/vnd.ms-powerpoint".equals(fileType)
+                || "application/pdf".equals(fileType)
+                || fileType.startsWith("application/vnd.openxmlformats-officedocument.")
+                || coreLoader.isSupported(options);
     }
 
     private Uri doOnlineConvert(Options options) throws IOException {

--- a/app/src/main/java/at/tomtasche/reader/background/PrintingManager.java
+++ b/app/src/main/java/at/tomtasche/reader/background/PrintingManager.java
@@ -1,6 +1,5 @@
 package at.tomtasche.reader.background;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Handler;
 import android.os.HandlerThread;

--- a/app/src/main/java/at/tomtasche/reader/ui/widget/PageView.java
+++ b/app/src/main/java/at/tomtasche/reader/ui/widget/PageView.java
@@ -83,19 +83,17 @@ public class PageView extends WebView implements ParagraphListener {
             public void onPageFinished(WebView view, String url) {
                 super.onPageFinished(view, url);
 
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    buggyWebViewHandler.postDelayed(new Runnable() {
+                buggyWebViewHandler.postDelayed(new Runnable() {
 
-                        @Override
-                        public void run() {
-                            if (!wasCommitCalled) {
-                                crashManager.log(new RuntimeException("commit was not called"));
+                    @Override
+                    public void run() {
+                        if (!wasCommitCalled) {
+                            crashManager.log(new RuntimeException("commit was not called"));
 
-                                loadUrl(url);
-                            }
+                            loadUrl(url);
                         }
-                    }, 2500);
-                }
+                    }
+                }, 2500);
             }
 
             @Override

--- a/app/src/main/java/com/commonsware/android/print/PdfDocumentAdapter.java
+++ b/app/src/main/java/com/commonsware/android/print/PdfDocumentAdapter.java
@@ -31,10 +31,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import androidx.annotation.RequiresApi;
 
 // taken from: https://github.com/commonsguy/cw-omnibus/blob/f2ffeb687d002f4a41b52a6ef5bb2580eb6a4ed6/Printing/PrintManager/app/src/main/java/com/commonsware/android/print/PdfDocumentAdapter.java
-@RequiresApi(api = Build.VERSION_CODES.KITKAT)
 public class PdfDocumentAdapter extends ThreadedPrintDocumentAdapter {
 
     private final String title;

--- a/app/src/main/java/com/commonsware/android/print/ThreadedPrintDocumentAdapter.java
+++ b/app/src/main/java/com/commonsware/android/print/ThreadedPrintDocumentAdapter.java
@@ -26,9 +26,7 @@ import android.print.PrintDocumentAdapter;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import androidx.annotation.RequiresApi;
 
-@RequiresApi(api = Build.VERSION_CODES.KITKAT)
 abstract class ThreadedPrintDocumentAdapter extends
         PrintDocumentAdapter {
     abstract LayoutJob buildLayoutJob(PrintAttributes oldAttributes,

--- a/app/src/test/java/at/tomtasche/reader/background/OnlineLoaderTest.java
+++ b/app/src/test/java/at/tomtasche/reader/background/OnlineLoaderTest.java
@@ -10,13 +10,21 @@ public class OnlineLoaderTest {
 
     @Before
     public void setUp() {
-        onlineLoader = new OnlineLoader(null, null);
+        onlineLoader = new OnlineLoader(null, new CoreLoader(null, true));
+    }
+
+    private FileLoader.Options options(String fileType) {
+        FileLoader.Options options = new FileLoader.Options();
+        options.fileType = fileType;
+        return options;
     }
 
     private boolean isSupported(String fileType) {
-        FileLoader.Options options = new FileLoader.Options();
-        options.fileType = fileType;
-        return onlineLoader.isSupported(options);
+        return onlineLoader.isSupported(options(fileType));
+    }
+
+    private boolean isConvertible(String fileType) {
+        return onlineLoader.isConvertible(options(fileType));
     }
 
     @Test
@@ -53,5 +61,26 @@ public class OnlineLoaderTest {
     public void rejectsUnknownMimeTypes() {
         Assert.assertFalse(isSupported("application/octet-stream"));
         Assert.assertFalse(isSupported("application/x-made-up"));
+    }
+
+    @Test
+    public void convertsOfficeDocumentsItself() {
+        Assert.assertTrue(isConvertible("application/pdf"));
+        Assert.assertTrue(isConvertible("text/rtf"));
+        Assert.assertTrue(isConvertible("application/vnd.wordperfect"));
+        Assert.assertTrue(isConvertible("application/vnd.ms-excel"));
+        Assert.assertTrue(isConvertible("application/msword"));
+        Assert.assertTrue(isConvertible("application/vnd.ms-powerpoint"));
+        Assert.assertTrue(isConvertible("application/vnd.openxmlformats-officedocument.presentationml.presentation"));
+        // delegated to CoreLoader
+        Assert.assertTrue(isConvertible("application/vnd.oasis.opendocument.text"));
+    }
+
+    @Test
+    public void handsEverythingElseToAThirdPartyViewer() {
+        Assert.assertFalse(isConvertible("text/plain"));
+        Assert.assertFalse(isConvertible("image/png"));
+        Assert.assertFalse(isConvertible("application/zip"));
+        Assert.assertFalse(isConvertible("application/vnd.ms-excel.sheet.macroEnabled.12"));
     }
 }


### PR DESCRIPTION
Stacked on #498 (which is stacked on #497).

## Why 26

minSdk 23 was the root cause of the crash fixed in #497, it pinned `androidx.webkit` to 1.15.0, and the floor itself was never tested — the API 23 emulator entry has been disabled since #390. API 26 is the level that makes `java.nio.file` legal, so the whole class of problem goes away rather than getting another guard.

## Changes

- `minSdk 26`, switched to the modern `minSdk`/`targetSdk` DSL (the `minSdkVersion`/`targetSdkVersion` methods are removed in AGP 9, which is the next PR)
- `androidx.webkit` 1.16.0
- `os.api_level = 26` in `conanprofile.txt` so the native side matches
- **`androidx.core` stays at 1.18.0** — 1.19.0 requires AGP 9.1+, so it moves to the toolchain PR

Guards removed as dead: `SDK_INT >= M` in `PageView`, `SDK_INT >= O` selecting the upload path in `OnlineLoader`, and `@RequiresApi(KITKAT)` on both print adapters. `PageView.toggleDarkMode()`'s `Q` check stays — 29 is still above the floor.

## Two things worth a look

**The conan gradle plugin does not track `conanprofile.txt` as a task input.** After editing it, `conanInstall-*` stays `UP-TO-DATE` locally and the native libs silently keep their old API level. CI is fine — its conan cache key hashes the file — but locally this is a footgun. I verified the API 26 build by hand:

```
conan install app/conanfile.txt -pr:h app/build/conanprofile.txt -pr:b default \
  -s:h arch=armv8 --build=missing
→ Install finished successfully
```

So odrcore does build against API 26. **Expect the first CI run on this PR to be slow** — the conan cache key changes and everything rebuilds from source once.

**CI gains an API 26 emulator run.** The minimum supported level has never been exercised, which is part of why an API 26+ call could ship inside a branch only pre-26 devices took. If it turns out flaky (as API 23 was, #390), it is one line to drop.

## Incidental

`OnlineLoader.loadSync()`'s ~400-character inline condition became `isConvertible()`, now unit tested. Testing it required `CoreLoader` to be constructible without a device — it called `CoreWrapper.initialize()` (which does `System.loadLibrary`) from its constructor. That moved into `initialize()`; `LoaderService` calls it immediately after construction, so the runtime sequence is identical.

## Verification

`./gradlew assembleDebug testProDebugUnitTest lintProDebug lintLiteDebug` — green, 25 unit tests.