### PR TITLE
Drop the open action from the toolbar

### DIFF
--- a/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
@@ -10,6 +10,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.SystemClock
 import android.util.Log
+import android.view.View
 import androidx.core.content.FileProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.IdlingRegistry
@@ -48,6 +49,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.anyOf
 import org.hamcrest.Matchers.equalTo
 import org.junit.After
 import org.junit.AfterClass
@@ -253,13 +255,14 @@ class MainActivityTests {
             )
     }
 
-    // the toolbar action now launches ACTION_OPEN_DOCUMENT directly, which the test stubs out.
-    // it used to raise a chooser of our own that a file manager had to be picked from first.
+    // the landing screen is the only thing offering to open a document now that the toolbar
+    // action is gone. exactly one of its two entry points is on screen - the fab is hidden
+    // while the empty state is up - and which one depends on whether an earlier test already
+    // left a document in the recent list, so match either.
     private fun openDocumentThroughPicker() {
         onView(
                 allOf(
-                    withId(R.id.menu_open),
-                    withContentDescription("Open document"),
+                    anyOf<View>(withId(R.id.landing_open_fab), withId(R.id.landing_empty_open)),
                     isDisplayed(),
                 )
             )

--- a/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
@@ -452,17 +452,6 @@ class MainActivity : AppCompatActivity(), MenuProvider {
                 analyticsManager.report(AnalyticsConstants.EVENT_SEARCH)
             }
 
-            R.id.menu_open -> {
-                findDocument()
-
-                analyticsManager.report("menu_open")
-                analyticsManager.report(
-                    AnalyticsConstants.EVENT_SELECT_CONTENT,
-                    AnalyticsConstants.PARAM_CONTENT_TYPE,
-                    "choose",
-                )
-            }
-
             R.id.menu_open_with -> {
                 documentFragment?.openWith(this)
 

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -4,13 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <item
-        android:id="@+id/menu_open"
-        android:icon="@drawable/ic_folder_open"
-        android:title="@string/menu_open"
-        app:showAsAction="always"
-        tools:ignore="AlwaysShowAction" />
-
-    <item
         android:id="@+id/menu_edit"
         android:icon="@drawable/ic_edit"
         android:title="@string/menu_edit"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,7 +17,6 @@
     <string name="dialog_uploading_message_appendix">Uploaded files are private and automatically deleted after 24 hours.</string>
     <string name="dialog_upload_file">We aren\'t able to open this document, because we don\'t support its format. Do you want to upload it to our server temporarily, so we can display it for you anyway? Uploaded files are private and automatically deleted after 24 hours.</string>
     <string name="menu_search">Search in document</string>
-    <string name="menu_open">Open document</string>
     <string name="menu_open_with">Open with...</string>
     <string name="menu_share">Share document</string>
     <string name="menu_edit">Edit document</string>


### PR DESCRIPTION
Stacked on #528.

The landing screen already offers to open a document twice - the fab, and the labelled button in the empty state - and both go straight to the system picker since the chooser dialog went away. The toolbar icon was a third copy of the same intent, in the one place where it is least explained: an unlabelled folder glyph next to the title.

Inside a document it was the odd one out too. Every other toolbar action acts on the document that is open; this one threw it away and started over, which is what back already does, and back lands on the list where the next document gets picked anyway.

The instrumented tests reached the picker through that icon, so they now click whichever landing entry point is on screen - which of the two it is depends on whether an earlier test already left something in the recent list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)