### PR TITLE
Drop the java interop annotations the migration made obsolete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,10 +140,18 @@ the `.pro` suffix) differ on purpose - do not "fix" the mismatch:
 
 ### Language
 
-Mixed Java and Kotlin; Kotlin support is built into AGP 9, no kotlin plugin is applied.
-New code should be Kotlin. When converting an existing class, watch two things:
+Kotlin; support is built into AGP 9, no kotlin plugin is applied. The only java left is
+`com/commonsware/android/print`, which is vendored third party code with its own copyright
+header and stays java so it can still be diffed against upstream. It calls nothing of ours,
+so there is no java-to-kotlin call anywhere in the project.
 
-- Java callers spell static helpers as `Foo.bar()`, so converted utility classes need
-  `object` plus `@JvmStatic`, and public final fields need `@JvmField`.
-- Kotlin classes with default arguments are called from the remaining java loaders, which
-  cannot see defaults - either pass every argument or add `@JvmOverloads`.
+That means `@JvmStatic`, `@JvmField`, `@JvmOverloads` and `@Throws` are not needed for
+interop and should not be added back for it. What is left of them is there for a runtime
+that reflects over the bytecode, and each one says so:
+
+- `@JvmField` on the `CREATOR`s in `FileLoader`, which the parcelable contract requires to
+  be a static field.
+- `@JvmOverloads` on `ProgressDialogFragment`'s constructor, so the no-arg constructor the
+  fragment framework re-creates it with exists.
+- `@JvmStatic` on the `@BeforeClass` / `@AfterClass` methods in the instrumented tests,
+  which JUnit requires to be static.

--- a/app/src/androidTest/java/app/opendocument/droid/test/CoreTest.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/CoreTest.kt
@@ -166,9 +166,9 @@ class CoreTest {
 
         private var sharedLoader: CoreLoader? = null
 
+        // @JvmStatic because junit requires @BeforeClass / @AfterClass to be static
         @JvmStatic
         @BeforeClass
-        @Throws(InterruptedException::class)
         fun startServer() {
             val appCtx = InstrumentationRegistry.getInstrumentation().targetContext
 

--- a/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
@@ -436,6 +436,7 @@ class MainActivityTests {
         // insertion ordered, so the "All test files" log below reads in extraction order
         private val testFiles = LinkedHashMap<String, File>()
 
+        // @JvmStatic because junit requires @BeforeClass / @AfterClass to be static
         @JvmStatic
         @BeforeClass
         fun extractTestFiles() {

--- a/app/src/debug/java/app/opendocument/droid/ui/OpenFileIdling.kt
+++ b/app/src/debug/java/app/opendocument/droid/ui/OpenFileIdling.kt
@@ -12,16 +12,13 @@ object OpenFileIdling {
 
     private val RESOURCE = CountingIdlingResource("MainActivity.openFileIdlingResource")
 
-    @JvmStatic
     val idlingResource: IdlingResource
         get() = RESOURCE
 
-    @JvmStatic
     fun increment() {
         RESOURCE.increment()
     }
 
-    @JvmStatic
     fun decrement() {
         if (!RESOURCE.isIdleNow) {
             RESOURCE.decrement()

--- a/app/src/main/java/app/opendocument/droid/background/AndroidFileCache.kt
+++ b/app/src/main/java/app/opendocument/droid/background/AndroidFileCache.kt
@@ -5,7 +5,6 @@ import android.net.Uri
 import androidx.core.content.FileProvider
 import java.io.File
 
-/** @JvmStatic throughout, because the java callers still spell these as static calls. */
 object AndroidFileCache {
 
     private const val CACHE_DIRECTORY_PREFIX = "cache."
@@ -26,7 +25,6 @@ object AndroidFileCache {
         return cache
     }
 
-    @JvmStatic
     fun getCacheDirectory(cacheFile: File): File {
         // !! rather than a graceful fallback: reaching the filesystem root means the file was
         // never below a cache directory, which the java version blew up on just as loudly
@@ -42,18 +40,15 @@ object AndroidFileCache {
         return path.substring(path.indexOf(CACHE_DIRECTORY_PREFIX))
     }
 
-    @JvmStatic
     fun getCacheFileUri(context: Context, file: File): Uri {
         return FileProvider.getUriForFile(context, getProviderAuthority(context), file)
     }
 
-    @JvmStatic
     fun isCached(context: Context, uri: Uri): Boolean {
         return uri.host == getProviderAuthority(context) &&
             uri.toString().contains(CACHE_DIRECTORY_PREFIX)
     }
 
-    @JvmStatic
     fun getCacheFile(context: Context, uri: Uri): File? {
         if (!isCached(context, uri)) {
             return null
@@ -64,7 +59,6 @@ object AndroidFileCache {
         return File(getRootCacheDirectory(context), cacheFileString)
     }
 
-    @JvmStatic
     fun createCacheFile(context: Context): File {
         val cacheRoot = getRootCacheDirectory(context)
         val cacheDirectory = File(cacheRoot, CACHE_DIRECTORY_PREFIX + System.currentTimeMillis())
@@ -74,7 +68,6 @@ object AndroidFileCache {
         return File(cacheDirectory, "cached-file.tmp")
     }
 
-    @JvmStatic
     fun cleanup(context: Context) {
         val cache = getRootCacheDirectory(context)
         val directories =

--- a/app/src/main/java/app/opendocument/droid/background/CoreLoader.kt
+++ b/app/src/main/java/app/opendocument/droid/background/CoreLoader.kt
@@ -319,7 +319,6 @@ class CoreLoader(context: Context?, private val doOoxml: Boolean) :
          * this has to have run before any document is loaded. LoaderService constructs and
          * initializes the CoreLoader while starting up, well before the first load request.
          */
-        @JvmStatic
         @Synchronized
         fun initializeCore(context: Context) {
             if (coreInitialized) {

--- a/app/src/main/java/app/opendocument/droid/background/FileLoader.kt
+++ b/app/src/main/java/app/opendocument/droid/background/FileLoader.kt
@@ -132,24 +132,22 @@ abstract class FileLoader(context: Context?, protected val type: LoaderType) {
     /**
      * What to load and everything the loaders found out about it along the way - [MetadataLoader]
      * fills most of these in before handing the same instance on to the loader that does the work.
-     *
-     * @JvmField so the remaining java call sites keep reading these as fields rather than getters.
      */
     class Options() : Parcelable {
 
-        @JvmField var originalUri: Uri? = null
-        @JvmField var cacheUri: Uri? = null
-        @JvmField var persistentUri: Boolean = false
+        var originalUri: Uri? = null
+        var cacheUri: Uri? = null
+        var persistentUri: Boolean = false
 
-        @JvmField var fileExists: Boolean = false
-        @JvmField var filename: String? = null
-        @JvmField var fileType: String? = null
-        @JvmField var fileExtension: String? = null
+        var fileExists: Boolean = false
+        var filename: String? = null
+        var fileType: String? = null
+        var fileExtension: String? = null
 
-        @JvmField var password: String? = null
+        var password: String? = null
 
-        @JvmField var limit: Boolean = false
-        @JvmField var translatable: Boolean = false
+        var limit: Boolean = false
+        var translatable: Boolean = false
 
         @Suppress("DEPRECATION") // the typed readParcelable overload only exists since API 33
         private constructor(parcel: Parcel) : this() {
@@ -182,6 +180,7 @@ abstract class FileLoader(context: Context?, protected val type: LoaderType) {
         }
 
         companion object {
+            // @JvmField because the framework looks CREATOR up as a static field
             @JvmField
             val CREATOR: Parcelable.Creator<Options> =
                 object : Parcelable.Creator<Options> {
@@ -196,11 +195,10 @@ abstract class FileLoader(context: Context?, protected val type: LoaderType) {
      * The outcome of one load: the [Options] it ran with plus one uri per part of the document
      * (spreadsheets have one per sheet, everything else a single one with a null title).
      */
-    class Result(@JvmField val loaderType: LoaderType, @JvmField val options: Options) :
-        Parcelable {
+    class Result(val loaderType: LoaderType, val options: Options) : Parcelable {
 
-        @JvmField val partTitles: MutableList<String?> = LinkedList()
-        @JvmField val partUris: MutableList<Uri> = LinkedList()
+        val partTitles: MutableList<String?> = LinkedList()
+        val partUris: MutableList<Uri> = LinkedList()
 
         override fun describeContents(): Int = 0
 
@@ -212,6 +210,7 @@ abstract class FileLoader(context: Context?, protected val type: LoaderType) {
         }
 
         companion object {
+            // @JvmField because the framework looks CREATOR up as a static field
             @JvmField
             val CREATOR: Parcelable.Creator<Result> =
                 object : Parcelable.Creator<Result> {

--- a/app/src/main/java/app/opendocument/droid/background/MimeTypeResolver.kt
+++ b/app/src/main/java/app/opendocument/droid/background/MimeTypeResolver.kt
@@ -17,15 +17,12 @@ object MimeTypeResolver {
         fun mimeTypeFromExtension(extension: String?): String?
     }
 
-    /** @JvmField so java call sites keep reading these as fields rather than getters. */
-    class Resolution
-    internal constructor(@JvmField val mimeType: String?, @JvmField val extension: String?)
+    class Resolution internal constructor(val mimeType: String?, val extension: String?)
 
     /**
      * Returns the extension of the given filename, or null if it does not have one. Dotfiles
      * (`.bashrc`) and trailing dots (`report.`) count as "no extension".
      */
-    @JvmStatic
     fun parseExtension(filename: String?): String? {
         if (filename == null) {
             return null
@@ -45,7 +42,6 @@ object MimeTypeResolver {
      * mime type could be detected it is looked up from the extension instead. Either field of the
      * result may be null.
      */
-    @JvmStatic
     fun resolve(
         mimeType: String?,
         filenameExtension: String?,

--- a/app/src/main/java/app/opendocument/droid/background/OnlineLoader.kt
+++ b/app/src/main/java/app/opendocument/droid/background/OnlineLoader.kt
@@ -69,7 +69,6 @@ class OnlineLoader(context: Context?, private val coreLoader: CoreLoader) :
             coreLoader.isSupported(options)
     }
 
-    @Throws(IOException::class)
     private fun doOnlineConvert(options: Options): Uri {
         // https://stackoverflow.com/a/2469587/198996
         val basePath = "https://use.opendocument.app"
@@ -103,7 +102,6 @@ class OnlineLoader(context: Context?, private val coreLoader: CoreLoader) :
         return Uri.parse(basePath + redirectUrl)
     }
 
-    @Throws(IOException::class)
     private fun doTransferUpload(options: Options): Uri {
         val binaryFile =
             checkNotNull(AndroidFileCache.getCacheFile(context, checkNotNull(options.cacheUri)))
@@ -143,7 +141,6 @@ class OnlineLoader(context: Context?, private val coreLoader: CoreLoader) :
         return Uri.parse(GOOGLE_VIEWER_URL + URLEncoder.encode(downloadUrl, StreamUtil.ENCODING))
     }
 
-    @Throws(IOException::class)
     private fun readBody(connection: HttpURLConnection): String? {
         val inputStream = connection.inputStream ?: return null
 

--- a/app/src/main/java/app/opendocument/droid/background/ParcelUtil.kt
+++ b/app/src/main/java/app/opendocument/droid/background/ParcelUtil.kt
@@ -5,10 +5,9 @@ import android.os.Parcel
 /** Parcel.writeBoolean/readBoolean exist since API 29, which is above minSdk. */
 object ParcelUtil {
 
-    @JvmStatic
     fun writeBoolean(parcel: Parcel, value: Boolean) {
         parcel.writeInt(if (value) 1 else 0)
     }
 
-    @JvmStatic fun readBoolean(parcel: Parcel): Boolean = parcel.readInt() != 0
+    fun readBoolean(parcel: Parcel): Boolean = parcel.readInt() != 0
 }

--- a/app/src/main/java/app/opendocument/droid/background/RawLoader.kt
+++ b/app/src/main/java/app/opendocument/droid/background/RawLoader.kt
@@ -7,7 +7,6 @@ import android.util.Base64OutputStream
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
-import java.io.IOException
 import java.io.OutputStream
 
 /**
@@ -162,7 +161,6 @@ class RawLoader(
         }
     }
 
-    @Throws(IOException::class)
     private fun writeBase64(cacheFile: File, cacheDirectory: File, outputStream: OutputStream) {
         // need to store it in a separate file first because BaseStream writes characters on close
         val baseFile = File(cacheDirectory, "tmp")

--- a/app/src/main/java/app/opendocument/droid/background/RecentDocumentsUtil.kt
+++ b/app/src/main/java/app/opendocument/droid/background/RecentDocumentsUtil.kt
@@ -3,18 +3,12 @@ package app.opendocument.droid.background
 import android.content.Context
 import android.net.Uri
 import java.io.BufferedReader
-import java.io.IOException
 import java.io.InputStreamReader
 import java.io.OutputStreamWriter
 import java.nio.charset.StandardCharsets
 import org.json.JSONArray
-import org.json.JSONException
 import org.json.JSONObject
 
-/**
- * @JvmStatic and @Throws throughout, because the java callers still spell these as static calls and
- *   catch the checked exceptions they declare.
- */
 object RecentDocumentsUtil {
 
     private const val FILENAME = "recent_documents.json"
@@ -23,8 +17,6 @@ object RecentDocumentsUtil {
      * The recently opened documents, oldest first. Insertion ordered - a HashMap used to hand them
      * back in an arbitrary order, which made the "recent" list not actually ordered by recency.
      */
-    @JvmStatic
-    @Throws(IOException::class, JSONException::class)
     fun getRecentDocuments(context: Context): Map<String, String> {
         val result = LinkedHashMap<String, String>()
 
@@ -37,7 +29,6 @@ object RecentDocumentsUtil {
         return result
     }
 
-    @Throws(IOException::class, JSONException::class)
     private fun getRecentDocumentsJson(context: Context): JSONArray {
         context.openFileInput(FILENAME).use { input ->
             BufferedReader(InputStreamReader(input, StandardCharsets.UTF_8)).use { reader ->
@@ -46,8 +37,6 @@ object RecentDocumentsUtil {
         }
     }
 
-    @JvmStatic
-    @Throws(IOException::class, JSONException::class)
     fun addRecentDocument(context: Context, title: String?, uri: Uri) {
         if (title == null) {
             return
@@ -76,7 +65,6 @@ object RecentDocumentsUtil {
         saveJson(context, jsonArray)
     }
 
-    @Throws(IOException::class)
     private fun saveJson(context: Context, jsonArray: JSONArray) {
         context.openFileOutput(FILENAME, Context.MODE_PRIVATE).use { output ->
             OutputStreamWriter(output, StandardCharsets.UTF_8).use { writer ->
@@ -85,8 +73,6 @@ object RecentDocumentsUtil {
         }
     }
 
-    @JvmStatic
-    @Throws(IOException::class, JSONException::class)
     fun removeRecentDocument(context: Context, title: String?, uri: Uri) {
         if (title == null) {
             return
@@ -102,7 +88,6 @@ object RecentDocumentsUtil {
         saveJson(context, jsonArray)
     }
 
-    @Throws(JSONException::class)
     private fun findUriIndex(uriString: String, jsonArray: JSONArray): Int {
         var index = -1
         for (i in 0 until jsonArray.length()) {

--- a/app/src/main/java/app/opendocument/droid/background/StreamUtil.kt
+++ b/app/src/main/java/app/opendocument/droid/background/StreamUtil.kt
@@ -4,35 +4,25 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
-import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
 
-/** @JvmStatic throughout, because the java callers still spell these as static calls. */
 object StreamUtil {
 
     const val ENCODING: String = "UTF-8"
 
-    @JvmStatic
-    @Throws(IOException::class)
     fun copy(src: File, dst: File) {
         copy(FileInputStream(src), dst)
     }
 
-    @JvmStatic
-    @Throws(IOException::class)
     fun copy(src: File, out: OutputStream) {
         copy(FileInputStream(src), out)
     }
 
-    @JvmStatic
-    @Throws(IOException::class)
     fun copy(input: InputStream, dst: File) {
         FileOutputStream(dst).use { out -> copy(input, out) }
     }
 
-    @JvmStatic
-    @Throws(IOException::class)
     fun readFully(input: InputStream): String {
         val out = ByteArrayOutputStream()
         copy(input, out)
@@ -41,8 +31,6 @@ object StreamUtil {
     }
 
     /** Closes the input, never the output - the caller owns that one. */
-    @JvmStatic
-    @Throws(IOException::class)
     fun copy(input: InputStream, out: OutputStream) {
         input.use {
             it.copyTo(out)

--- a/app/src/main/java/app/opendocument/droid/nonfree/AnalyticsManager.kt
+++ b/app/src/main/java/app/opendocument/droid/nonfree/AnalyticsManager.kt
@@ -20,7 +20,6 @@ class AnalyticsManager {
         this.enabled = enabled
     }
 
-    @JvmOverloads
     fun report(
         event: String,
         key1: String? = null,

--- a/app/src/main/java/app/opendocument/droid/ui/SnackbarHelper.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/SnackbarHelper.kt
@@ -4,10 +4,8 @@ import android.app.Activity
 import android.view.View
 import com.google.android.material.snackbar.Snackbar
 
-/** @JvmStatic because the java callers still spell this as a static call. */
 object SnackbarHelper {
 
-    @JvmStatic
     fun show(
         activity: Activity,
         resId: Int,

--- a/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
@@ -70,15 +70,15 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
      * included - alive instead.
      */
     class DocumentViewModel : ViewModel() {
-        @JvmField var lastResult: FileLoader.Result? = null
-        @JvmField var currentHtmlDiff: String? = null
+        var lastResult: FileLoader.Result? = null
+        var currentHtmlDiff: String? = null
 
         // loads cannot be canceled once running, so results of abandoned loads
         // (e.g. user navigated back while the document was still loading) are
         // identified by their uri and dropped
-        @JvmField var lastRequestedUri: Uri? = null
+        var lastRequestedUri: Uri? = null
 
-        @JvmField var lastSelectedTab: Int = -1
+        var lastSelectedTab: Int = -1
     }
 
     private lateinit var state: DocumentViewModel
@@ -261,7 +261,6 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
         serviceQueue.addToQueue { service -> service.loadWithType(loaderType, options) }
     }
 
-    @JvmOverloads
     fun loadUri(uri: Uri, persistentUri: Boolean, editable: Boolean = false) {
         initializePageView()
 

--- a/app/src/release/java/app/opendocument/droid/ui/OpenFileIdling.kt
+++ b/app/src/release/java/app/opendocument/droid/ui/OpenFileIdling.kt
@@ -7,7 +7,7 @@ package app.opendocument.droid.ui
  */
 object OpenFileIdling {
 
-    @JvmStatic fun increment() {}
+    fun increment() {}
 
-    @JvmStatic fun decrement() {}
+    fun decrement() {}
 }


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

`com/commonsware/android/print` is the only java left, and it imports nothing but `android.*` and `java.*`. There is no java-to-kotlin call anywhere in the project anymore, so every `@JvmStatic`, `@JvmField`, `@JvmOverloads` and `@Throws` that existed to keep java call sites compiling is dead weight - along with the comments explaining them, which had become false rather than merely stale ("because the java callers still spell these as static calls").

### What stays

Three survive, because a runtime reflects over the bytecode rather than calling from java. Each now carries a comment saying which one and why, so the next cleanup does not take them:

- `@JvmField` on the two `CREATOR`s - the parcelable contract requires a static field
- `@JvmOverloads` on `ProgressDialogFragment`'s constructor - the fragment framework re-creates it through the no-arg constructor
- `@JvmStatic` on `@BeforeClass` / `@AfterClass` - junit requires those to be static

### Notes

Removing `@JvmField` from `FileLoader.Options` and `Result` turns the fields into ordinary properties; nothing changes for the kotlin call sites, which already read them as properties. `@Throws` only ever affected the generated `throws` clause - kotlin has no checked exceptions.

CLAUDE.md described the codebase as mixed java and kotlin and told you to reach for exactly these annotations when converting a class; it now describes what is actually left.

### Verification

`spotlessCheck`, `testProDebugUnitTest`, `lintProDebug`, `assembleProDebug`, `assembleProDebugAndroidTest` and a minified `assembleProRelease` pass locally with no compiler warnings.