### PR TITLE
Build the pro apk and attach it to the github release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ name: release
 # only machine holding the keystore. This does the same steps in CI:
 #   1. build the signed app bundles with gradle
 #   2. hand them to fastlane, which uploads them to the play store
+#   3. on a tag, attach the signed pro apk to the github release, which every
+#      release up to v4.6 carried and which the laptop build produced by hand
 #
 # Requires these repository secrets (see the "Release signing" section in the
 # README for what they mean):
@@ -43,7 +45,8 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read
+  # to attach the apk to the github release of a tag
+  contents: write
 
 env:
   ndk_version: 28.2.13676358
@@ -170,7 +173,10 @@ jobs:
     - name: Gradle cache
       uses: gradle/actions/setup-gradle@v4
 
-    - name: build bundles
+    # the apk is the sideloadable copy that goes onto the github release. only
+    # pro has ever been published that way - lite is the ad supported play
+    # build, and an apk of it outside the store has no audience
+    - name: build bundles and the pro apk
       env:
         ODR_KEYSTORE: ${{ runner.temp }}/google_play.keystore
         ODR_KEYSTORE_PASSWORD: ${{ secrets.ODR_KEYSTORE_PASSWORD }}
@@ -179,15 +185,16 @@ jobs:
       run: |
         tasks=""
         case "${{ env.flavor }}" in
-          pro)  tasks="bundleProRelease" ;;
+          pro)  tasks="bundleProRelease assembleProRelease" ;;
           lite) tasks="bundleLiteRelease" ;;
-          *)    tasks="bundleProRelease bundleLiteRelease" ;;
+          *)    tasks="bundleProRelease bundleLiteRelease assembleProRelease" ;;
         esac
         ./gradlew $tasks --stacktrace
 
     # a release that silently produced an unsigned bundle would be rejected by
-    # the play store with a much less obvious error
-    - name: verify bundles are signed
+    # the play store with a much less obvious error, and an unsigned apk on the
+    # release page would not install at all
+    - name: verify bundles and the apk are signed
       run: |
         for aab in app/build/outputs/bundle/*/*.aab; do
           if unzip -l "$aab" | grep -qE " META-INF/[^/]+\.(RSA|DSA)$"; then
@@ -197,6 +204,22 @@ jobs:
             exit 1
           fi
         done
+        # the apk takes apksigner rather than the same grep: from minSdk 24 up
+        # agp leaves v1 signing off, so there is no META-INF/*.RSA to find and
+        # the signature sits in a block the zip listing does not show
+        apk=app/build/outputs/apk/pro/release/app-pro-release.apk
+        if [ -e "$apk" ]; then
+          apksigner=$(ls -1 "${ANDROID_HOME}"/build-tools/*/apksigner 2>/dev/null | sort -V | tail -1)
+          if [ -z "$apksigner" ]; then
+            echo "::error::found no apksigner under ${ANDROID_HOME}/build-tools"
+            exit 1
+          fi
+          if ! "$apksigner" verify "$apk" > /dev/null; then
+            echo "::error::$apk is not signed"
+            exit 1
+          fi
+          echo "signed: $apk"
+        fi
 
     # ndk.debugSymbolLevel puts the symbols inside the bundle itself, under
     # BUNDLE-METADATA/com.android.tools.build.debugsymbols, so the play store
@@ -209,6 +232,17 @@ jobs:
         name: bundles
         path: app/build/outputs/bundle/*/*.aab
         if-no-files-found: error
+
+    # also as a workflow artifact, not just on the release: a dispatched run has
+    # no tag to attach anything to, and that is how a release gets test flown
+    - name: Artifact apk
+      if: ${{ env.flavor != 'lite' }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: apk
+        path: app/build/outputs/apk/pro/release/app-pro-release.apk
+        if-no-files-found: error
+        compression-level: 0
 
     # via the environment rather than inline, so that a quote in the secret
     # cannot end up as part of the script
@@ -229,6 +263,22 @@ jobs:
         for lane in $lanes; do
           bundle exec fastlane android "$lane" track:"${{ env.track }}"
         done
+
+    # after the upload, so the release page never offers an apk for a version
+    # that never reached play. a tag push arrives before the release object is
+    # cut more often than not, so create it when it is not there yet
+    - name: attach the apk to the github release
+      if: ${{ github.ref_type == 'tag' && env.flavor != 'lite' && inputs.dry_run != true }}
+      env:
+        GH_TOKEN: ${{ github.token }}
+        tag: ${{ github.ref_name }}
+      run: |
+        apk=app/build/outputs/apk/pro/release/app-pro-release.apk
+        if gh release view "$tag" > /dev/null 2>&1; then
+          gh release upload "$tag" "$apk" --clobber
+        else
+          gh release create "$tag" "$apk" --generate-notes
+        fi
 
     - name: drop credentials
       if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,9 @@ name: release
 # only machine holding the keystore. This does the same steps in CI:
 #   1. build the signed app bundles with gradle
 #   2. hand them to fastlane, which uploads them to the play store
-#   3. on a tag, attach the signed pro apk to the github release, which every
-#      release up to v4.6 carried and which the laptop build produced by hand
+#   3. on a tag, attach the signed pro apk to that tag's github release, which
+#      every release up to v4.6 carried and the laptop build produced by hand.
+#      the release has to exist already
 #
 # Requires these repository secrets (see the "Release signing" section in the
 # README for what they mean):
@@ -265,8 +266,8 @@ jobs:
         done
 
     # after the upload, so the release page never offers an apk for a version
-    # that never reached play. a tag push arrives before the release object is
-    # cut more often than not, so create it when it is not there yet
+    # that never reached play. the release itself stays a human decision - this
+    # only fills in its apk, and says so rather than inventing one
     - name: attach the apk to the github release
       if: ${{ github.ref_type == 'tag' && env.flavor != 'lite' && inputs.dry_run != true }}
       env:
@@ -274,11 +275,11 @@ jobs:
         tag: ${{ github.ref_name }}
       run: |
         apk=app/build/outputs/apk/pro/release/app-pro-release.apk
-        if gh release view "$tag" > /dev/null 2>&1; then
-          gh release upload "$tag" "$apk" --clobber
-        else
-          gh release create "$tag" "$apk" --generate-notes
+        if ! gh release view "$tag" > /dev/null 2>&1; then
+          echo "::error::$tag has no github release to attach $apk to. create it, then re-run this job or upload the apk artifact by hand."
+          exit 1
         fi
+        gh release upload "$tag" "$apk" --clobber
 
     - name: drop credentials
       if: always()

--- a/README.md
+++ b/README.md
@@ -49,8 +49,11 @@ Without them `bundleProRelease` and friends still build, just unsigned.
 
 Pushing a `v*` tag runs the `release` workflow, which builds both signed bundles and
 uploads them to the Play Store internal track - the same thing the fastlane lanes did
-from a laptop. Running the workflow manually additionally allows picking the flavor,
-the track, and a dry run that builds and attaches the bundles without uploading.
+from a laptop. It also builds the signed Pro APK and attaches it to the GitHub release
+of that tag, creating the release if the tag has none yet; that APK is the sideloadable
+copy every release up to v4.6 carried. Running the workflow manually additionally allows
+picking the flavor, the track, and a dry run that builds and attaches the bundles and
+the APK as workflow artifacts without uploading or touching a release.
 
 It needs these repository secrets:
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Without them `bundleProRelease` and friends still build, just unsigned.
 Pushing a `v*` tag runs the `release` workflow, which builds both signed bundles and
 uploads them to the Play Store internal track - the same thing the fastlane lanes did
 from a laptop. It also builds the signed Pro APK and attaches it to the GitHub release
-of that tag, creating the release if the tag has none yet; that APK is the sideloadable
-copy every release up to v4.6 carried. Running the workflow manually additionally allows
+of that tag, which has to exist already - the workflow does not create one, it fails
+instead. That APK is the sideloadable copy every release up to v4.6 carried. Running the workflow manually additionally allows
 picking the flavor, the track, and a dry run that builds and attaches the bundles and
 the APK as workflow artifacts without uploading or touching a release.
 


### PR DESCRIPTION
Every release up to and including v4.6 carries a signed Pro APK, uploaded by hand back when releases were built on a maintainer laptop:

```
v4.6:    app-pro-release.apk  91MB
v4.3.1:  app-pro-release.apk  92MB
v4.3:    app-pro-release.apk  92MB
v4.2:    app-pro-release.apk  92MB
v4.1:    app-pro-release.apk  98MB
```

The workflow that took the laptop's job over builds bundles only, so from the next tag onward that asset would quietly stop appearing. An `.aab` does not fill the gap - it is not installable without `bundletool`.

## What this does

`assembleProRelease` now runs alongside the bundles. R8 already runs for the bundle and both packaging paths consume its output, so the added cost is packaging, zipalign and signing. The APK is signed by `signingConfigs.releasePro`, exactly like the ones on the older releases.

On a tag push it goes onto the GitHub release for that tag. That release has to exist already: cutting one stays a human decision, so a tag without a release fails the step with a message saying what to do rather than getting a generated stub. The upload `--clobber`s an existing asset, runs after the Play upload so the release page never offers an APK for a version that did not reach Play, and is skipped on a dry run. That is what `contents: write` is for.

The APK is also uploaded as a workflow artifact, because a dispatched run has no tag to attach anything to and that is how a release candidate gets test flown.

Pro only, as it has always been. Lite is the ad supported Play build, and an APK of it outside the store has no audience.

## Signing check

The bundles are checked by grepping the zip listing for `META-INF/*.RSA`. That does not carry over to the APK: from minSdk 24 up AGP leaves v1 signing off, so there is nothing under `META-INF` to find and the signature lives in a block the listing does not show. The APK is verified with `apksigner` from the newest installed build-tools instead.

## Note

`assemble` also runs `mergeNativeDebugMetadata`, so `build/outputs/native-debug-symbols/` gets populated on this path - the directory #532 removed a step for. It stays unpublished: those are the same symbols the aab already carries into Play, and the aab is archived on the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A88vehGiVrPQDmr59Ppkio
