### PR TITLE
Pin the ruby version the release workflow sets up

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,9 +85,14 @@ jobs:
         distribution: 'zulu'
         java-version: 21
 
+    # the version has to be spelled out here: setup-ruby only infers one from a
+    # .ruby-version / .tool-versions file, neither of which this repo has, and it
+    # does not read the `ruby ">= 3.2"` constraint in the Gemfile. 3.4 is what
+    # Gemfile.lock was resolved with.
     - name: setup ruby
       uses: ruby/setup-ruby@v1
       with:
+        ruby-version: '3.4'
         bundler-cache: true
 
     - name: setup python 3.12


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

The [first dispatch of the release workflow](https://github.com/opendocument-app/OpenDocument.droid/actions/runs/30216712737/job/89832094094) died in `setup ruby`:

```
Error: input ruby-version needs to be specified if no .ruby-version or .tool-versions file exists
```

`ruby/setup-ruby` only infers a version from a `.ruby-version` or `.tool-versions` file, and we have neither. The `ruby ">= 3.2"` line in the `Gemfile` is not something it reads. So spell the version out, matching the `RUBY VERSION` that `Gemfile.lock` was resolved with.

Note this only unblocks step 5 of 20 - nothing past `setup ruby` has ever run, so conan, the bundle build, the signing check and the Play upload are all still unproven. Worth dispatching with `dry_run: true` once this is on main, which builds and attaches the bundles but skips the upload.