### PR TITLE
Fix the release workflow's play store upload, conan cache key and debug symbols step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
       run: sudo apt-get install -y ninja-build
 
     - name: setup java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: 'zulu'
         java-version: 21
@@ -133,7 +133,7 @@ jobs:
         bundler-cache: true
 
     - name: setup python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: 3.12
     - name: install python dependencies
@@ -149,12 +149,18 @@ jobs:
       run: git submodule update --init --depth 1 conan-odr-index
 
     # same cache the build workflow populates, so a release does not have to
-    # rebuild odrcore from source
+    # rebuild odrcore from source. the key has to be spelled the same way
+    # build_test spells it, or only the restore-keys prefix can ever match and
+    # the index revision stops being part of what is looked up
+    - name: conan cache key
+      id: conan-cache-key
+      run: echo "key=conan2-${{ runner.os }}-ndk${{ env.ndk_version }}-index$(git rev-parse HEAD:conan-odr-index)-${{ hashFiles('app/conanfile.txt', 'app/conanprofile.txt') }}" >> "$GITHUB_OUTPUT"
+
     - name: conan cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v6
       with:
         path: ~/.conan2/p
-        key: conan2-${{ runner.os }}-ndk${{ env.ndk_version }}-index${{ hashFiles('.git/modules/conan-odr-index/HEAD') }}-${{ hashFiles('app/conanfile.txt', 'app/conanprofile.txt') }}
+        key: ${{ steps.conan-cache-key.outputs.key }}
         restore-keys: |
           conan2-${{ runner.os }}-ndk${{ env.ndk_version }}-
 
@@ -192,23 +198,25 @@ jobs:
           fi
         done
 
+    # ndk.debugSymbolLevel puts the symbols inside the bundle itself, under
+    # BUNDLE-METADATA/com.android.tools.build.debugsymbols, so the play store
+    # gets them from the upload and anyone who needs them can unzip the aab
+    # archived here. build/outputs/native-debug-symbols is only written on the
+    # apk path, by mergeNativeDebugMetadata, which a bundle build never runs
     - name: Artifact bundles
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: bundles
         path: app/build/outputs/bundle/*/*.aab
         if-no-files-found: error
 
-    - name: Artifact native debug symbols
-      uses: actions/upload-artifact@v4
-      with:
-        name: native-debug-symbols
-        path: app/build/outputs/native-debug-symbols/*/*.zip
-        if-no-files-found: warn
-
+    # via the environment rather than inline, so that a quote in the secret
+    # cannot end up as part of the script
     - name: play store credentials
       if: ${{ inputs.dry_run != true }}
-      run: echo '${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT }}' > fastlane_google_play.json
+      env:
+        service_account: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT }}
+      run: printf '%s' "$service_account" > fastlane_google_play.json
 
     - name: upload to play store
       if: ${{ inputs.dry_run != true }}

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ app/lite/release/
 .cxx/
 
 fastlane/report.xml
+fastlane_google_play.json
 
 .idea/
 

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,2 +1,2 @@
-json_key_file("../fastlane_google_play.json") # Path to the json secret file - Follow https://docs.fastlane.tools/actions/supply/#setup to get one
+json_key_file("fastlane_google_play.json") # Path to the json secret file, relative to the repository root - Follow https://docs.fastlane.tools/actions/supply/#setup to get one
 package_name("at.tomtasche.reader") # e.g. com.krausefx.app


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

The [first release run that actually reached the upload step](https://github.com/opendocument-app/OpenDocument.droid/actions/runs/30242540356/job/89902597956) failed, and going through the rest of the workflow turned up three more things. All four are below; the first is the one that broke the run.

## The service account key was looked for one directory too high

```
Could not find service account json file at path
'/home/runner/work/OpenDocument.droid/fastlane_google_play.json'
[!] Invalid default value for json_key, doesn't match verify_block
```

`release.yml` writes the key into the checkout root, `/home/runner/work/OpenDocument.droid/OpenDocument.droid/`, while the `Appfile` asked for `../fastlane_google_play.json`. Fastlane resolves that relative to the directory containing `fastlane/`, so `../` landed in the workspace parent. `supply` validates `json_key` while parsing options, so the lane died before uploading anything and `uploadLite` never ran.

The `../` prefix is a leftover from the original `add fastlane` commit, back when fastlane ran with `fastlane/` as its working directory. Nothing caught it because the only green release run so far was a dry run, where the credentials and upload steps are both skipped.

The key file is gitignored now too, since its documented location moved from above the repository to inside it.

## The conan cache key was spelled differently than the one build_test writes

`build_test` builds the key from `git rev-parse HEAD:conan-odr-index`; `release` hashed `.git/modules/conan-odr-index/HEAD` instead. Both vary with the submodule revision, but they never produce the same string, so the exact key could not match and the release always fell through to the `restore-keys` prefix - which hands back the newest cache carrying that prefix no matter which index revision built it. That is exactly the discrimination the index component is in the key for.

The run shows both halves:

```
key: conan2-Linux-ndk28.2.13676358-index41ba6d81babbd8828667e8c3017d24ff744fc7b121f0e25166403ec77f48a9bb-c78aff...
Cache restored from key: conan2-Linux-ndk28.2.13676358-indexa7930869a669efa17ef23cba28c2756418be0ee6-c78aff...
```

64 hex characters of `hashFiles` output against the 40 of the submodule sha. `release` now computes the key the same way `build_test` does. The cache keys in `build_test` itself are consistent between its build and test jobs - the test job restores by `needs.build.outputs.conan-cache-key` - and needed no change.

## The native debug symbols artifact could never find anything

```
No files were found with the provided path: app/build/outputs/native-debug-symbols/*/*.zip
```

Not a missing configuration: `ndk.debugSymbolLevel = "full"` packs the symbols into the bundle itself. From the aab that run produced:

```
BUNDLE-METADATA/com.android.tools.build.debugsymbols/arm64-v8a/libodr_jni.so.dbg
BUNDLE-METADATA/com.android.tools.build.debugsymbols/armeabi-v7a/libodr_jni.so.dbg
...
```

That is how the play store receives them. `build/outputs/native-debug-symbols` is written by `mergeNativeDebugMetadata` on the apk path, which a bundle build never runs - the log only has `extractProReleaseNativeDebugMetadata`, which feeds the bundle. So the step was permanent warning noise, and anyone who wants the symbols can unzip the archived aab. Removed, with a comment saying where they went.

## Smaller things

The service account json is passed through the environment instead of being interpolated into the script, and the action versions now match what `build_test` already uses (`setup-java@v5`, `setup-python@v7`, `upload-artifact@v7`, `cache/restore@v6`).

Left alone deliberately: `actions/checkout@v4` is Node-20 deprecated but is on v4 in all three workflows, so bumping it belongs in its own change; and with `flavor: both` a failing `uploadLite` still leaves `uploadPro` published, which is the same behaviour the manual lanes always had.