### PR TITLE
Log why the consent flow hid the ad banner

### DIFF
--- a/app/src/main/java/app/opendocument/droid/nonfree/AdManager.java
+++ b/app/src/main/java/app/opendocument/droid/nonfree/AdManager.java
@@ -11,6 +11,7 @@ import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.ads.RequestConfiguration;
 import com.google.android.ump.ConsentInformation;
 import com.google.android.ump.ConsentRequestParameters;
+import com.google.android.ump.FormError;
 import com.google.android.ump.UserMessagingPlatform;
 import java.util.List;
 
@@ -100,6 +101,15 @@ public class AdManager {
                             loadAndShowError -> {
                                 if (loadAndShowError != null
                                         || !consentInformation.canRequestAds()) {
+                                    // without this the banner just silently stays hidden,
+                                    // and the ump sdk only logs an unspecific "Error
+                                    // making request."
+                                    crashManager.log(
+                                            "consent form failed: "
+                                                    + describe(loadAndShowError)
+                                                    + ", canRequestAds="
+                                                    + consentInformation.canRequestAds());
+
                                     hideGoogleAds();
 
                                     return;
@@ -108,7 +118,22 @@ public class AdManager {
                                 activity.runOnUiThread(this::showAdaptiveBanner);
                             });
                 },
-                requestConsentError -> hideGoogleAds());
+                requestConsentError -> {
+                    // fires for the mundane offline case too - a device that was asleep
+                    // times out against fundingchoicesmessages.google.com
+                    crashManager.log(
+                            "consent info update failed: " + describe(requestConsentError));
+
+                    hideGoogleAds();
+                });
+    }
+
+    private static String describe(FormError error) {
+        if (error == null) {
+            return "no error";
+        }
+
+        return error.getErrorCode() + "/" + error.getMessage();
     }
 
     // https://developers.google.com/admob/android/banner/adaptive


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Why

While checking that the ad banner still works after the package rename, the banner failed to appear and there was no way to tell why from the app's own logs.

Both UMP callbacks in `AdManager` discard their `FormError` and just call `hideGoogleAds()`, so "consent failed" and "ads were never requested" look identical from outside. The UMP SDK only logs an unspecific `Error making request.` of its own. Diagnosing it needed a temporary patch, a rebuild and a reinstall.

## What

Report the error code and message through `CrashManager` in both callbacks, plus `canRequestAds()` for the case where the form itself succeeded but consent was withheld. A small `describe(FormError)` helper keeps the two call sites readable.

Both callbacks only run while ads are enabled, which is also the only path that assigns `crashManager`, so this adds no new null path. `CrashManager` is logcat-only (tag `ODR`) since the Firebase integration was removed, so nothing leaves the device.

## Testing

Verified on a physical Pixel 9 Pro running the Lite debug flavor.

**The banner itself works.** Consent form loads, `canRequestAds=true`, `onAdLoaded` fires and a real ad renders in `ad_container`. So the rename to `app.opendocument.droid` did not break AdMob — the identity is tied to `applicationId`, which is unchanged.

**Happy path stays quiet.** No new lines under the `ODR` tag on a successful load.

**Failure path produces the intended line.** Reproduced by clearing the cached UMP consent state and launching with the screen off, so the device dozes and the request times out:

```
D/ODR (21897): consent info update failed: 4/The server timed out.
```

That is the whole point of the change — previously this same run logged nothing at all from the app, and the banner just silently stayed hidden.

`spotlessCheck` and `assembleLiteDebug` pass.

Worth knowing for anyone testing this: once consent info is cached, `requestConsentInfoUpdate` succeeds from cache even with no network, so the error path cannot be reproduced without clearing `shared_prefs/__GOOGLE_FUNDING_CHOICE_SDK_INTERNAL__.xml` first.