### PR TITLE
Open the system picker directly

### DIFF
--- a/app/src/androidTest/java/app/opendocument/droid/test/LandingTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/LandingTests.kt
@@ -3,6 +3,8 @@
 
 package app.opendocument.droid.test
 
+import android.app.Activity
+import android.app.Instrumentation
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -12,6 +14,7 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
@@ -71,6 +74,30 @@ class LandingTests {
     }
 
     @Test
+    fun emptyStateOpensTheSystemPicker() {
+        stubOpenDocumentCancelled()
+
+        launch()
+
+        onView(withId(R.id.landing_empty_open)).perform(click())
+
+        Intents.intended(hasAction(Intent.ACTION_OPEN_DOCUMENT))
+    }
+
+    @Test
+    fun theFabOpensTheSystemPicker() {
+        // the fab is hidden behind the empty state, which offers the same thing with a label
+        seedRecentDocument()
+        stubOpenDocumentCancelled()
+
+        launch()
+
+        onView(withId(R.id.landing_open_fab)).perform(click())
+
+        Intents.intended(hasAction(Intent.ACTION_OPEN_DOCUMENT))
+    }
+
+    @Test
     fun aRecentDocumentIsListed() {
         seedRecentDocument()
 
@@ -113,6 +140,15 @@ class LandingTests {
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
 
         return activity
+    }
+
+    /**
+     * The picker is stubbed as cancelled: these tests are about what the landing screen asks for,
+     * not about loading a document.
+     */
+    private fun stubOpenDocumentCancelled() {
+        Intents.intending(hasAction(Intent.ACTION_OPEN_DOCUMENT))
+            .respondWith(Instrumentation.ActivityResult(Activity.RESULT_CANCELED, null))
     }
 
     private fun seedRecentDocument() {

--- a/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
@@ -48,7 +48,6 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import org.hamcrest.Matchers.allOf
-import org.hamcrest.Matchers.anyOf
 import org.hamcrest.Matchers.equalTo
 import org.junit.After
 import org.junit.AfterClass
@@ -254,21 +253,13 @@ class MainActivityTests {
             )
     }
 
+    // the toolbar action now launches ACTION_OPEN_DOCUMENT directly, which the test stubs out.
+    // it used to raise a chooser of our own that a file manager had to be picked from first.
     private fun openDocumentThroughPicker() {
         onView(
                 allOf(
                     withId(R.id.menu_open),
                     withContentDescription("Open document"),
-                    isDisplayed(),
-                )
-            )
-            .perform(click())
-
-        // The menu item could be either Documents or Files.
-        onView(
-                allOf(
-                    withId(android.R.id.text1),
-                    anyOf(withText("Documents"), withText("Files")),
                     isDisplayed(),
                 )
             )

--- a/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
@@ -5,7 +5,6 @@ import android.content.ActivityNotFoundException
 import android.content.ComponentName
 import android.content.Intent
 import android.content.ServiceConnection
-import android.content.pm.ResolveInfo
 import android.content.res.Configuration
 import android.net.Uri
 import android.os.Bundle
@@ -20,7 +19,6 @@ import android.view.View
 import android.widget.LinearLayout
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
@@ -641,51 +639,33 @@ class MainActivity : AppCompatActivity(), MenuProvider {
         intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION)
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
 
-        val packageManager = packageManager
-        val targetList: List<ResolveInfo> =
-            packageManager.queryIntentActivities(intent, 0).filter { target ->
-                target.activityInfo.packageName == packageName || target.activityInfo.exported
-            }
+        // straight to the system picker. this used to put an "Open document via:" dialog of our
+        // own in front of it, listing every app that answers ACTION_OPEN_DOCUMENT - an extra tap
+        // that duplicated what the picker itself already offers, since it can browse Drive,
+        // Downloads, a usb stick and every installed file manager on its own.
+        try {
+            OpenFileIdling.increment()
 
-        // the recently opened documents used to be the last row here; they are the landing
-        // screen itself now
-        val targetNames = targetList.map { it.loadLabel(packageManager).toString() }.toTypedArray()
+            openDocumentLauncher.launch(intent)
+        } catch (e: ActivityNotFoundException) {
+            OpenFileIdling.decrement()
 
-        val builder = AlertDialog.Builder(this)
-        builder.setTitle(R.string.dialog_choose_filemanager)
-        builder.setItems(targetNames) { dialog, which ->
-            val target = targetList[which]
+            crashManager.log(e)
 
-            intent.component =
-                ComponentName(target.activityInfo.packageName, target.activityInfo.name)
-
-            try {
-                OpenFileIdling.increment()
-
-                openDocumentLauncher.launch(intent)
-            } catch (e: Exception) {
-                OpenFileIdling.decrement()
-
-                crashManager.log(e)
-
-                SnackbarHelper.show(
-                    this,
-                    R.string.crouton_error_open_app,
-                    { findDocument() },
-                    true,
-                    true,
-                )
-            }
-
-            analyticsManager.report(
-                AnalyticsConstants.EVENT_SELECT_CONTENT,
-                AnalyticsConstants.PARAM_CONTENT_TYPE,
-                target.activityInfo.packageName,
+            SnackbarHelper.show(
+                this,
+                R.string.crouton_error_open_app,
+                { findDocument() },
+                true,
+                true,
             )
-
-            dialog.dismiss()
         }
-        builder.show()
+
+        analyticsManager.report(
+            AnalyticsConstants.EVENT_SELECT_CONTENT,
+            AnalyticsConstants.PARAM_CONTENT_TYPE,
+            "picker",
+        )
     }
 
     override fun onPause() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,15 +11,11 @@
     <string name="toast_error_save_failed">File could not be saved. Please contact support@opendocument.app</string>
     <string name="toast_error_out_of_memory">Device out of memory! Too many pictures, or file too big.</string>
     <string name="toast_error_password_protected">This document is password-protected</string>
-    <string name="dialog_recent_title">Recent documents</string>
-    <string name="dialog_choose_filemanager">Open document via:</string>
     <string name="dialog_loading_title">Loading…</string>
     <string name="dialog_uploading_title">Uploading…</string>
     <string name="dialog_generic_loading_message">Please wait, this could take a few minutes.</string>
     <string name="dialog_uploading_message_appendix">Uploaded files are private and automatically deleted after 24 hours.</string>
     <string name="dialog_upload_file">We aren\'t able to open this document, because we don\'t support its format. Do you want to upload it to our server temporarily, so we can display it for you anyway? Uploaded files are private and automatically deleted after 24 hours.</string>
-    <string name="dialog_list_no_documents_found">No documents found</string>
-    <string name="menu_recent">Recently opened documents</string>
     <string name="menu_search">Search in document</string>
     <string name="menu_open">Open document</string>
     <string name="menu_open_with">Open with...</string>


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fourth of six, stacked. Base: `landing/03-recents-list` (#525). Small and isolated.

`findDocument` queried every activity answering `ACTION_OPEN_DOCUMENT` and raised an "Open document via:" dialog to choose between them — before launching the picker it was going to launch anyway. That tap buys nothing: the system picker already browses Drive, Downloads, a usb stick and every installed file manager, and it is the UI people know.

Its last row used to be the recently opened documents, which is the landing screen itself as of the previous PR, so the dialog has nothing of its own left.

**The `<queries>` entries stay.** They were there for `queryIntentActivities`, but removing package visibility is exactly the kind of change that breaks on one OEM and nowhere else.

`MainActivityTests` drove the picker through that dialog, so it loses the step. The intent stubbing is untouched — Espresso-Intents intercepts at `execStartActivity`, below `ActivityResultLauncher`, so it still matches with the component unset.

### Verification
18 instrumented tests green, including `testODT`, `testPDF` and `testPasswordProtectedODT`, which all go through the changed helper.