### PR TITLE
Add a release workflow and split building from uploading in fastlane

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,187 @@
+name: release
+
+# Releases used to be built and uploaded from a maintainer laptop, which was the
+# only machine holding the keystore. This does the same steps in CI:
+#   1. build the signed app bundles with gradle
+#   2. hand them to fastlane, which uploads them to the play store
+#
+# Requires these repository secrets (see the "Release signing" section in the
+# README for what they mean):
+#   ODR_KEYSTORE_BASE64           base64 of google_play.keystore
+#   ODR_KEYSTORE_PASSWORD         keystore password
+#   ODR_KEY_PASSWORD_PRO          key password for the reader-pro alias
+#   ODR_KEY_PASSWORD_LITE         key password for the reader alias
+#   GOOGLE_PLAY_SERVICE_ACCOUNT   json key of the play console service account
+#
+# Without them the workflow fails fast in the "check secrets" step instead of
+# producing an unsigned bundle and trying to upload it.
+
+on:
+  workflow_dispatch:
+    inputs:
+      flavor:
+        description: which flavor to release
+        type: choice
+        options: [both, pro, lite]
+        default: both
+      track:
+        description: play store track
+        type: choice
+        options: [internal, alpha, beta, production]
+        default: internal
+      dry_run:
+        description: build and attach the bundles, but do not upload
+        type: boolean
+        default: false
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  ndk_version: 28.2.13676358
+  # tag pushes go to the internal track, same as the manual lanes always did.
+  # anything wider has to be dispatched deliberately.
+  track: ${{ inputs.track || 'internal' }}
+  flavor: ${{ inputs.flavor || 'both' }}
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    steps:
+    - name: check secrets
+      env:
+        keystore: ${{ secrets.ODR_KEYSTORE_BASE64 }}
+        keystore_password: ${{ secrets.ODR_KEYSTORE_PASSWORD }}
+        service_account: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT }}
+      run: |
+        missing=""
+        [ -n "$keystore" ] || missing="$missing ODR_KEYSTORE_BASE64"
+        [ -n "$keystore_password" ] || missing="$missing ODR_KEYSTORE_PASSWORD"
+        if [ "${{ inputs.dry_run }}" != "true" ]; then
+          [ -n "$service_account" ] || missing="$missing GOOGLE_PLAY_SERVICE_ACCOUNT"
+        fi
+        if [ -n "$missing" ]; then
+          echo "::error::missing repository secrets:$missing"
+          exit 1
+        fi
+
+    - name: checkout
+      uses: actions/checkout@v4
+
+    - name: install ninja
+      run: sudo apt-get install -y ninja-build
+
+    - name: setup java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'zulu'
+        java-version: 21
+
+    - name: setup ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+
+    - name: setup python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.12
+    - name: install python dependencies
+      run: pip install conan
+
+    - name: install ndk
+      run: yes | ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --install "ndk;${{ env.ndk_version }}"
+
+    - name: conan profile
+      run: conan profile detect
+
+    - name: checkout conan-index
+      run: git submodule update --init --depth 1 conan-odr-index
+
+    # same cache the build workflow populates, so a release does not have to
+    # rebuild odrcore from source
+    - name: conan cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/.conan2/p
+        key: conan2-${{ runner.os }}-ndk${{ env.ndk_version }}-index${{ hashFiles('.git/modules/conan-odr-index/HEAD') }}-${{ hashFiles('app/conanfile.txt', 'app/conanprofile.txt') }}
+        restore-keys: |
+          conan2-${{ runner.os }}-ndk${{ env.ndk_version }}-
+
+    - name: export conan-odr-index
+      run: python conan-odr-index/scripts/conan_export_all_packages.py
+
+    - name: Gradle cache
+      uses: gradle/actions/setup-gradle@v4
+
+    - name: decode keystore
+      run: echo "${{ secrets.ODR_KEYSTORE_BASE64 }}" | base64 -d > "${RUNNER_TEMP}/google_play.keystore"
+
+    - name: build bundles
+      env:
+        ODR_KEYSTORE: ${{ runner.temp }}/google_play.keystore
+        ODR_KEYSTORE_PASSWORD: ${{ secrets.ODR_KEYSTORE_PASSWORD }}
+        ODR_KEY_PASSWORD_PRO: ${{ secrets.ODR_KEY_PASSWORD_PRO }}
+        ODR_KEY_PASSWORD_LITE: ${{ secrets.ODR_KEY_PASSWORD_LITE }}
+      run: |
+        tasks=""
+        case "${{ env.flavor }}" in
+          pro)  tasks="bundleProRelease" ;;
+          lite) tasks="bundleLiteRelease" ;;
+          *)    tasks="bundleProRelease bundleLiteRelease" ;;
+        esac
+        ./gradlew $tasks --stacktrace
+
+    # a release that silently produced an unsigned bundle would be rejected by
+    # the play store with a much less obvious error
+    - name: verify bundles are signed
+      run: |
+        for aab in app/build/outputs/bundle/*/*.aab; do
+          if unzip -l "$aab" | grep -qE " META-INF/[^/]+\.(RSA|DSA)$"; then
+            echo "signed: $aab"
+          else
+            echo "::error::$aab is not signed"
+            exit 1
+          fi
+        done
+
+    - name: Artifact bundles
+      uses: actions/upload-artifact@v4
+      with:
+        name: bundles
+        path: app/build/outputs/bundle/*/*.aab
+        if-no-files-found: error
+
+    - name: Artifact native debug symbols
+      uses: actions/upload-artifact@v4
+      with:
+        name: native-debug-symbols
+        path: app/build/outputs/native-debug-symbols/*/*.zip
+        if-no-files-found: warn
+
+    - name: play store credentials
+      if: ${{ inputs.dry_run != true }}
+      run: echo '${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT }}' > fastlane_google_play.json
+
+    - name: upload to play store
+      if: ${{ inputs.dry_run != true }}
+      run: |
+        case "${{ env.flavor }}" in
+          pro)  lanes="uploadPro" ;;
+          lite) lanes="uploadLite" ;;
+          *)    lanes="uploadPro uploadLite" ;;
+        esac
+        for lane in $lanes; do
+          bundle exec fastlane android "$lane" track:"${{ env.track }}"
+        done
+
+    - name: drop credentials
+      if: always()
+      run: rm -f fastlane_google_play.json "${RUNNER_TEMP}/google_play.keystore"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,9 @@ name: release
 # README for what they mean):
 #   ODR_KEYSTORE_BASE64           base64 of google_play.keystore
 #   ODR_KEYSTORE_PASSWORD         keystore password
-#   ODR_KEY_PASSWORD_PRO          key password for the reader-pro alias
-#   ODR_KEY_PASSWORD_LITE         key password for the reader alias
+#   ODR_KEY_PASSWORD_PRO          key password for the reader-pro alias, optional:
+#                                 an unset one falls back to the store password
+#   ODR_KEY_PASSWORD_LITE         key password for the reader alias, same fallback
 #   GOOGLE_PLAY_SERVICE_ACCOUNT   json key of the play console service account
 #
 # Without them the workflow fails fast in the "check secrets" step instead of

--- a/README.md
+++ b/README.md
@@ -40,3 +40,25 @@ or as environment variables:
 | `odr.keyPasswordLite`  | `ODR_KEY_PASSWORD_LITE`  | key password, defaults to store  |
 
 Without them `bundleProRelease` and friends still build, just unsigned.
+
+## Releasing
+
+Pushing a `v*` tag runs the `release` workflow, which builds both signed bundles and
+uploads them to the Play Store internal track - the same thing the fastlane lanes did
+from a laptop. Running the workflow manually additionally allows picking the flavor,
+the track, and a dry run that builds and attaches the bundles without uploading.
+
+It needs these repository secrets:
+
+| secret | contents |
+|---|---|
+| `ODR_KEYSTORE_BASE64` | `base64 -i google_play.keystore` |
+| `ODR_KEYSTORE_PASSWORD` | store password |
+| `ODR_KEY_PASSWORD_PRO` | key password for the `reader-pro` alias |
+| `ODR_KEY_PASSWORD_LITE` | key password for the `reader` alias |
+| `GOOGLE_PLAY_SERVICE_ACCOUNT` | play console service account json key |
+
+Releasing from a laptop still works: `fastlane android deployPro` builds and uploads,
+and takes an optional `track:` (`fastlane android deployPro track:beta`).
+
+Remember to raise `versionCode` in `app/src/main/AndroidManifest.xml` before tagging.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,8 +16,13 @@ plugins {
 //
 // When they are absent the release variants build unsigned instead of failing, so
 // contributors and CI can still build them.
+// empty counts as absent: a github actions secret that is not set still reaches the
+// build as an empty environment variable, and taking that at face value would use an
+// empty key password instead of falling back to the store one
 def signingSetting = { String property, String environmentVariable ->
-    providers.gradleProperty(property).orElse(providers.environmentVariable(environmentVariable))
+    providers.gradleProperty(property)
+            .orElse(providers.environmentVariable(environmentVariable))
+            .filter { !it.isEmpty() }
 }
 def releaseKeystore = signingSetting('odr.keystore', 'ODR_KEYSTORE')
 def releaseKeystorePassword = signingSetting('odr.keystorePassword', 'ODR_KEYSTORE_PASSWORD')

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,49 +1,58 @@
 default_platform(:android)
 
-platform :android do
-  desc "Deploy a new version to the Google Play"
-  lane :deployPro do
-    gradle(
-      task: "clean"
-    )
+# flavor name as gradle spells it => play store package name
+PACKAGE_NAMES = {
+  "Pro" => "at.tomtasche.reader.pro",
+  "Lite" => "at.tomtasche.reader"
+}.freeze
 
-    gradle(
-      task: "bundle",
-      flavor: "Pro",
-      build_type: "Release"
-    )
-    upload_to_play_store(
-      track: 'internal',
-      package_name: 'at.tomtasche.reader.pro',
-      skip_upload_metadata: true,
-      skip_upload_changelogs: true,
-      skip_upload_images: true,
-      skip_upload_screenshots: true
-    )
+DEFAULT_TRACK = "internal".freeze
+
+platform :android do
+  desc "Build and upload the Pro version to Google Play"
+  lane :deployPro do |options|
+    buildBundle(flavor: "Pro")
+    uploadBundle(flavor: "Pro", track: options[:track])
   end
 
-  desc "Deploy a new version to the Google Play"
-  lane :deployLite do
-    gradle(
-      task: "clean"
-    )
+  desc "Build and upload the Lite version to Google Play"
+  lane :deployLite do |options|
+    buildBundle(flavor: "Lite")
+    uploadBundle(flavor: "Lite", track: options[:track])
+  end
 
-    gradle(
-      task: "bundle",
-      flavor: "Lite",
-      build_type: "Release"
-    )
-    upload_to_play_store(
-      track: 'internal',
-      package_name: 'at.tomtasche.reader',
-      skip_upload_metadata: true,
-      skip_upload_changelogs: true,
-      skip_upload_images: true,
-      skip_upload_screenshots: true
-    )
+  desc "Upload an already built Pro bundle. Used by the release workflow, which builds " \
+       "with gradle directly so that the native dependency cache is reused."
+  lane :uploadPro do |options|
+    uploadBundle(flavor: "Pro", track: options[:track])
+  end
+
+  desc "Upload an already built Lite bundle"
+  lane :uploadLite do |options|
+    uploadBundle(flavor: "Lite", track: options[:track])
   end
 
   lane :tests do
     gradle(task: "connectedAndroidTest")
+  end
+
+  private_lane :buildBundle do |options|
+    gradle(task: "clean")
+    gradle(task: "bundle", flavor: options[:flavor], build_type: "Release")
+  end
+
+  private_lane :uploadBundle do |options|
+    flavor = options[:flavor]
+    variant = flavor.downcase
+
+    upload_to_play_store(
+      track: options[:track] || DEFAULT_TRACK,
+      package_name: PACKAGE_NAMES.fetch(flavor),
+      aab: "app/build/outputs/bundle/#{variant}Release/app-#{variant}-release.aab",
+      skip_upload_metadata: true,
+      skip_upload_changelogs: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true
+    )
   end
 end


### PR DESCRIPTION
Stacked on #502. This is what #500 (moving signing credentials out of the repo) was a prerequisite for.

## What it does

Releases were built and uploaded from a maintainer laptop, because that was the only machine with the keystore. The workflow now builds the signed bundles with gradle and hands them to fastlane to upload.

Building with gradle directly rather than through the fastlane lane is deliberate: it reuses the conan cache the build workflow populates, instead of rebuilding odrcore from source on every release (`deployPro` starts with `gradle clean`).

- **A `v*` tag releases both flavors to the `internal` track** — exactly what the manual lanes always did. Anything wider has to be dispatched deliberately.
- **Manual dispatch** can pick flavor (`pro`/`lite`/`both`), track (`internal`/`alpha`/`beta`/`production`), and a **dry run** that builds and attaches the bundles without uploading.
- **Missing secrets fail in the first step**, not thirty minutes into a native build.
- **Bundles are verified to carry a signature block before upload** — an accidentally unsigned release would otherwise fail in the Play Store with a far less obvious error. This matters because #500 made unsigned builds succeed by design.
- The keystore and service account key are deleted in an `always()` step.

## Fastfile

`uploadPro` / `uploadLite` upload an already-built bundle (what CI uses). `deployPro` / `deployLite` still build *and* upload, so releasing from a laptop keeps working unchanged. Both now accept an optional track instead of hardcoding `internal`:

```
fastlane android deployPro track:beta
```

The duplicated lane bodies moved into private lanes.

## Verification

I could not test against the real keystore, so I generated a throwaway one with both aliases (`reader-pro`, `reader`) and ran the real path:

```
ODR_KEYSTORE=... ODR_KEYSTORE_PASSWORD=... ODR_KEY_PASSWORD_PRO=... ODR_KEY_PASSWORD_LITE=... \
  ./gradlew bundleProRelease bundleLiteRelease
→ signed: app/build/outputs/bundle/liteRelease/app-lite-release.aab
→ signed: app/build/outputs/bundle/proRelease/app-pro-release.aab
```

Both bundles land at exactly the paths the Fastfile uploads from, and the workflow's signature-check step (run verbatim) passes on them. Ruby syntax and both workflow YAMLs validated.

## ⚠️ Before merging

The five secrets must be added to the repository, or the workflow fails at step 1. They are listed in the README section this PR adds. **Rotate the keystore passwords first** — the old ones are in git history.

I would suggest a **dry run** dispatch as the first real exercise of this.