### PR TITLE
Move to AGP 9 / Gradle 9, add a version catalog and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+
+updates:
+  # reads gradle/libs.versions.toml, so a bump is a one line change in the catalog
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      androidx:
+        patterns:
+          - "androidx.*"
+      test:
+        patterns:
+          - "androidx.test*"
+          - "junit*"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  # fastlane and its dependencies
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -27,7 +27,7 @@ permissions:
   security-events: write
 
 env:
-  ndk_version: 28.1.13356709
+  ndk_version: 28.2.13676358
 
 jobs:
   build:
@@ -45,7 +45,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
-        java-version: 17
+        java-version: 21
 
     - name: setup python 3.12
       uses: actions/setup-python@v5
@@ -154,7 +154,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
-        java-version: 17
+        java-version: 21
 
     - name: setup python 3.12
       uses: actions/setup-python@v5

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,8 +1,8 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
-    id 'com.android.application'
-    id 'app.opendocument.conanandroidgradleplugin'
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.conan.android)
 }
 
 // Release signing credentials are supplied out of band - they used to be committed
@@ -26,7 +26,7 @@ def releaseKeyPasswordLite = signingSetting('odr.keyPasswordLite', 'ODR_KEY_PASS
 def hasReleaseSigning = releaseKeystore.isPresent() && releaseKeystorePassword.isPresent()
 
 android {
-    ndkVersion "28.1.13356709"
+    ndkVersion = "28.2.13676358"
 }
 
 // conan is taken from PATH by default. Point odr.conanExecutable (or ODR_CONAN) at a
@@ -37,10 +37,15 @@ def conanExecutable_ = providers.gradleProperty('odr.conanExecutable')
         .orElse(providers.environmentVariable('ODR_CONAN'))
         .getOrElse('conan')
 
+// android.ndkDirectory was removed in AGP 9; the ndk location now comes from the
+// androidComponents sdk components provider
+def ndkDirectory = androidComponents.sdkComponents.ndkDirectory.map { it.asFile.toString() }
+
 tasks.register('conanProfile', Copy) {
     from "conanprofile.txt"
     into project.layout.buildDirectory
-    filter(ReplaceTokens, tokens: ["NDK_PATH": android.ndkDirectory.toString()])
+    inputs.property("ndkDirectory", ndkDirectory)
+    filter(ReplaceTokens, tokens: ["NDK_PATH": ndkDirectory.get()])
 }
 
 ["armv8", "armv7", "x86", "x86_64"].each { architecture ->
@@ -55,16 +60,16 @@ tasks.register('conanProfile', Copy) {
 
 android {
     defaultConfig {
-        applicationId "at.tomtasche.reader"
-        minSdk 26
-        targetSdk 36
+        applicationId = "at.tomtasche.reader"
+        minSdk = 26
+        targetSdk = 36
 
-        testApplicationId "at.tomtasche.reader.test"
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testApplicationId = "at.tomtasche.reader.test"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         externalNativeBuild {
             cmake {
-                targets "odr-core"
+                targets = ["odr-core"]
                 arguments(
                     "-DANDROID_STL=c++_shared",
                     "-DCMAKE_TOOLCHAIN_FILE=build/conan/android_toolchain.cmake",
@@ -74,22 +79,22 @@ android {
         }
     }
 
-    flavorDimensions "default"
+    flavorDimensions = ["default"]
 
     signingConfigs {
         if (hasReleaseSigning) {
             releasePro {
-                storeFile file(releaseKeystore.get())
-                storePassword releaseKeystorePassword.get()
-                keyAlias "reader-pro"
-                keyPassword releaseKeyPasswordPro.getOrElse(releaseKeystorePassword.get())
+                storeFile = file(releaseKeystore.get())
+                storePassword = releaseKeystorePassword.get()
+                keyAlias = "reader-pro"
+                keyPassword = releaseKeyPasswordPro.getOrElse(releaseKeystorePassword.get())
             }
 
             releaseLite {
-                storeFile file(releaseKeystore.get())
-                storePassword releaseKeystorePassword.get()
-                keyAlias "reader"
-                keyPassword releaseKeyPasswordLite.getOrElse(releaseKeystorePassword.get())
+                storeFile = file(releaseKeystore.get())
+                storePassword = releaseKeystorePassword.get()
+                keyAlias = "reader"
+                keyPassword = releaseKeyPasswordLite.getOrElse(releaseKeystorePassword.get())
             }
         }
     }
@@ -97,18 +102,18 @@ android {
     productFlavors {
         lite {
             if (hasReleaseSigning) {
-                signingConfig signingConfigs.releaseLite
+                signingConfig = signingConfigs.releaseLite
             }
 
             resValue("bool", "DISABLE_TRACKING", "false")
         }
 
         pro {
-            applicationIdSuffix ".pro"
-            versionNameSuffix "-pro"
+            applicationIdSuffix = ".pro"
+            versionNameSuffix = "-pro"
 
             if (hasReleaseSigning) {
-                signingConfig signingConfigs.releasePro
+                signingConfig = signingConfigs.releasePro
             }
 
             resValue("bool", "DISABLE_TRACKING", "true")
@@ -117,8 +122,8 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled true
-            shrinkResources true
+            minifyEnabled = true
+            shrinkResources = true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.txt'
             ndk.debugSymbolLevel = "full"
         }
@@ -131,32 +136,34 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     externalNativeBuild {
         cmake {
-            version "3.22.0+"
-            path "CMakeLists.txt"
+            version = "3.22.0+"
+            path = "CMakeLists.txt"
         }
     }
     lint {
         // lint errors are build failures. NewApi in particular is the check that
         // would have caught the java.nio.file usage below minSdk that shipped for
         // years while this was switched off.
-        abortOnError true
+        abortOnError = true
 
         // warnings stay warnings for now - there is a backlog of them (unused
         // resources, typography, rtl) that is not worth blocking builds on
-        warningsAsErrors false
+        warningsAsErrors = false
 
         // consumed by github code scanning, so findings show up inline on PRs
-        sarifReport true
-        htmlReport true
+        sarifReport = true
+        htmlReport = true
     }
     buildFeatures {
         buildConfig = true
+        // AGP 9 makes resValue opt-in; the flavors use it for DISABLE_TRACKING
+        resValues = true
     }
     packaging {
         jniLibs {
@@ -167,36 +174,37 @@ android {
             // pickFirsts += ['**/libc++_shared.so']
         }
     }
-    namespace 'at.tomtasche.reader'
-    compileSdk 36
+    namespace = 'at.tomtasche.reader'
+    // ahead of targetSdk on purpose: compiling against newer APIs is independent of
+    // opting in to their runtime behavior. androidx.core 1.19.0 requires 37.
+    compileSdk = 37
 
     // TODO can and should this be architecture dependent?
     sourceSets.main.assets.srcDirs += "build/conan/armv8/assets"
 }
 
 dependencies {
-    implementation 'com.google.android.gms:play-services-ads:25.4.0'
-    implementation 'com.google.android.play:review:2.0.2'
-    implementation 'com.google.android.ump:user-messaging-platform:4.0.0'
+    implementation libs.play.services.ads
+    implementation libs.play.review
+    implementation libs.user.messaging.platform
 
-    implementation 'androidx.appcompat:appcompat:1.7.1'
-    // core 1.19.0+ requires AGP 9.1+, bumped together with the toolchain
-    implementation 'androidx.core:core:1.18.0'
-    implementation 'com.google.android.material:material:1.14.0'
-    implementation 'androidx.webkit:webkit:1.16.0'
+    implementation libs.androidx.appcompat
+    implementation libs.androidx.core
+    implementation libs.material
+    implementation libs.androidx.webkit
 
-    implementation 'com.viliussutkus89:assetextractor-android:1.3.3'
+    implementation libs.asset.extractor
 
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation libs.junit
 
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
-    androidTestImplementation 'androidx.test:rules:1.7.0'
-    androidTestImplementation 'androidx.test:runner:1.7.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.3.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.7.0'
+    androidTestImplementation libs.espresso.core
+    androidTestImplementation libs.espresso.intents
+    androidTestImplementation libs.androidx.test.rules
+    androidTestImplementation libs.androidx.test.runner
+    androidTestImplementation libs.androidx.test.junit
     // espresso-idling-resource is used in main sourceSet as well. cannot be just androidTestImplementation
-    implementation 'androidx.test.espresso:espresso-idling-resource:3.7.0'
-    implementation 'androidx.annotation:annotation:1.10.0'
+    implementation libs.espresso.idling.resource
+    implementation libs.androidx.annotation
 }
 
 // Without removing .cxx dir on cleanup, double gradle clean is erroring out.

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
 plugins {
-    id 'com.android.application' version '8.13.2' apply false
-    id 'app.opendocument.conanandroidgradleplugin' version '0.9.6' apply false
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.conan.android) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,43 @@
+[versions]
+agp = "9.3.1"
+conanAndroid = "0.9.6"
+
+androidxAnnotation = "1.10.0"
+androidxAppcompat = "1.7.1"
+androidxCore = "1.19.0"
+androidxWebkit = "1.16.0"
+material = "1.14.0"
+
+playServicesAds = "25.4.0"
+playReview = "2.0.2"
+userMessagingPlatform = "4.0.0"
+assetExtractor = "1.3.3"
+
+junit = "4.13.2"
+espresso = "3.7.0"
+androidxTest = "1.7.0"
+androidxTestJunit = "1.3.0"
+
+[libraries]
+androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidxAnnotation" }
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidxAppcompat" }
+androidx-core = { module = "androidx.core:core", version.ref = "androidxCore" }
+androidx-webkit = { module = "androidx.webkit:webkit", version.ref = "androidxWebkit" }
+material = { module = "com.google.android.material:material", version.ref = "material" }
+
+play-services-ads = { module = "com.google.android.gms:play-services-ads", version.ref = "playServicesAds" }
+play-review = { module = "com.google.android.play:review", version.ref = "playReview" }
+user-messaging-platform = { module = "com.google.android.ump:user-messaging-platform", version.ref = "userMessagingPlatform" }
+asset-extractor = { module = "com.viliussutkus89:assetextractor-android", version.ref = "assetExtractor" }
+
+junit = { module = "junit:junit", version.ref = "junit" }
+espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
+espresso-intents = { module = "androidx.test.espresso:espresso-intents", version.ref = "espresso" }
+espresso-idling-resource = { module = "androidx.test.espresso:espresso-idling-resource", version.ref = "espresso" }
+androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidxTest" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidxTest" }
+androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "androidxTestJunit" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+conan-android = { id = "app.opendocument.conanandroidgradleplugin", version.ref = "conanAndroid" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Stacked on #500. The riskiest PR in the stack — worth the closest look.

## Why

Runtime dependencies were already current; the *toolchain* was a full major behind. AGP 8.13.2 → **9.3.1**, Gradle 8.14.5 → **9.6.1**.

## Bootstrapping note

AGP 9 cannot configure a project on Gradle 8 at all:

```
com.google.common.util.concurrent.ExecutionError:
  java.lang.NoClassDefFoundError: org/gradle/features/binding/ProjectTypeBinding
```

That includes the `wrapper` task itself, so `./gradlew wrapper --gradle-version 9.6.1` fails once AGP is bumped. `gradle-wrapper.properties` had to be edited by hand first, then `./gradlew wrapper` re-run to regenerate the scripts. Worth knowing if you ever bisect through this commit.

## What AGP 9 forced

1. **`resValue` is opt-in now** — without `buildFeatures.resValues = true` the build fails with *"Product Flavor lite contains custom resource values, but the feature is disabled"*. Both flavors use it for `DISABLE_TRACKING`.
2. **`android.ndkDirectory` was removed.** `conanProfile` now takes the NDK path from `androidComponents.sdkComponents.ndkDirectory`. It is also declared as a task input, which it never was — a small improvement on the input-tracking gap noted in #499.
3. **`androidx.core` 1.19.0 requires `compileSdk 37`.** So compileSdk is now ahead of targetSdk. That is deliberate and safe: compiling against newer APIs is independent of opting in to their runtime behavior. **`targetSdk` stays at 36** — moving it is a behavior change that deserves its own PR and its own testing.

## Also here

- **Version catalog** (`gradle/libs.versions.toml`) — every version in one place.
- **Dependabot is back.** It was deleted in `11bd7468`; the recent Gemfile bumps must have come from somewhere else, because gradle updates were not being proposed at all. Configured for `gradle` (reads the catalog), `github-actions` and `bundler`, with androidx and test deps grouped so they arrive as one PR each instead of six.
- **JDK 21** in CI (both jobs), **NDK 28.2.13676358** (current 28.x LTS).
- The Gradle-10 "space assignment" deprecation was the only warning this build emitted; the whole file moves to `=` assignment while it is being touched.

## Verification

- `./gradlew assembleDebug testProDebugUnitTest lintProDebug lintLiteDebug` — green
- `./gradlew bundleProRelease` — green, R8 + lintVital included. Confirmed the output has no `META-INF/*.RSA` signature block, i.e. it builds unsigned when no credentials are set, which is the behavior #500 introduced.
- The `app.opendocument.conanandroidgradleplugin` 0.9.6 plugin works unchanged on Gradle 9 — 0.9.6 is still the latest published version, so this was the main unknown going in.

⚠️ **Expect a slow first CI run** — the NDK version is part of the conan cache key, so packages rebuild once.