### PR TITLE
Update conan-odr-index and bump odrcore to 5.7.0

### DIFF
--- a/app/conanfile.txt
+++ b/app/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-odrcore/5.5.0
+odrcore/5.7.0
 
 [generators]
 CMakeToolchain
@@ -11,4 +11,5 @@ odrcore/*:with_pdf2htmlEX=False
 odrcore/*:with_wvWare=False
 odrcore/*:with_libmagic=True
 odrcore/*:with_http_server=True
+odrcore/*:with_cli=False
 odrcore/*:bundle_assets=False


### PR DESCRIPTION
Moves the `conan-odr-index` submodule to `010a878` and bumps the pinned core to `odrcore/5.7.0`.

## Index

`49780d8..010a878` adds the 5.6.0 and 5.7.0 recipes, version-gates the options older cores do not know about (so a downgrade keeps resolving), and exposes `ODR_CLI` as a `with_cli` option.

## Core

- **5.6.0** – pdf CRLF operator tokenization fix, synthesized missing name table, fixed-size pdf/image content now opens fit-to-width on mobile, configurable initial zoom via `HtmlViewportMode`.
- **5.7.0** – python bindings and JNI bindings (`app.opendocument.core`) with a maven distribution.

The JNI bindings stay off in this PR (`with_jni` defaults to `False`). Rewiring the app's hand-written `core_wrapper.cpp` onto them is a separate change stacked on this one.

## `with_cli=False`

`ODR_CLI` defaults to `ON` in odrcore's `CMakeLists.txt`, so every android build so far has compiled and packaged cli tools that the app never links. Turning the new option off drops them.

## Verification

- `conan install` for all four architectures (armv8, armv7, x86, x86_64) resolves 5.7.0 from the remote.
- `./gradlew assembleProDebug` builds.
- `./gradlew connectedProDebugAndroidTest` – 12/12 green on a Pixel 6 Pro AVD (API 31), covering odt/docx/xlsx/pdf loading, password-protected documents and both edit-mode paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)