### PR TITLE
Take signing secrets out of the repo and drop dead Crashlytics wiring

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,0 @@
-{
-  "projects": {
-    "default": "admob-app-id-9025061963"
-  }
-}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# It's Android's first OpenOffice Document Reader! ![](https://github.com/opendocument-app/OpenDocument.droid/actions/workflows/android_main.yml/badge.svg)
+# It's Android's first OpenOffice Document Reader! ![](https://github.com/opendocument-app/OpenDocument.droid/actions/workflows/build_test.yml/badge.svg)
 
 This is an Android frontend for our C++ OpenDocument.core library. Feel free to use it in your own project too, but please don't forget to tell us about it!
 
@@ -18,6 +18,25 @@ Please help to translate on the https://crowdin.com/project/opendocument
 
 - install conan using pip in a venv
 - `conan profile detect --force`
-- make sure `conan` is in your $PATH or replace conan-call in `app/build.gradle`
+- make sure `conan` is in your $PATH, or point gradle at it with
+  `-Podr.conanExecutable=/path/to/venv/bin/conan` (the `ODR_CONAN` environment
+  variable works too). The gradle daemon captures its environment at startup, so
+  a venv activated afterwards is not visible to it - run `./gradlew --stop` after
+  changing $PATH.
 - `git submodule update --init --depth 1 conan-odr-index`
 - `python conan-odr-index/scripts/conan_export_all_packages.py`
+
+## Release signing
+
+Debug builds need no setup. Release variants are signed only if the credentials are
+supplied from outside the repository, as gradle properties in `~/.gradle/gradle.properties`
+or as environment variables:
+
+| gradle property        | environment variable     | meaning                          |
+|------------------------|--------------------------|----------------------------------|
+| `odr.keystore`         | `ODR_KEYSTORE`           | path to the keystore             |
+| `odr.keystorePassword` | `ODR_KEYSTORE_PASSWORD`  | store password                   |
+| `odr.keyPasswordPro`   | `ODR_KEY_PASSWORD_PRO`   | key password, defaults to store  |
+| `odr.keyPasswordLite`  | `ODR_KEY_PASSWORD_LITE`  | key password, defaults to store  |
+
+Without them `bundleProRelease` and friends still build, just unsigned.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,9 +5,37 @@ plugins {
     id 'app.opendocument.conanandroidgradleplugin'
 }
 
+// Release signing credentials are supplied out of band - they used to be committed
+// in plain text right here. Set them either as gradle properties (in
+// ~/.gradle/gradle.properties, never in the repo) or as environment variables:
+//
+//   odr.keystore         / ODR_KEYSTORE          path to the keystore
+//   odr.keystorePassword / ODR_KEYSTORE_PASSWORD store password
+//   odr.keyPasswordPro   / ODR_KEY_PASSWORD_PRO  key password, defaults to the store one
+//   odr.keyPasswordLite  / ODR_KEY_PASSWORD_LITE key password, defaults to the store one
+//
+// When they are absent the release variants build unsigned instead of failing, so
+// contributors and CI can still build them.
+def signingSetting = { String property, String environmentVariable ->
+    providers.gradleProperty(property).orElse(providers.environmentVariable(environmentVariable))
+}
+def releaseKeystore = signingSetting('odr.keystore', 'ODR_KEYSTORE')
+def releaseKeystorePassword = signingSetting('odr.keystorePassword', 'ODR_KEYSTORE_PASSWORD')
+def releaseKeyPasswordPro = signingSetting('odr.keyPasswordPro', 'ODR_KEY_PASSWORD_PRO')
+def releaseKeyPasswordLite = signingSetting('odr.keyPasswordLite', 'ODR_KEY_PASSWORD_LITE')
+def hasReleaseSigning = releaseKeystore.isPresent() && releaseKeystorePassword.isPresent()
+
 android {
     ndkVersion "28.1.13356709"
 }
+
+// conan is taken from PATH by default. Point odr.conanExecutable (or ODR_CONAN) at a
+// specific binary when it lives in a virtualenv that is not on the gradle daemon's
+// PATH - the daemon captures its environment at startup, so a venv activated in the
+// shell afterwards is not visible to it.
+def conanExecutable_ = providers.gradleProperty('odr.conanExecutable')
+        .orElse(providers.environmentVariable('ODR_CONAN'))
+        .getOrElse('conan')
 
 tasks.register('conanProfile', Copy) {
     from "conanprofile.txt"
@@ -21,7 +49,7 @@ tasks.register('conanProfile', Copy) {
         deployer.set('conandeployer.py')
         deployerFolder.set(outputDirectory.get().asFile.toString() + "/assets/core")
         dependsOn(tasks.named('conanProfile'))
-        conanExecutable.set('conan')
+        conanExecutable.set(conanExecutable_)
     }
 }
 
@@ -49,24 +77,28 @@ android {
     flavorDimensions "default"
 
     signingConfigs {
-        releasePro {
-            storeFile file("../../google_play.keystore")
-            storePassword "releaseme"
-            keyAlias "reader-pro"
-            keyPassword "releaseme"
-        }
+        if (hasReleaseSigning) {
+            releasePro {
+                storeFile file(releaseKeystore.get())
+                storePassword releaseKeystorePassword.get()
+                keyAlias "reader-pro"
+                keyPassword releaseKeyPasswordPro.getOrElse(releaseKeystorePassword.get())
+            }
 
-        releaseLite {
-            storeFile file("../../google_play.keystore")
-            storePassword "releaseme"
-            keyAlias "reader"
-            keyPassword "releaseme"
+            releaseLite {
+                storeFile file(releaseKeystore.get())
+                storePassword releaseKeystorePassword.get()
+                keyAlias "reader"
+                keyPassword releaseKeyPasswordLite.getOrElse(releaseKeystorePassword.get())
+            }
         }
     }
 
     productFlavors {
         lite {
-            signingConfig signingConfigs.releaseLite
+            if (hasReleaseSigning) {
+                signingConfig signingConfigs.releaseLite
+            }
 
             resValue("bool", "DISABLE_TRACKING", "false")
         }
@@ -75,7 +107,9 @@ android {
             applicationIdSuffix ".pro"
             versionNameSuffix "-pro"
 
-            signingConfig signingConfigs.releasePro
+            if (hasReleaseSigning) {
+                signingConfig signingConfigs.releasePro
+            }
 
             resValue("bool", "DISABLE_TRACKING", "true")
         }

--- a/build-test.sh
+++ b/build-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+set -euo pipefail
 
-./gradlew assembleProDebug
-./gradlew assembleProDebugAndroidTest
+./gradlew assembleProDebug assembleProDebugAndroidTest
 
 ls app/build/outputs/apk/pro/debug/app-pro-debug.apk
 ls app/build/outputs/apk/androidTest/pro/debug/app-pro-debug-androidTest.apk

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -20,7 +20,6 @@ platform :android do
       skip_upload_images: true,
       skip_upload_screenshots: true
     )
-    gradle(task: "app:uploadCrashlyticsSymbolFileProRelease")
   end
 
   desc "Deploy a new version to the Google Play"
@@ -42,7 +41,6 @@ platform :android do
       skip_upload_images: true,
       skip_upload_screenshots: true
     )
-    gradle(task: "app:uploadCrashlyticsSymbolFileLiteRelease")
   end
 
   lane :tests do

--- a/firebase.json
+++ b/firebase.json
@@ -1,5 +1,0 @@
-{
-  "storage": {
-    "rules": "storage.rules"
-  }
-}

--- a/upload-symbols.sh
+++ b/upload-symbols.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-./gradlew app:uploadCrashlyticsSymbolFileLiteRelease
-./gradlew app:uploadCrashlyticsSymbolFileProRelease


### PR DESCRIPTION
Stacked on #499.

## The deploy path was broken

Both fastlane lanes ended with:

```ruby
gradle(task: "app:uploadCrashlyticsSymbolFileProRelease")
```

That task comes from the `com.google.firebase.crashlytics` gradle plugin, which **is not applied anywhere** in this project. Crashlytics was removed along with the other nonfree integrations — `CrashManager` is a `Log.d` stub today — but the deploy scripts kept calling it, so `deployPro` and `deployLite` have been failing on their last step. `upload-symbols.sh` called the same two tasks and is deleted.

Play Console still gets native symbols via `ndk.debugSymbolLevel = "full"`, which is untouched.

`firebase.json` and `.firebaserc` are removed too — `firebase.json` points at a `storage.rules` file that does not exist in this repo.

## Signing credentials

`app/build.gradle` contained the keystore passwords in plaintext (`storePassword "releaseme"`). They now come from gradle properties or environment variables:

| gradle property | environment variable | meaning |
|---|---|---|
| `odr.keystore` | `ODR_KEYSTORE` | path to the keystore |
| `odr.keystorePassword` | `ODR_KEYSTORE_PASSWORD` | store password |
| `odr.keyPasswordPro` | `ODR_KEY_PASSWORD_PRO` | key password, defaults to store password |
| `odr.keyPasswordLite` | `ODR_KEY_PASSWORD_LITE` | key password, defaults to store password |

If they are absent the release variants build **unsigned** instead of failing, so contributors and CI can still build them. This is the prerequisite for the release workflow later in the stack, which will read them from GitHub secrets.

⚠️ **Action needed on your side:** put these in `~/.gradle/gradle.properties` before your next local release build, and rotate the keystore passwords, since the old ones are in git history.

## Also

- The conan binary is selectable with `-Podr.conanExecutable=...` / `ODR_CONAN` instead of everyone editing `build.gradle` locally — which is exactly what the working copy had done.
- `build-test.sh` uses one gradle invocation instead of two, with `set -euo pipefail` so a failed build no longer falls through to the `ls` calls and exits 0.
- The README build badge pointed at `android_main.yml`, which does not exist — the workflow is `build_test.yml`, so the badge has been rendering broken.

## Verification

`./gradlew -Podr.conanExecutable=... assembleProDebug testProDebugUnitTest` — green with no signing properties set (release configs simply absent).