### PR TITLE
Check the keystore before the release build, not after

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,43 @@ jobs:
     # .ruby-version / .tool-versions file, neither of which this repo has, and it
     # does not read the `ruby ">= 3.2"` constraint in the Gemfile. 3.4 is what
     # Gemfile.lock was resolved with.
+    # the keystore is decoded and checked up front, before the conan and gradle
+    # setup: signing is the very last thing the build does, so a bad password
+    # otherwise only surfaces as a signProReleaseBundle failure six minutes in
+    - name: decode keystore
+      run: echo "${{ secrets.ODR_KEYSTORE_BASE64 }}" | base64 -d > "${RUNNER_TEMP}/google_play.keystore"
+
+    # keytool reports the same two failures in a second, and tells them apart, which
+    # gradle does not: it wraps both in "Failed to read key <alias> from store". A
+    # -list only proves the store password, so the key passwords get their own check
+    # via -certreq, which needs the private key itself. Neither writes to the keystore.
+    - name: verify keystore
+      env:
+        keystore_password: ${{ secrets.ODR_KEYSTORE_PASSWORD }}
+        key_password_pro: ${{ secrets.ODR_KEY_PASSWORD_PRO }}
+        key_password_lite: ${{ secrets.ODR_KEY_PASSWORD_LITE }}
+      run: |
+        keystore="${RUNNER_TEMP}/google_play.keystore"
+        if ! keytool -list -keystore "$keystore" -storepass "$keystore_password" > /dev/null; then
+          echo "::error::ODR_KEYSTORE_PASSWORD does not open the keystore, or ODR_KEYSTORE_BASE64 did not decode to it. A trailing newline in either secret is enough to do this."
+          exit 1
+        fi
+        # an unset key password falls back to the store one, the same way
+        # app/build.gradle resolves it
+        verify_key() {
+          if ! keytool -certreq -alias "$1" -keystore "$keystore" \
+              -storepass "$keystore_password" -keypass "${2:-$keystore_password}" > /dev/null; then
+            echo "::error::the $1 key cannot be used - check its key password secret"
+            exit 1
+          fi
+        }
+        case "${{ env.flavor }}" in
+          pro)  verify_key reader-pro "$key_password_pro" ;;
+          lite) verify_key reader "$key_password_lite" ;;
+          *)    verify_key reader-pro "$key_password_pro"
+                verify_key reader "$key_password_lite" ;;
+        esac
+
     - name: setup ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -126,9 +163,6 @@ jobs:
 
     - name: Gradle cache
       uses: gradle/actions/setup-gradle@v4
-
-    - name: decode keystore
-      run: echo "${{ secrets.ODR_KEYSTORE_BASE64 }}" | base64 -d > "${RUNNER_TEMP}/google_play.keystore"
 
     - name: build bundles
       env:


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

The last release run failed in `:app:signProReleaseBundle` after six minutes:

```
KeytoolException: Failed to read key reader-pro from store ".../google_play.keystore":
  Keystore was tampered with, or password was incorrect
Caused by: java.io.IOException: Keystore was tampered with, or password was incorrect
Caused by: java.security.UnrecoverableKeyException: Password verification failed
```

Two things made that harder to act on than it should be.

**It fails last.** Signing happens after conan, the merge, and r8, so a secret that
does not match costs a full build before saying so.

**The message points at the wrong secret.** Gradle wraps every cause in `Failed to
read key <alias> from store`, but that chain is the JKS *store* password check, not
the key password for `reader-pro`. Against a throwaway JKS on the same jdk 21:

| what is wrong | what java throws |
|---|---|
| store password | `IOException: Keystore was tampered with…` → `UnrecoverableKeyException: Password verification failed` |
| key password | `UnrecoverableKeyException: Cannot recover key` |
| truncated file | `EOFException` |

So the run above was `ODR_KEYSTORE_PASSWORD`, and the alias in the message was a
red herring. (A trailing newline captured when setting the secret is enough to do
it — `gh secret set NAME < file` keeps one.)

This decodes the keystore right after the jdk is set up and checks it there:
`keytool -list` proves the store password, and `keytool -certreq` needs the private
key itself, so it proves each key password separately and reports which alias
failed. An unset key password falls back to the store password, the same way
`app/build.gradle` resolves it, and only the aliases for the flavors being built
are checked. Neither keytool invocation writes to the keystore — verified by
hashing it before and after.

Exercised locally against a two-alias JKS: happy path, wrong store password, wrong
key password, and an unset key password with both matching and not matching the
store one.

Note this does not fix the failing release — the secret still has to be re-set.
It makes the next wrong one obvious in a second instead of six minutes.