### PR TITLE
Replace startActivityForResult, retained fragments and action bar tabs

### DIFF
--- a/app/src/androidTest/java/at/tomtasche/reader/test/MainActivityTests.java
+++ b/app/src/androidTest/java/at/tomtasche/reader/test/MainActivityTests.java
@@ -20,7 +20,6 @@ import android.app.Activity;
 import android.app.Instrumentation;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.ActivityInfo;
 import android.content.res.AssetManager;
 import android.net.Uri;
 import android.os.SystemClock;
@@ -34,6 +33,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.ActivityTestRule;
+import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
+import androidx.test.runner.lifecycle.Stage;
 import at.tomtasche.reader.R;
 import at.tomtasche.reader.background.FileLoader;
 import at.tomtasche.reader.ui.EditActionModeCallback;
@@ -99,6 +100,13 @@ public class MainActivityTests {
 
         if (null != m_idlingResource) {
             IdlingRegistry.getInstance().unregister(m_idlingResource);
+        }
+
+        // a test that recreated the activity left one behind that the rule does not know
+        // about, and it would still be around when the next test launches its own
+        MainActivity resumed = resumedMainActivity();
+        if (resumed != null && resumed != mainActivityActivityTestRule.getActivity()) {
+            InstrumentationRegistry.getInstrumentation().runOnMainSync(resumed::finish);
         }
 
         // Finish and wait for activity to be destroyed
@@ -366,7 +374,7 @@ public class MainActivityTests {
     }
 
     @Test
-    public void testDocumentSurvivesRotation() throws InterruptedException {
+    public void testDocumentSurvivesRecreation() throws InterruptedException {
         File testFile = s_testFiles.get("test.odt");
         Assert.assertNotNull(testFile);
         MainActivity activity = mainActivityActivityTestRule.getActivity();
@@ -375,26 +383,56 @@ public class MainActivityTests {
         Assert.assertNotNull(before);
 
         // the document state used to be kept alive by setRetainInstance(true) and now
-        // lives in a ViewModel, so a configuration change must not drop it or reload
-        rotate(activity, ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
-        try {
-            DocumentFragment afterRotation = waitForDocumentFragment(activity, 10000);
-            Assert.assertNotNull("fragment gone after rotation", afterRotation);
-            Assert.assertTrue("document state lost across rotation", afterRotation.hasLastResult());
-            Assert.assertEquals(
-                    "document was reloaded instead of restored",
-                    before.options.originalUri,
-                    afterRotation.getLastResult().options.originalUri);
-        } finally {
-            rotate(activity, ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
-        }
+        // lives in a ViewModel, so a configuration change must not drop it or reload.
+        // rotating is not enough to check that: MainActivity handles orientation and
+        // screenSize itself, so it is only reconfigured, never torn down. recreate() is
+        // what a locale or font scale change does, and that is the path the ViewModel and
+        // the saved instance state have to survive.
+        MainActivity recreated = recreate(activity);
+        Assert.assertNotNull("activity gone after recreation", recreated);
+        Assert.assertNotSame("activity was not recreated", activity, recreated);
+
+        DocumentFragment afterRecreation = waitForDocumentFragment(recreated, 10000);
+        Assert.assertNotNull("fragment gone after recreation", afterRecreation);
+        Assert.assertNotSame("fragment was not recreated", documentFragment, afterRecreation);
+        Assert.assertTrue(
+                "document state lost across recreation", waitForLastResult(afterRecreation, 10000));
+        Assert.assertEquals(
+                "document was reloaded instead of restored",
+                before.options.originalUri,
+                afterRecreation.getLastResult().options.originalUri);
     }
 
-    private void rotate(MainActivity activity, int orientation) {
+    private MainActivity recreate(MainActivity activity) {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(activity::recreate);
+
+        long startMs = SystemClock.elapsedRealtime();
+        do {
+            MainActivity current = resumedMainActivity();
+            if (current != null && current != activity) {
+                InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+                return current;
+            }
+            SystemClock.sleep(100);
+        } while (SystemClock.elapsedRealtime() - startMs < 10000);
+
+        return null;
+    }
+
+    private MainActivity resumedMainActivity() {
+        AtomicReference<MainActivity> current = new AtomicReference<>();
         InstrumentationRegistry.getInstrumentation()
-                .runOnMainSync(() -> activity.setRequestedOrientation(orientation));
-        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
-        SystemClock.sleep(2000);
+                .runOnMainSync(
+                        () -> {
+                            for (Activity candidate :
+                                    ActivityLifecycleMonitorRegistry.getInstance()
+                                            .getActivitiesInStage(Stage.RESUMED)) {
+                                if (candidate instanceof MainActivity) {
+                                    current.set((MainActivity) candidate);
+                                }
+                            }
+                        });
+        return current.get();
     }
 
     private DocumentFragment loadDocument(MainActivity activity, File testFile)

--- a/app/src/androidTest/java/at/tomtasche/reader/test/MainActivityTests.java
+++ b/app/src/androidTest/java/at/tomtasche/reader/test/MainActivityTests.java
@@ -20,6 +20,7 @@ import android.app.Activity;
 import android.app.Instrumentation;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
 import android.content.res.AssetManager;
 import android.net.Uri;
 import android.os.SystemClock;
@@ -34,6 +35,7 @@ import androidx.test.filters.LargeTest;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.ActivityTestRule;
 import at.tomtasche.reader.R;
+import at.tomtasche.reader.background.FileLoader;
 import at.tomtasche.reader.ui.EditActionModeCallback;
 import at.tomtasche.reader.ui.OpenFileIdling;
 import at.tomtasche.reader.ui.activity.DocumentFragment;
@@ -361,6 +363,38 @@ public class MainActivityTests {
         Assert.assertTrue(
                 "DOCX should become editable after entering edit mode",
                 waitForEditableState(pageView, true, 10000));
+    }
+
+    @Test
+    public void testDocumentSurvivesRotation() throws InterruptedException {
+        File testFile = s_testFiles.get("test.odt");
+        Assert.assertNotNull(testFile);
+        MainActivity activity = mainActivityActivityTestRule.getActivity();
+        DocumentFragment documentFragment = loadDocument(activity, testFile);
+        FileLoader.Result before = documentFragment.getLastResult();
+        Assert.assertNotNull(before);
+
+        // the document state used to be kept alive by setRetainInstance(true) and now
+        // lives in a ViewModel, so a configuration change must not drop it or reload
+        rotate(activity, ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+        try {
+            DocumentFragment afterRotation = waitForDocumentFragment(activity, 10000);
+            Assert.assertNotNull("fragment gone after rotation", afterRotation);
+            Assert.assertTrue("document state lost across rotation", afterRotation.hasLastResult());
+            Assert.assertEquals(
+                    "document was reloaded instead of restored",
+                    before.options.originalUri,
+                    afterRotation.getLastResult().options.originalUri);
+        } finally {
+            rotate(activity, ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+        }
+    }
+
+    private void rotate(MainActivity activity, int orientation) {
+        InstrumentationRegistry.getInstrumentation()
+                .runOnMainSync(() -> activity.setRequestedOrientation(orientation));
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        SystemClock.sleep(2000);
     }
 
     private DocumentFragment loadDocument(MainActivity activity, File testFile)

--- a/app/src/main/java/at/tomtasche/reader/ui/activity/DocumentFragment.java
+++ b/app/src/main/java/at/tomtasche/reader/ui/activity/DocumentFragment.java
@@ -90,6 +90,15 @@ public class DocumentFragment extends Fragment
         int lastSelectedTab = -1;
     }
 
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // not in onViewCreated: when the activity is recreated it asks a restored fragment
+        // for hasLastResult() from its own onCreate, which is before any view exists
+        state = new ViewModelProvider(this).get(DocumentViewModel.class);
+    }
+
     @Nullable @Override
     public View onCreateView(
             @NonNull LayoutInflater inflater,
@@ -136,8 +145,6 @@ public class DocumentFragment extends Fragment
 
         pageContainer = view.findViewById(R.id.page_container);
         tabLayout = view.findViewById(R.id.document_tabs);
-
-        state = new ViewModelProvider(this).get(DocumentViewModel.class);
 
         mainHandler = new Handler(Looper.getMainLooper());
 
@@ -809,24 +816,24 @@ public class DocumentFragment extends Fragment
                 public void onTabSelected(TabLayout.Tab tab) {
                     // an edited document must not switch away from the page being edited,
                     // so the previous tab is re-selected instead
-                    if (state.lastResult.options.translatable) {
-                        if (state.lastSelectedTab >= 0) {
-                            // reselecting from inside onTabSelected() does not take effect
-                            mainHandler.postDelayed(
-                                    () -> {
-                                        TabLayout.Tab previous =
-                                                tabLayout.getTabAt(state.lastSelectedTab);
-                                        if (previous != null) {
-                                            previous.select();
-                                        }
-                                    },
-                                    1);
+                    if (state.lastResult.options.translatable && state.lastSelectedTab >= 0) {
+                        // reselecting from inside onTabSelected() does not take effect
+                        mainHandler.postDelayed(
+                                () -> {
+                                    TabLayout.Tab previous =
+                                            tabLayout.getTabAt(state.lastSelectedTab);
+                                    if (previous != null) {
+                                        previous.select();
+                                    }
+                                },
+                                1);
 
-                            return;
-                        }
-
-                        state.lastSelectedTab = tab.getPosition();
+                        return;
                     }
+
+                    // in every mode, so restoreTabs() puts the indicator back on the page
+                    // the user was looking at after the view is recreated
+                    state.lastSelectedTab = tab.getPosition();
 
                     loadData(state.lastResult.partUris.get(tab.getPosition()).toString());
                 }
@@ -852,7 +859,8 @@ public class DocumentFragment extends Fragment
     }
 
     public boolean hasLastResult() {
-        return state.lastResult != null;
+        // the activity can hold a freshly constructed fragment that has not been created yet
+        return state != null && state.lastResult != null;
     }
 
     public String getLastFileType() {

--- a/app/src/main/java/at/tomtasche/reader/ui/activity/DocumentFragment.java
+++ b/app/src/main/java/at/tomtasche/reader/ui/activity/DocumentFragment.java
@@ -18,12 +18,13 @@ import android.widget.EditText;
 import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.ActionBar;
+import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.view.MenuProvider;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
+import androidx.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModelProvider;
 import at.tomtasche.reader.R;
 import at.tomtasche.reader.background.AndroidFileCache;
 import at.tomtasche.reader.background.FileLoader;
@@ -36,6 +37,7 @@ import at.tomtasche.reader.nonfree.CrashManager;
 import at.tomtasche.reader.ui.SnackbarHelper;
 import at.tomtasche.reader.ui.widget.PageView;
 import at.tomtasche.reader.ui.widget.ProgressDialogFragment;
+import com.google.android.material.tabs.TabLayout;
 import com.google.android.play.core.review.ReviewInfo;
 import com.google.android.play.core.review.ReviewManager;
 import com.google.android.play.core.review.ReviewManagerFactory;
@@ -45,7 +47,7 @@ import java.io.IOException;
 import java.util.List;
 
 public class DocumentFragment extends Fragment
-        implements LoaderService.LoaderListener, ActionBar.TabListener, MenuProvider {
+        implements LoaderService.LoaderListener, MenuProvider {
 
     private static final String SAVED_KEY_LAST_RESULT = "LAST_RESULT";
     private static final String SAVED_KEY_CURRENT_HTML_DIFF = "CURRENT_HTML_DIFF";
@@ -57,56 +59,61 @@ public class DocumentFragment extends Fragment
 
     private ProgressDialogFragment progressDialog;
 
-    private ViewGroup container;
+    private ViewGroup pageContainer;
     private PageView pageView;
 
     private Menu menu;
 
-    private FileLoader.Result lastResult;
-
-    private String currentHtmlDiff;
-
     private FileLoader.Result resultOnStart;
     private Throwable errorOnStart;
 
-    // loads cannot be canceled once running, so results of abandoned loads
-    // (e.g. user navigated back while the document was still loading) are
-    // identified by their uri and dropped
-    private Uri lastRequestedUri;
+    private TabLayout tabLayout;
 
-    private int lastSelectedTab = -1;
+    private DocumentViewModel state;
 
     private LoaderServiceQueue serviceQueue;
+
+    /**
+     * Survives configuration changes, so a rotation neither reloads the document nor loses unsaved
+     * edits. This used to be setRetainInstance(true), which kept the whole fragment - views
+     * included - alive instead.
+     */
+    public static class DocumentViewModel extends ViewModel {
+        FileLoader.Result lastResult;
+        String currentHtmlDiff;
+
+        // loads cannot be canceled once running, so results of abandoned loads
+        // (e.g. user navigated back while the document was still loading) are
+        // identified by their uri and dropped
+        Uri lastRequestedUri;
+
+        int lastSelectedTab = -1;
+    }
 
     @Nullable @Override
     public View onCreateView(
             @NonNull LayoutInflater inflater,
             @Nullable ViewGroup container,
             @Nullable Bundle savedInstanceState) {
-        this.container = container;
-
         getActivity().addMenuProvider(this, getActivity());
 
-        return super.onCreateView(inflater, container, savedInstanceState);
+        return inflater.inflate(R.layout.fragment_document, container, false);
     }
 
     private void initializePageView() {
         if (pageView != null) {
-            container.removeAllViews();
+            pageContainer.removeAllViews();
             pageView.destroy();
             pageView = null;
         }
 
         try {
-            ViewGroup inflatedView =
-                    (ViewGroup)
-                            getLayoutInflater()
-                                    .inflate(R.layout.fragment_document, container, true);
-            pageView = inflatedView.findViewById(R.id.page_view);
+            getLayoutInflater().inflate(R.layout.page_view, pageContainer, true);
+            pageView = pageContainer.findViewById(R.id.page_view);
 
             pageView.setDocumentFragment(this);
         } catch (Throwable t) {
-            // can't call crashlytics yet at this point (onActivityCreated not called)
+            // can't call crashlytics yet at this point (onViewCreated not called)
 
             String errorString =
                     "Please install \"Android System WebView\" and restart the app afterwards.";
@@ -124,8 +131,13 @@ public class DocumentFragment extends Fragment
     }
 
     @Override
-    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        pageContainer = view.findViewById(R.id.page_container);
+        tabLayout = view.findViewById(R.id.document_tabs);
+
+        state = new ViewModelProvider(this).get(DocumentViewModel.class);
 
         mainHandler = new Handler(Looper.getMainLooper());
 
@@ -142,30 +154,60 @@ public class DocumentFragment extends Fragment
                     }
                 });
 
-        crashManager.log("onActivityCreated");
+        crashManager.log("onViewCreated");
 
         if (savedInstanceState != null) {
-            crashManager.log("onActivityCreated has savedInstanceState");
+            crashManager.log("onViewCreated has savedInstanceState");
 
             initializePageView();
 
-            lastResult = savedInstanceState.getParcelable(SAVED_KEY_LAST_RESULT);
-            if (lastResult != null) {
-                crashManager.log("savedInstanceState has lastResult");
-
-                prepareLoad(lastResult.loaderType, false);
+            // the view model survives a rotation, the bundle also survives process death
+            if (state.lastResult == null) {
+                state.lastResult = savedInstanceState.getParcelable(SAVED_KEY_LAST_RESULT);
+            }
+            if (state.currentHtmlDiff == null) {
+                state.currentHtmlDiff = savedInstanceState.getString(SAVED_KEY_CURRENT_HTML_DIFF);
             }
 
-            currentHtmlDiff = savedInstanceState.getString(SAVED_KEY_CURRENT_HTML_DIFF);
+            if (state.lastResult != null) {
+                crashManager.log("restoring lastResult");
+
+                prepareLoad(state.lastResult.loaderType, false);
+                restoreTabs(state.lastResult);
+            }
 
             pageView.restoreState(savedInstanceState);
         }
+    }
 
-        // the app is designed to work fine without this setting, however, it is enabled for
-        // performance reasons
-        // (avoids redundant reloads of documents) and usability (edits are not lost on orientation
-        // change)
-        setRetainInstance(true);
+    /**
+     * Rebuilds the tab strip after the view was recreated. The tabs live in the fragment view, so
+     * unlike the document itself they do not survive a rotation on their own.
+     */
+    private void restoreTabs(FileLoader.Result result) {
+        if (result.partTitles.size() <= 1) {
+            return;
+        }
+
+        addTabs(result.partTitles);
+
+        int selected = Math.max(state.lastSelectedTab, 0);
+        TabLayout.Tab tab = tabLayout.getTabAt(selected);
+        if (tab != null) {
+            tab.select();
+        }
+    }
+
+    private void addTabs(List<String> titles) {
+        for (int i = 0; i < titles.size(); i++) {
+            String name = titles.get(i);
+            if (name == null) name = "Page " + (i + 1);
+
+            tabLayout.addTab(tabLayout.newTab().setText(name), false);
+        }
+
+        tabLayout.setVisibility(View.VISIBLE);
+        tabLayout.addOnTabSelectedListener(tabSelectedListener);
     }
 
     @Override
@@ -179,8 +221,8 @@ public class DocumentFragment extends Fragment
         menu.findItem(R.id.menu_print).setVisible(true);
 
         // the other menu items are dynamically enabled based on the loaded document
-        if (lastResult != null) {
-            prepareMenu(lastResult.loaderType, lastResult.options.fileType);
+        if (state.lastResult != null) {
+            prepareMenu(state.lastResult.loaderType, state.lastResult.options.fileType);
         }
     }
 
@@ -196,8 +238,8 @@ public class DocumentFragment extends Fragment
 
         crashManager.log("onSaveInstanceState");
 
-        outState.putParcelable(SAVED_KEY_LAST_RESULT, lastResult);
-        outState.putString(SAVED_KEY_CURRENT_HTML_DIFF, currentHtmlDiff);
+        outState.putParcelable(SAVED_KEY_LAST_RESULT, state.lastResult);
+        outState.putString(SAVED_KEY_CURRENT_HTML_DIFF, state.currentHtmlDiff);
 
         pageView.saveState(outState);
     }
@@ -252,7 +294,7 @@ public class DocumentFragment extends Fragment
     public void loadUri(Uri uri, boolean persistentUri, boolean editable) {
         initializePageView();
 
-        lastRequestedUri = uri;
+        state.lastRequestedUri = uri;
 
         FileLoader.Options options = new FileLoader.Options();
         options.originalUri = uri;
@@ -263,14 +305,14 @@ public class DocumentFragment extends Fragment
     }
 
     public void reloadUri(boolean translatable) {
-        lastResult.options.translatable = translatable;
+        state.lastResult.options.translatable = translatable;
 
-        loadWithType(lastResult.loaderType, lastResult.options);
+        loadWithType(state.lastResult.loaderType, state.lastResult.options);
     }
 
     public void prepareSave(Runnable callback, boolean fullSave) {
         if (fullSave) {
-            currentHtmlDiff = null;
+            state.currentHtmlDiff = null;
 
             callback.run();
         }
@@ -280,7 +322,7 @@ public class DocumentFragment extends Fragment
 
                     @Override
                     public void onHtml(String htmlDiff) {
-                        currentHtmlDiff = htmlDiff;
+                        state.currentHtmlDiff = htmlDiff;
 
                         callback.run();
                     }
@@ -298,7 +340,7 @@ public class DocumentFragment extends Fragment
                 new LoaderServiceQueue.QueueEntry() {
                     @Override
                     public void onService(LoaderService service) {
-                        service.saveAsync(lastResult, outFile, currentHtmlDiff);
+                        service.saveAsync(state.lastResult, outFile, state.currentHtmlDiff);
                     }
                 });
     }
@@ -310,10 +352,13 @@ public class DocumentFragment extends Fragment
     }
 
     private void resetTabs() {
-        ActionBar bar = ((AppCompatActivity) getActivity()).getSupportActionBar();
-        bar.removeAllTabs();
+        if (tabLayout != null) {
+            tabLayout.clearOnTabSelectedListeners();
+            tabLayout.removeAllTabs();
+            tabLayout.setVisibility(View.GONE);
+        }
 
-        lastSelectedTab = -1;
+        state.lastSelectedTab = -1;
     }
 
     private void toggleDocumentMenu(boolean enabled) {
@@ -393,7 +438,8 @@ public class DocumentFragment extends Fragment
     }
 
     private boolean isActivityReadyForResult(FileLoader.Result result) {
-        if (lastRequestedUri != null && !lastRequestedUri.equals(result.options.originalUri)) {
+        if (state.lastRequestedUri != null
+                && !state.lastRequestedUri.equals(result.options.originalUri)) {
             crashManager.log("dropping result of abandoned load: " + result.options.originalUri);
 
             return false;
@@ -407,7 +453,7 @@ public class DocumentFragment extends Fragment
         }
 
         // needs to be saved for errors too for features like "Open With" to work
-        lastResult = result;
+        state.lastResult = result;
 
         resultOnStart = null;
         errorOnStart = null;
@@ -429,28 +475,17 @@ public class DocumentFragment extends Fragment
 
         resetTabs();
 
-        ActionBar bar = ((AppCompatActivity) activity).getSupportActionBar();
         List<String> titles = result.partTitles;
         int pages = titles.size();
         if (pages > 1) {
-            bar.setNavigationMode(ActionBar.NAVIGATION_MODE_TABS);
-            for (int i = 0; i < pages; i++) {
-                ActionBar.Tab tab = bar.newTab();
-                String name = titles.get(i);
-                if (name == null) name = "Page " + (i + 1);
-                tab.setText(name);
-                tab.setTabListener(this);
+            addTabs(titles);
 
-                bar.addTab(tab);
+            TabLayout.Tab first = tabLayout.getTabAt(0);
+            if (first != null) {
+                first.select();
             }
-
-            bar.setSelectedNavigationItem(0);
-        } else {
-            bar.setNavigationMode(ActionBar.NAVIGATION_MODE_STANDARD);
-
-            if (pages == 1) {
-                loadData(result.partUris.get(0).toString());
-            }
+        } else if (pages == 1) {
+            loadData(result.partUris.get(0).toString());
         }
 
         if (result.loaderType == FileLoader.LoaderType.RAW
@@ -556,7 +591,7 @@ public class DocumentFragment extends Fragment
 
     @Override
     public void onSaveSuccess(Uri outFile) {
-        currentHtmlDiff = null;
+        state.currentHtmlDiff = null;
 
         SnackbarHelper.show(getActivity(), R.string.toast_edit_status_saved, null, false, false);
 
@@ -565,7 +600,7 @@ public class DocumentFragment extends Fragment
 
     @Override
     public void onSaveError() {
-        currentHtmlDiff = null;
+        state.currentHtmlDiff = null;
 
         SnackbarHelper.show(getActivity(), R.string.toast_error_save_failed, null, true, true);
     }
@@ -643,11 +678,11 @@ public class DocumentFragment extends Fragment
     }
 
     public void openWith(Activity activity) {
-        doReopen(lastResult.options, activity, true, false);
+        doReopen(state.lastResult.options, activity, true, false);
     }
 
     public void share(Activity activity) {
-        doReopen(lastResult.options, activity, true, true);
+        doReopen(state.lastResult.options, activity, true, true);
     }
 
     private void doReopen(
@@ -718,11 +753,18 @@ public class DocumentFragment extends Fragment
     }
 
     private void showProgress(boolean isUpload) {
-        if (progressDialog == null && getFragmentManager() != null) {
+        // getParentFragmentManager() throws when the fragment is not attached, where the
+        // deprecated getFragmentManager() used to return null
+        if (!isAdded()) {
+            return;
+        }
+
+        FragmentManager fragmentManager = getParentFragmentManager();
+
+        if (progressDialog == null) {
             progressDialog =
                     (ProgressDialogFragment)
-                            getFragmentManager()
-                                    .findFragmentByTag(ProgressDialogFragment.FRAGMENT_TAG);
+                            fragmentManager.findFragmentByTag(ProgressDialogFragment.FRAGMENT_TAG);
         }
 
         if (progressDialog != null) {
@@ -731,15 +773,6 @@ public class DocumentFragment extends Fragment
 
         try {
             progressDialog = new ProgressDialogFragment(isUpload);
-
-            FragmentManager fragmentManager = getFragmentManager();
-            if (fragmentManager == null) {
-                crashManager.log(new NullPointerException());
-
-                progressDialog = null;
-
-                return;
-            }
 
             progressDialog.show(fragmentManager, ProgressDialogFragment.FRAGMENT_TAG);
         } catch (IllegalStateException e) {
@@ -751,10 +784,10 @@ public class DocumentFragment extends Fragment
     }
 
     private void dismissProgress() {
-        if (progressDialog == null && getFragmentManager() != null) {
+        if (progressDialog == null && isAdded()) {
             progressDialog =
                     (ProgressDialogFragment)
-                            getFragmentManager()
+                            getParentFragmentManager()
                                     .findFragmentByTag(ProgressDialogFragment.FRAGMENT_TAG);
         }
 
@@ -770,37 +803,40 @@ public class DocumentFragment extends Fragment
         progressDialog = null;
     }
 
-    @Override
-    public void onTabSelected(ActionBar.Tab tab, androidx.fragment.app.FragmentTransaction ft) {
-        if (lastResult.options.translatable) {
-            if (lastSelectedTab >= 0) {
-                // I think there was an issue switching tab inside of onTabSelected()
-                mainHandler.postDelayed(
-                        new Runnable() {
-                            @Override
-                            public void run() {
-                                ActionBar bar =
-                                        ((AppCompatActivity) getActivity()).getSupportActionBar();
-                                bar.setSelectedNavigationItem(lastSelectedTab);
-                            }
-                        },
-                        1);
+    private final TabLayout.OnTabSelectedListener tabSelectedListener =
+            new TabLayout.OnTabSelectedListener() {
+                @Override
+                public void onTabSelected(TabLayout.Tab tab) {
+                    // an edited document must not switch away from the page being edited,
+                    // so the previous tab is re-selected instead
+                    if (state.lastResult.options.translatable) {
+                        if (state.lastSelectedTab >= 0) {
+                            // reselecting from inside onTabSelected() does not take effect
+                            mainHandler.postDelayed(
+                                    () -> {
+                                        TabLayout.Tab previous =
+                                                tabLayout.getTabAt(state.lastSelectedTab);
+                                        if (previous != null) {
+                                            previous.select();
+                                        }
+                                    },
+                                    1);
 
-                return;
-            }
+                            return;
+                        }
 
-            lastSelectedTab = tab.getPosition();
-        }
+                        state.lastSelectedTab = tab.getPosition();
+                    }
 
-        Uri uri = lastResult.partUris.get(tab.getPosition());
-        loadData(uri.toString());
-    }
+                    loadData(state.lastResult.partUris.get(tab.getPosition()).toString());
+                }
 
-    @Override
-    public void onTabUnselected(ActionBar.Tab tab, androidx.fragment.app.FragmentTransaction ft) {}
+                @Override
+                public void onTabUnselected(TabLayout.Tab tab) {}
 
-    @Override
-    public void onTabReselected(ActionBar.Tab tab, androidx.fragment.app.FragmentTransaction ft) {}
+                @Override
+                public void onTabReselected(TabLayout.Tab tab) {}
+            };
 
     private void loadData(String url) {
         pageView.loadUrl(url);
@@ -810,12 +846,17 @@ public class DocumentFragment extends Fragment
         return pageView;
     }
 
+    @VisibleForTesting
+    public FileLoader.Result getLastResult() {
+        return state.lastResult;
+    }
+
     public boolean hasLastResult() {
-        return lastResult != null;
+        return state.lastResult != null;
     }
 
     public String getLastFileType() {
-        return lastResult.options.fileType;
+        return state.lastResult.options.fileType;
     }
 
     public CrashManager getCrashManager() {

--- a/app/src/main/java/at/tomtasche/reader/ui/activity/MainActivity.java
+++ b/app/src/main/java/at/tomtasche/reader/ui/activity/MainActivity.java
@@ -25,8 +25,9 @@ import android.view.View;
 import android.widget.CompoundButton;
 import android.widget.LinearLayout;
 import androidx.activity.OnBackPressedCallback;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.SwitchCompat;
@@ -75,7 +76,6 @@ public class MainActivity extends AppCompatActivity implements MenuProvider {
     private static final boolean IS_TESTING = isTesting();
     private static final int GOOGLE_REQUEST_CODE = 1993;
     private static final String DOCUMENT_FRAGMENT_TAG = "document_fragment";
-    private static final int CREATE_CODE = 4213;
 
     private Handler handler;
 
@@ -150,6 +150,43 @@ public class MainActivity extends AppCompatActivity implements MenuProvider {
                     serviceQueue.setService(service);
                 }
             };
+
+    // ACTION_OPEN_DOCUMENT, dispatched to a file manager the user picked
+    private final ActivityResultLauncher<Intent> openDocumentLauncher =
+            registerForActivityResult(
+                    new ActivityResultContracts.StartActivityForResult(),
+                    result -> {
+                        OpenFileIdling.decrement();
+
+                        Intent data = result.getData();
+                        if (result.getResultCode() != Activity.RESULT_OK || data == null) {
+                            return;
+                        }
+
+                        Uri uri = data.getData();
+                        if (uri == null) {
+                            return;
+                        }
+
+                        crashManager.log("open document result");
+
+                        loadUri(uri);
+                    });
+
+    // ACTION_CREATE_DOCUMENT, the target the current document is saved to
+    private final ActivityResultLauncher<Intent> createDocumentLauncher =
+            registerForActivityResult(
+                    new ActivityResultContracts.StartActivityForResult(),
+                    result -> {
+                        Intent data = result.getData();
+                        if (data == null || data.getData() == null) {
+                            return;
+                        }
+
+                        lastSaveUri = data.getData();
+
+                        documentFragment.save(lastSaveUri);
+                    });
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -364,7 +401,7 @@ public class MainActivity extends AppCompatActivity implements MenuProvider {
 
             intent.setType(documentFragment.getLastFileType());
 
-            startActivityForResult(intent, CREATE_CODE);
+            createDocumentLauncher.launch(intent);
         } catch (ActivityNotFoundException e) {
             // happens on a variety devices, e.g. Samsung Galaxy Tab4 7.0 with Android 4.4.2
             crashManager.log(e);
@@ -426,25 +463,16 @@ public class MainActivity extends AppCompatActivity implements MenuProvider {
         }
     }
 
+    // The play services availability dialog calls startActivityForResult() itself with a
+    // request code we hand it, so its result cannot be routed through an
+    // ActivityResultLauncher. Everything the app launches on its own goes through the
+    // launchers declared above.
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
         super.onActivityResult(requestCode, resultCode, intent);
 
         if (requestCode == GOOGLE_REQUEST_CODE) {
             initializeProprietaryLibraries();
-        } else if (requestCode == CREATE_CODE && intent != null) {
-            lastSaveUri = intent.getData();
-
-            documentFragment.save(lastSaveUri);
-        } else if (intent != null) {
-            crashManager.log("onActivityResult loadUri");
-
-            Uri uri = intent.getData();
-            if (requestCode == 42 && resultCode == Activity.RESULT_OK && uri != null) {
-                OpenFileIdling.decrement();
-
-                loadUri(uri);
-            }
         }
     }
 
@@ -676,10 +704,6 @@ public class MainActivity extends AppCompatActivity implements MenuProvider {
             documentFragment = null;
         }
 
-        ActionBar bar = getSupportActionBar();
-        bar.removeAllTabs();
-        bar.setNavigationMode(ActionBar.NAVIGATION_MODE_STANDARD);
-
         lastUri = null;
 
         documentContainer.setVisibility(View.GONE);
@@ -740,7 +764,7 @@ public class MainActivity extends AppCompatActivity implements MenuProvider {
                         try {
                             OpenFileIdling.increment();
 
-                            startActivityForResult(intent, 42);
+                            openDocumentLauncher.launch(intent);
                         } catch (Exception e) {
                             OpenFileIdling.decrement();
 

--- a/app/src/main/res/layout/fragment_document.xml
+++ b/app/src/main/res/layout/fragment_document.xml
@@ -1,11 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-    <at.tomtasche.reader.ui.widget.PageView
-            android:id="@+id/page_view"
+    <!-- one tab per sheet for spreadsheets, hidden for every other format -->
+    <com.google.android.material.tabs.TabLayout
+            android:id="@+id/document_tabs"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:tabMode="scrollable" />
+
+    <FrameLayout
+            android:id="@+id/page_container"
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
 </LinearLayout>

--- a/app/src/main/res/layout/page_view.xml
+++ b/app/src/main/res/layout/page_view.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Inflated into the page container of fragment_document every time a document is
+  loaded: the WebView is thrown away and recreated rather than reused, so no state
+  from the previous document can leak into the next one.
+-->
+<at.tomtasche.reader.ui.widget.PageView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/page_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />


### PR DESCRIPTION
Stacked on #504. The last three deprecated UI patterns. They are in one PR because they all touch the document display path and needed to be verified together on a device.

**This is the one with user-visible changes** — the tab strip moves.

## 1. Activity Result API

Opening and saving went through `startActivityForResult` with magic request codes `42` and `4213`, all dispatched in one `onActivityResult`. Both are `ActivityResultLauncher`s now.

`onActivityResult` survives for exactly one case: the Play Services availability dialog calls `startActivityForResult` *itself* with a request code we hand it, so its result cannot be routed through a launcher. That is commented in place rather than left looking like an oversight.

One gotcha worth knowing: the launcher fields have to be declared *after* the fields their callbacks read (`crashManager`, `documentFragment`, `lastSaveUri`), otherwise javac rejects them as illegal forward references.

## 2. ActionBar tabs → Material TabLayout

`ActionBar.NAVIGATION_MODE_TABS` and `ActionBar.TabListener` have been deprecated since API 21. Multi-sheet documents now use a `TabLayout` in the fragment layout, above the WebView.

**Visible change:** tabs move from inside the action bar to a strip below it. Per #490 this only affects spreadsheets.

The rule that an edited document may not switch away from the page being edited is preserved, including the `postDelayed` re-select that works around re-selecting from inside the selection callback.

## 3. setRetainInstance → ViewModel

This is the substantive one. `setRetainInstance(true)` kept the whole fragment — views included — alive across configuration changes. The document result, html diff, requested URI and selected tab move into a `DocumentViewModel`; the view is rebuilt normally.

Knock-on effects:

- **`onCreateView` now returns the inflated layout instead of `null`.** That is what allows the deprecated `onActivityCreated` to become `onViewCreated` — `onViewCreated` is simply not called when `onCreateView` returns null. The PageView is inflated into a container inside that layout, so it is still discarded and recreated per document and no WebView state leaks between documents.
- **The tab strip is rebuilt from the restored result.** Tabs live in the fragment view now, so unlike the document they do not survive rotation on their own. Previously they lived in the action bar and were simply *lost* on rotation — this is a small bug fix that falls out.
- **`getParentFragmentManager()` throws where `getFragmentManager()` returned null.** The progress dialog paths check `isAdded()` instead; a straight rename would have turned a null check into a crash.

## Verification

Full instrumented suite on a Pixel 6 Pro emulator (API 31): **12 tests, 0 failures**, plus `spotlessCheck assembleDebug testProDebugUnitTest lintProDebug lintLiteDebug`.

The 12th is new: `testDocumentSurvivesRotation` loads a document, rotates to landscape and back, and asserts the fragment still holds the same result — the behavior `setRetainInstance` existed to provide, which nothing covered before. To be precise about what it proves: it verifies the document is neither lost nor reloaded across a configuration change; it does not isolate the ViewModel from the `onSaveInstanceState` bundle, since both paths are in play.