### PR TITLE
Stop releasing the persisted grant the recent list depends on

### DIFF
--- a/app/src/main/java/app/opendocument/droid/background/MetadataLoader.kt
+++ b/app/src/main/java/app/opendocument/droid/background/MetadataLoader.kt
@@ -129,7 +129,12 @@ class MetadataLoader(context: Context?) : FileLoader(context, LoaderType.METADAT
 
             if (options.persistentUri) {
                 try {
-                    RecentDocumentsUtil.addRecentDocument(context, filename, uri)
+                    val evicted = RecentDocumentsUtil.addRecentDocument(context, filename, uri)
+                    if (evicted.isNotEmpty()) {
+                        // hand the uri permissions of the documents that just fell off the end
+                        // of the list back, so we stay well below the per package grant limit
+                        PersistedUriPermissions.prune(context)
+                    }
                 } catch (e: IOException) {
                     crashManager.log(e)
                 }
@@ -142,7 +147,7 @@ class MetadataLoader(context: Context?) : FileLoader(context, LoaderType.METADAT
             val originalUri = options.originalUri
             if (originalUri != null) {
                 try {
-                    RecentDocumentsUtil.removeRecentDocument(context, options.filename, originalUri)
+                    RecentDocumentsUtil.removeRecentDocument(context, originalUri)
                 } catch (e1: Exception) {
                     crashManager.log(e1)
                 }

--- a/app/src/main/java/app/opendocument/droid/background/PersistedUriPermissions.kt
+++ b/app/src/main/java/app/opendocument/droid/background/PersistedUriPermissions.kt
@@ -1,0 +1,93 @@
+package app.opendocument.droid.background
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+
+/**
+ * The persisted uri permissions the app holds on to.
+ *
+ * A document picked through the storage access framework is only readable for as long as we hold a
+ * grant for it. Since the recently opened documents list hands those uris back on a later launch,
+ * the grants have to outlive the process - they are reclaimed by [prune] once nothing refers to
+ * them any more, rather than being released when the document is closed.
+ */
+object PersistedUriPermissions {
+
+    private const val READ_FLAG = Intent.FLAG_GRANT_READ_URI_PERMISSION
+
+    /**
+     * Takes a persistable read permission for [uri].
+     *
+     * @return whether a persisted grant is held afterwards. False for providers that do not offer
+     *   persistable permissions at all, and for uris that did not arrive on an intent of ours.
+     */
+    fun takeRead(context: Context, uri: Uri): Boolean {
+        return try {
+            context.contentResolver.takePersistableUriPermission(uri, READ_FLAG)
+
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    /**
+     * Whether [uri] is readable through a grant that survives a restart, either because it is
+     * persisted itself or because it sits below a directory tree we hold a grant for.
+     */
+    fun isRetained(context: Context, uri: Uri): Boolean {
+        val value = uri.toString()
+
+        for (permission in context.contentResolver.persistedUriPermissions) {
+            if (!permission.isReadPermission) {
+                continue
+            }
+
+            val held = permission.uri.toString()
+            if (held == value || value.startsWith("$held/")) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    /**
+     * Releases every persisted grant nothing refers to any more.
+     *
+     * Reconciling against the stored lists rather than releasing on eviction keeps this idempotent:
+     * a grant that is covered twice is not released twice, and grants leaked by earlier versions
+     * get mopped up on the next launch.
+     *
+     * Does file and binder work, so it must not run on the main thread.
+     */
+    fun prune(context: Context) {
+        val keep = HashSet<String>()
+        for (entry in RecentDocumentsUtil.getRecentDocuments(context)) {
+            keep.add(entry.uri)
+        }
+
+        for (permission in context.contentResolver.persistedUriPermissions) {
+            val held = permission.uri.toString()
+            if (held in keep) {
+                continue
+            }
+
+            var flags = 0
+            if (permission.isReadPermission) {
+                flags = flags or READ_FLAG
+            }
+            if (permission.isWritePermission) {
+                flags = flags or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+            }
+
+            try {
+                // releasing with flags we do not hold throws, hence taking them off the grant
+                context.contentResolver.releasePersistableUriPermission(permission.uri, flags)
+            } catch (e: Exception) {
+                // nothing to do about it, and it will be retried on the next launch
+            }
+        }
+    }
+}

--- a/app/src/main/java/app/opendocument/droid/background/RecentDocumentList.kt
+++ b/app/src/main/java/app/opendocument/droid/background/RecentDocumentList.kt
@@ -1,0 +1,55 @@
+package app.opendocument.droid.background
+
+/**
+ * The ordering, de-duplication and capping rules of the recently opened documents list.
+ *
+ * Deliberately free of Android dependencies so it can be covered by plain JVM unit tests; in
+ * production [RecentDocumentsUtil] adds the file and JSON handling around it.
+ */
+object RecentDocumentList {
+
+    /**
+     * How many documents to remember. Every entry holds a persisted uri permission, and those are
+     * capped per package (128 before android 11, 512 from it), so this cannot grow without bound.
+     */
+    const val MAX_ENTRIES: Int = 32
+
+    class Entry(val filename: String, val uri: String, val lastOpenedAt: Long) {
+
+        override fun equals(other: Any?): Boolean =
+            other is Entry &&
+                other.filename == filename &&
+                other.uri == uri &&
+                other.lastOpenedAt == lastOpenedAt
+
+        override fun hashCode(): Int =
+            filename.hashCode() * 31 * 31 + uri.hashCode() * 31 + lastOpenedAt.hashCode()
+
+        override fun toString(): String = "Entry($filename, $uri, $lastOpenedAt)"
+    }
+
+    /**
+     * The list after an [add], plus whatever fell off the end of it. The evicted entries are handed
+     * back so their persisted uri permissions can be released again.
+     */
+    class Update internal constructor(val entries: List<Entry>, val evicted: List<Entry>)
+
+    /**
+     * Puts [entry] at the front of [current], newest first. An entry for the same uri that is
+     * already in the list is replaced rather than duplicated, and anything past [max] is evicted.
+     */
+    fun add(current: List<Entry>, entry: Entry, max: Int = MAX_ENTRIES): Update {
+        val entries = ArrayList<Entry>(current.size + 1)
+        entries.add(entry)
+        current.filterTo(entries) { it.uri != entry.uri }
+
+        if (entries.size <= max) {
+            return Update(entries, emptyList())
+        }
+
+        return Update(entries.subList(0, max).toList(), entries.subList(max, entries.size).toList())
+    }
+
+    /** Drops every entry for [uri]. Returns [current] unchanged if there is none. */
+    fun remove(current: List<Entry>, uri: String): List<Entry> = current.filter { it.uri != uri }
+}

--- a/app/src/main/java/app/opendocument/droid/background/RecentDocumentsUtil.kt
+++ b/app/src/main/java/app/opendocument/droid/background/RecentDocumentsUtil.kt
@@ -9,93 +9,123 @@ import java.nio.charset.StandardCharsets
 import org.json.JSONArray
 import org.json.JSONObject
 
+/**
+ * Stores the recently opened documents in an app private json file.
+ *
+ * Only the file and json handling lives here - the ordering and capping rules are in
+ * [RecentDocumentList], which is android free and unit tested.
+ *
+ * Every method is synchronized: the loaders write from [LoaderService]'s background thread while
+ * the landing screen reads from its own executor.
+ */
 object RecentDocumentsUtil {
 
     private const val FILENAME = "recent_documents.json"
 
+    private const val KEY_URI = "uri"
+    private const val KEY_FILENAME = "filename"
+    private const val KEY_LAST_OPENED_AT = "lastOpenedAt"
+
     /**
-     * The recently opened documents, oldest first. Insertion ordered - a HashMap used to hand them
-     * back in an arbitrary order, which made the "recent" list not actually ordered by recency.
+     * The recently opened documents, newest first.
+     *
+     * Returns an empty list when nothing was ever saved, rather than making every caller catch the
+     * [java.io.FileNotFoundException] that reading a missing file throws.
      */
-    fun getRecentDocuments(context: Context): Map<String, String> {
-        val result = LinkedHashMap<String, String>()
+    @Synchronized
+    fun getRecentDocuments(context: Context): List<RecentDocumentList.Entry> = read(context)
 
-        val jsonArray = getRecentDocumentsJson(context)
-        for (i in 0 until jsonArray.length()) {
-            val document = jsonArray.getJSONObject(i)
-            result[document.getString("filename")] = document.getString("uri")
-        }
-
-        return result
-    }
-
-    private fun getRecentDocumentsJson(context: Context): JSONArray {
-        context.openFileInput(FILENAME).use { input ->
-            BufferedReader(InputStreamReader(input, StandardCharsets.UTF_8)).use { reader ->
-                return JSONArray(reader.readText())
-            }
-        }
-    }
-
-    fun addRecentDocument(context: Context, title: String?, uri: Uri) {
+    /**
+     * Records [uri] as the most recently opened document.
+     *
+     * @return the entries that fell out of the list, so [PersistedUriPermissions] can release the
+     *   uri permissions they were holding.
+     */
+    @Synchronized
+    fun addRecentDocument(
+        context: Context,
+        title: String?,
+        uri: Uri,
+    ): List<RecentDocumentList.Entry> {
         if (title == null) {
-            return
+            return emptyList()
         }
 
+        // documents copied into our own cache are reachable through the cache, not through the
+        // uri we were handed, so remembering them would hand back a uri that no longer resolves
         if (AndroidFileCache.isCached(context, uri)) {
-            return
+            return emptyList()
         }
 
-        val document = JSONObject()
-        document.put("uri", uri.toString())
-        document.put("filename", title)
+        val entry = RecentDocumentList.Entry(title, uri.toString(), System.currentTimeMillis())
+        val update = RecentDocumentList.add(read(context), entry)
 
-        var jsonArray: JSONArray
-        try {
-            jsonArray = getRecentDocumentsJson(context)
+        write(context, update.entries)
 
-            // avoid duplicates
-            removeRecentDocument(context, title, uri)
-        } catch (e: Exception) {
-            jsonArray = JSONArray()
-        }
-
-        jsonArray.put(document)
-
-        saveJson(context, jsonArray)
+        return update.evicted
     }
 
-    private fun saveJson(context: Context, jsonArray: JSONArray) {
+    /** Drops [uri] from the list. Does nothing if it is not in it. */
+    @Synchronized
+    fun removeRecentDocument(context: Context, uri: Uri) {
+        val current = read(context)
+        val remaining = RecentDocumentList.remove(current, uri.toString())
+
+        if (remaining.size != current.size) {
+            write(context, remaining)
+        }
+    }
+
+    private fun read(context: Context): List<RecentDocumentList.Entry> {
+        val jsonArray =
+            try {
+                context.openFileInput(FILENAME).use { input ->
+                    BufferedReader(InputStreamReader(input, StandardCharsets.UTF_8)).use { reader ->
+                        JSONArray(reader.readText())
+                    }
+                }
+            } catch (e: Exception) {
+                // nothing saved yet, or the file got truncated - either way there is no history
+                return emptyList()
+            }
+
+        val entries = ArrayList<RecentDocumentList.Entry>(jsonArray.length())
+        for (i in 0 until jsonArray.length()) {
+            val document = jsonArray.optJSONObject(i) ?: continue
+
+            val filename = document.optString(KEY_FILENAME, "")
+            val uri = document.optString(KEY_URI, "")
+            if (filename.isEmpty() || uri.isEmpty()) {
+                continue
+            }
+
+            entries.add(
+                RecentDocumentList.Entry(filename, uri, document.optLong(KEY_LAST_OPENED_AT, 0))
+            )
+        }
+
+        // the file stays in the append order older versions wrote it in, so that upgrading does
+        // not need a migration - the list is only turned around here, on the way out
+        entries.reverse()
+
+        return entries
+    }
+
+    private fun write(context: Context, entries: List<RecentDocumentList.Entry>) {
+        val jsonArray = JSONArray()
+        for (entry in entries.asReversed()) {
+            val document = JSONObject()
+            document.put(KEY_URI, entry.uri)
+            document.put(KEY_FILENAME, entry.filename)
+            document.put(KEY_LAST_OPENED_AT, entry.lastOpenedAt)
+
+            jsonArray.put(document)
+        }
+
         context.openFileOutput(FILENAME, Context.MODE_PRIVATE).use { output ->
             OutputStreamWriter(output, StandardCharsets.UTF_8).use { writer ->
                 writer.write(jsonArray.toString())
             }
         }
-    }
-
-    fun removeRecentDocument(context: Context, title: String?, uri: Uri) {
-        if (title == null) {
-            return
-        }
-
-        val jsonArray = getRecentDocumentsJson(context)
-        val deleteIndex = findUriIndex(uri.toString(), jsonArray)
-
-        if (deleteIndex >= 0) {
-            jsonArray.remove(deleteIndex)
-        }
-
-        saveJson(context, jsonArray)
-    }
-
-    private fun findUriIndex(uriString: String, jsonArray: JSONArray): Int {
-        var index = -1
-        for (i in 0 until jsonArray.length()) {
-            val document = jsonArray.getJSONObject(i)
-            if (uriString == document.getString("uri")) {
-                index = i
-            }
-        }
-        return index
     }
 }

--- a/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
@@ -35,6 +35,7 @@ import androidx.fragment.app.DialogFragment
 import app.opendocument.droid.R
 import app.opendocument.droid.background.LoaderService
 import app.opendocument.droid.background.LoaderServiceQueue
+import app.opendocument.droid.background.PersistedUriPermissions
 import app.opendocument.droid.background.PrintingManager
 import app.opendocument.droid.nonfree.AdManager
 import app.opendocument.droid.nonfree.AnalyticsConstants
@@ -204,6 +205,10 @@ class MainActivity : AppCompatActivity(), MenuProvider {
         initializeProprietaryLibraries()
 
         initializeCatchAllSwitch()
+
+        // reclaims the uri permissions of documents that have since dropped off the recently
+        // opened list. touches the filesystem and the permission binder, so not on the main thread
+        Thread { PersistedUriPermissions.prune(applicationContext) }.start()
 
         crashManager.log("onCreate")
 
@@ -470,27 +475,20 @@ class MainActivity : AppCompatActivity(), MenuProvider {
             uri.toString(),
         )
 
-        var isPersistentUri = false
-        try {
-            grantUriPermission(packageName, uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            contentResolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
-
-            isPersistentUri = true
-        } catch (e: Exception) {
-            // some providers don't support persisted permissions
-            crashManager.log(e)
-        }
+        // the grant has to outlive this call: loadUri only queues the load onto LoaderService,
+        // so MetadataLoader opens the stream long after we return. releasing it here - as this
+        // used to - also dropped the persisted grant, which left every uri in the recently
+        // opened list unreadable on the next launch. PersistedUriPermissions.prune() reclaims
+        // them instead, once nothing refers to them any more.
+        //
+        // takeRead fails for a document below a directory tree we were granted, because only a
+        // uri that arrived on one of our own intents can be persisted - isRetained covers those,
+        // so browsing to a document still records it as recent
+        val isPersistentUri =
+            PersistedUriPermissions.takeRead(this, uri) ||
+                PersistedUriPermissions.isRetained(this, uri)
 
         documentFragment.loadUri(uri, isPersistentUri)
-
-        try {
-            contentResolver.releasePersistableUriPermission(
-                uri,
-                Intent.FLAG_GRANT_READ_URI_PERMISSION,
-            )
-        } catch (e: Exception) {
-            crashManager.log(e)
-        }
     }
 
     override fun onMenuItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/java/app/opendocument/droid/ui/widget/RecentDocumentDialogFragment.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/widget/RecentDocumentDialogFragment.kt
@@ -62,10 +62,8 @@ class RecentDocumentDialogFragment :
 
     private fun loadRecentDocuments() {
         items.clear()
-        try {
-            items.putAll(RecentDocumentsUtil.getRecentDocuments(requireActivity()))
-        } catch (e: Exception) {
-            e.printStackTrace()
+        for (entry in RecentDocumentsUtil.getRecentDocuments(requireActivity())) {
+            items[entry.filename] = entry.uri
         }
 
         if (items.isEmpty()) {

--- a/app/src/test/java/app/opendocument/droid/background/RecentDocumentListTest.kt
+++ b/app/src/test/java/app/opendocument/droid/background/RecentDocumentListTest.kt
@@ -1,0 +1,100 @@
+package app.opendocument.droid.background
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RecentDocumentListTest {
+
+    @Test
+    fun addPutsTheDocumentFirst() {
+        val update = RecentDocumentList.add(listOf(entry("older")), entry("newer"))
+
+        assertEquals(listOf("newer", "older"), update.entries.map { it.uri })
+        assertTrue(update.evicted.isEmpty())
+    }
+
+    @Test
+    fun addToAnEmptyListYieldsTheOneDocument() {
+        val update = RecentDocumentList.add(emptyList(), entry("only"))
+
+        assertEquals(listOf("only"), update.entries.map { it.uri })
+    }
+
+    @Test
+    fun addMovesAKnownDocumentBackToTheFrontInsteadOfDuplicatingIt() {
+        val current = listOf(entry("c"), entry("b"), entry("a"))
+
+        val update = RecentDocumentList.add(current, entry("a"))
+
+        assertEquals(listOf("a", "c", "b"), update.entries.map { it.uri })
+        assertTrue(update.evicted.isEmpty())
+    }
+
+    @Test
+    fun addKeepsTheNewestMetadataOfAKnownDocument() {
+        val current = listOf(RecentDocumentList.Entry("old name", "a", 1))
+
+        val update = RecentDocumentList.add(current, RecentDocumentList.Entry("new name", "a", 2))
+
+        assertEquals(1, update.entries.size)
+        assertEquals("new name", update.entries[0].filename)
+        assertEquals(2, update.entries[0].lastOpenedAt)
+    }
+
+    @Test
+    fun addDropsTheOldestDocumentOnceTheListIsFull() {
+        // newest first, so uri3 is the one that has been sitting there longest
+        val current = (1..3).map { entry("uri$it") }
+
+        val update = RecentDocumentList.add(current, entry("newest"), max = 3)
+
+        assertEquals(listOf("newest", "uri1", "uri2"), update.entries.map { it.uri })
+        assertEquals(listOf("uri3"), update.evicted.map { it.uri })
+    }
+
+    @Test
+    fun addEvictsEverythingPastTheCap() {
+        val current = (1..10).map { entry("uri$it") }
+
+        val update = RecentDocumentList.add(current, entry("newest"), max = 4)
+
+        assertEquals(4, update.entries.size)
+        assertEquals(7, update.evicted.size)
+        assertEquals(
+            listOf("uri4", "uri5", "uri6", "uri7", "uri8", "uri9", "uri10"),
+            update.evicted.map { it.uri },
+        )
+    }
+
+    @Test
+    fun reAddingAKnownDocumentToAFullListEvictsNothing() {
+        val current = (1..3).map { entry("uri$it") }
+
+        val update = RecentDocumentList.add(current, entry("uri3"), max = 3)
+
+        assertEquals(listOf("uri3", "uri1", "uri2"), update.entries.map { it.uri })
+        assertTrue(update.evicted.isEmpty())
+    }
+
+    @Test
+    fun removeDropsEveryEntryForTheUri() {
+        val current = listOf(entry("a"), entry("b"), entry("a"))
+
+        assertEquals(listOf("b"), RecentDocumentList.remove(current, "a").map { it.uri })
+    }
+
+    @Test
+    fun removeLeavesAnUnknownUriAlone() {
+        val current = listOf(entry("a"), entry("b"))
+
+        assertEquals(listOf("a", "b"), RecentDocumentList.remove(current, "c").map { it.uri })
+    }
+
+    @Test
+    fun removeFromAnEmptyListYieldsAnEmptyList() {
+        assertTrue(RecentDocumentList.remove(emptyList(), "a").isEmpty())
+    }
+
+    private fun entry(uri: String) = RecentDocumentList.Entry("name of $uri", uri, 0)
+}


### PR DESCRIPTION
First of six, stacked. Base: `main`.

`loadUri` took a persistable uri permission and released it four lines later — before the load it had just queued onto `LoaderService` had run. Every uri written to the recently opened list was therefore unreadable on the next launch, so the one place that surfaced them handed back documents that would not open.

Grants are now reclaimed by reconciling what we hold against the recent list, instead of being released on close. Idempotent, no per-removal bookkeeping, and it mops up grants earlier versions leaked.

`addRecentDocument`'s de-duplication was also a no-op: it read the json, called `removeRecentDocument` (which re-read, removed and saved), then wrote back the stale pre-removal array. Duplicates accumulated without bound.

Ordering, de-duplication and capping move into `RecentDocumentList`, free of android imports so plain JVM tests can cover them — the `MimeTypeResolver` pattern.

### Verification
- `testProDebugUnitTest` — 10 new cases over the logic the bug lived in
- `connectedProDebugAndroidTest` green
- On device: opened a document from Drive, force-stopped, relaunched, re-opened it from the list. That is the case that was broken.

The end-to-end fix is not assertable in the current harness — test fixtures come from the app's own `FileProvider`, which cannot grant persistable permissions.