### PR TITLE
Fix the flaky instrumented tests, and the app bug hiding behind one of them

### DIFF
--- a/.github/scripts/reap-crashpad.sh
+++ b/.github/scripts/reap-crashpad.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Kills the emulator's crash reporter once the emulator it belonged to is gone.
+#
+# crashpad_handler inherits the stdout of the step that started the emulator, and
+# a step cannot finish while anything still holds that pipe open. On api 26 and 29
+# the emulator regularly exits without taking it along - the green jobs end on
+# "Netsim Wifi ... is gone" with only adb and the gradle daemons left over, the
+# hung ones stop at "removeAll" and leave a crashpad_handler - and the runner then
+# sits there until the job times out. 45 minutes a go, several times over.
+#
+# run-instrumented-tests.sh cleans up after itself, but the action can also fail
+# before it ever runs the script: an "input keyevent 82" killed during boot ends
+# the same way. This runs detached from any step, so it covers that too.
+
+set -u
+
+while true; do
+  # only when no emulator is running, and only for a handler whose parent has
+  # already died - anything else is a live emulator's reporter and stays
+  if ! pgrep -f qemu-system > /dev/null; then
+    for pid in $(pgrep -f crashpad_handler); do
+      parent=$(ps -o ppid= -p "$pid" 2> /dev/null | tr -d ' ')
+      if [ "$parent" = "1" ]; then
+        kill -9 "$pid" 2> /dev/null || true
+      fi
+    done
+  fi
+
+  sleep 5
+done

--- a/.github/scripts/run-instrumented-tests.sh
+++ b/.github/scripts/run-instrumented-tests.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Runs the instrumented tests inside reactivecircus/android-emulator-runner.
+#
+# The action executes its "script:" input line by line, each line in its own
+# "sh -c" - so a multi-line if or loop is a syntax error there, and a variable
+# does not survive to the next line. That is not cosmetic: "|| status=$?" on one
+# line and "exit $status" on another meant gradle's exit code was swallowed and
+# an empty "exit" reported a failed test run as a green step. Everything that
+# needs shell state lives here instead, behind a one-line invocation.
+
+set -u
+
+# Clear logcat before the tests. Fails with "failed to clear the 'main' log" on
+# some system images (api 26 among them) and must not abort the run.
+adb logcat -c || true
+
+status=0
+# the test run takes about 4 minutes; anything past 20 is hung, and a hang has to
+# end as an ordinary failure so the logcat below still gets dumped and uploaded -
+# that is the only view into what the guest was doing
+timeout --kill-after=1m 20m ./gradlew connectedCheck || status=$?
+
+# Dump logcat after the tests. This used to sit after a bare gradle call, so the
+# only runs whose logs were worth uploading were exactly the ones that never got
+# here.
+adb logcat -d > logcat.txt || true
+
+# a hung run says nothing about which test wedged, so add what the device still
+# knows: anrs and tombstones, plus whether our processes are alive
+if [ "$status" = 124 ] || [ "$status" = 137 ]; then
+  adb shell ps -A > processes.txt 2>&1 || true
+  adb shell "cat /data/anr/*trace* 2>/dev/null" > anr-traces.txt || true
+  adb shell "ls -l /data/tombstones 2>/dev/null" > tombstones.txt || true
+fi
+
+# the step cannot end while the emulator the action started still holds its
+# output open, and the action's teardown only sends "adb emu kill" without
+# checking that anything came of it. on api 26 and 29 nothing does often enough
+# to matter - both jobs of run 30249138427 sat there for 40 minutes after their
+# tests had finished, one of them green - so kill it here, hard if the polite
+# request is ignored again
+adb emu kill || true
+for _ in $(seq 20); do
+  pgrep -f qemu-system > /dev/null || break
+  sleep 1
+done
+pkill -9 -f qemu-system || true
+
+exit "$status"

--- a/.github/scripts/run-instrumented-tests.sh
+++ b/.github/scripts/run-instrumented-tests.sh
@@ -34,17 +34,19 @@ if [ "$status" = 124 ] || [ "$status" = 137 ]; then
   adb shell "ls -l /data/tombstones 2>/dev/null" > tombstones.txt || true
 fi
 
-# the step cannot end while the emulator the action started still holds its
-# output open, and the action's teardown only sends "adb emu kill" without
-# checking that anything came of it. on api 26 and 29 nothing does often enough
-# to matter - both jobs of run 30249138427 sat there for 40 minutes after their
-# tests had finished, one of them green - so kill it here, hard if the polite
-# request is ignored again
+# the step cannot end while anything the action started still holds its stdout
+# open, and the action's teardown is one "adb emu kill" with no check that
+# anything came of it. on api 26 and 29 the emulator exits but leaves its crash
+# reporter behind - the green jobs end on "Netsim Wifi ... is gone" with adb and
+# the gradle daemons left over, the hung ones stop at "removeAll" and have a
+# crashpad_handler in the orphan list. that is worth 40 minutes of runner time
+# per job, so nothing gets to outlive the tests here
 adb emu kill || true
 for _ in $(seq 20); do
   pgrep -f qemu-system > /dev/null || break
   sleep 1
 done
 pkill -9 -f qemu-system || true
+pkill -9 -f crashpad_handler || true
 
 exit "$status"

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -142,11 +142,16 @@ jobs:
           # api 26 is minSdk - the floor was previously untested, which is part of
           # why an API 26+ only call could ship in a path only old devices took.
           # (the old api 23 entry was disabled for issue #390 and is now moot)
-          - { arch: x86_64, api-level: 26 }
-          - { arch: x86_64, api-level: 29 }
-          - { arch: x86_64, api-level: 30 }
-          - { arch: x86_64, api-level: 32 }
-          - { arch: x86_64, api-level: 34 }
+          #
+          # it is also the one image whose restored snapshot keeps getting the boot
+          # sequence's "input keyevent 82" SIGKILLed while the guest is still coming
+          # up - at the stock 1536MB and again at 4096MB, so the ram was not the whole
+          # story. it boots cold instead, which costs about a minute and has no thaw
+          - { arch: x86_64, api-level: 26, boot-options: -no-snapshot-load }
+          - { arch: x86_64, api-level: 29, boot-options: '' }
+          - { arch: x86_64, api-level: 30, boot-options: '' }
+          - { arch: x86_64, api-level: 32, boot-options: '' }
+          - { arch: x86_64, api-level: 34, boot-options: '' }
     steps:
     - name: checkout
       uses: actions/checkout@v4
@@ -213,6 +218,11 @@ jobs:
         sudo udevadm control --reload-rules
         sudo udevadm trigger --name-match=kvm
 
+    # detached on purpose: the step that hangs is the one running the emulator, so
+    # nothing that comes after it in this job would ever get to run. see the script
+    - name: Reap the emulator's crash reporter
+      run: nohup setsid bash .github/scripts/reap-crashpad.sh > /dev/null 2>&1 &
+
     - name: Create AVD and generate snapshot for caching
       if: steps.avd-cache.outputs.cache-hit != 'true'
       uses: reactivecircus/android-emulator-runner@v2
@@ -238,7 +248,7 @@ jobs:
         target: google_apis
         force-avd-creation: false
         ram-size: 4096M
-        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
+        emulator-options: -no-snapshot-save ${{ matrix.boot-options }} -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
         disable-animations: true
         # one line on purpose: the action runs this input line by line, each in its
         # own "sh -c", so anything with shell state has to be in the script itself

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -132,6 +132,9 @@ jobs:
   test:
     runs-on: ubuntu-24.04
     needs: build
+    # a job that wedges instead of failing would otherwise sit here until github's
+    # 6h limit. the whole job takes about 10 minutes when the emulator behaves
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -243,12 +246,23 @@ jobs:
           adb logcat -c || true
 
           status=0
-          ./gradlew connectedCheck || status=$?
+          # the test run takes about 4 minutes; anything past 20 is hung, and a hang
+          # has to end as a normal failure so the logcat below still gets dumped and
+          # uploaded - that is the only view into what the guest was doing
+          timeout --kill-after=1m 20m ./gradlew connectedCheck || status=$?
 
           # Dump logcat after tests. This used to sit after a bare gradle call, so the
           # only runs whose logs were worth uploading were the ones that never got here -
           # "||" keeps it reachable without swallowing the failure.
           adb logcat -d > logcat.txt
+
+          # a hung run says nothing about which test wedged, so add what the device
+          # still knows: anrs and tombstones, plus whether our processes are alive
+          if [ "$status" = 124 ] || [ "$status" = 137 ]; then
+            adb shell ps -A > processes.txt 2>&1 || true
+            adb shell "cat /data/anr/*trace* 2>/dev/null" > anr-traces.txt || true
+            adb shell "ls -l /data/tombstones 2>/dev/null" > tombstones.txt || true
+          fi
 
           exit $status
 
@@ -281,4 +295,7 @@ jobs:
           ~/.android/avd/*.avd/config.ini
           ~/.android/avd/*.avd/*.log
           logcat.txt
+          processes.txt
+          anr-traces.txt
+          tombstones.txt
         if-no-files-found: warn

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -142,16 +142,11 @@ jobs:
           # api 26 is minSdk - the floor was previously untested, which is part of
           # why an API 26+ only call could ship in a path only old devices took.
           # (the old api 23 entry was disabled for issue #390 and is now moot)
-          #
-          # it is also the one image whose restored snapshot keeps getting the boot
-          # sequence's "input keyevent 82" SIGKILLed while the guest is still coming
-          # up - at the stock 1536MB and again at 4096MB, so the ram was not the whole
-          # story. it boots cold instead, which costs about a minute and has no thaw
-          - { arch: x86_64, api-level: 26, boot-options: -no-snapshot-load }
-          - { arch: x86_64, api-level: 29, boot-options: '' }
-          - { arch: x86_64, api-level: 30, boot-options: '' }
-          - { arch: x86_64, api-level: 32, boot-options: '' }
-          - { arch: x86_64, api-level: 34, boot-options: '' }
+          - { arch: x86_64, api-level: 26 }
+          - { arch: x86_64, api-level: 29 }
+          - { arch: x86_64, api-level: 30 }
+          - { arch: x86_64, api-level: 32 }
+          - { arch: x86_64, api-level: 34 }
     steps:
     - name: checkout
       uses: actions/checkout@v4
@@ -207,9 +202,10 @@ jobs:
         path: |
           ~/.android/avd/*
           ~/.android/adb*
-        # what gets cached is a booted snapshot, so it pins the guest's memory image to
-        # the ram size it was taken at - this key has to change whenever that does. the
-        # bump also throws the api 26 snapshot away, which is the one that kept dying
+        # this caches the avd itself; the snapshot in it is no longer loaded, since the
+        # test step boots cold to keep the guest out of the thaw that kept killing the
+        # action's first adb command. the key still has to move whenever what is in here
+        # changes - v4 was the ram bump, which the snapshot used to pin
         key: avd-${{ matrix.api-level }}-v4
 
     - name: Enable KVM group perms
@@ -248,7 +244,13 @@ jobs:
         target: google_apis
         force-avd-creation: false
         ram-size: 4096M
-        emulator-options: -no-snapshot-save ${{ matrix.boot-options }} -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
+        # -no-snapshot-load: every api level boots cold. the action treats
+        # sys.boot_completed as "ready" and runs "input keyevent 82" straight after, which a
+        # restored snapshot is not ready for - api 26 had it SIGKILLed at 1536MB and again at
+        # 4096MB, api 29 got "No service published for: input" - and a guest that is still
+        # thawing cannot be waited for from out here. A cold boot has nothing to thaw and
+        # costs about a minute
+        emulator-options: -no-snapshot-save -no-snapshot-load -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
         disable-animations: true
         # one line on purpose: the action runs this input line by line, each in its
         # own "sh -c", so anything with shell state has to be in the script itself

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -199,7 +199,10 @@ jobs:
         path: |
           ~/.android/avd/*
           ~/.android/adb*
-        key: avd-${{ matrix.api-level }}-v3
+        # what gets cached is a booted snapshot, so it pins the guest's memory image to
+        # the ram size it was taken at - this key has to change whenever that does. the
+        # bump also throws the api 26 snapshot away, which is the one that kept dying
+        key: avd-${{ matrix.api-level }}-v4
 
     - name: Enable KVM group perms
       run: |
@@ -215,7 +218,12 @@ jobs:
         arch: ${{ matrix.arch }}
         target: google_apis
         force-avd-creation: false
-        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        # the images default to 1536MB, which left the guest so tight that the first adb
+        # command after a snapshot restore got killed while the system was still thawing
+        # ("input keyevent 82" exiting 137, api 26 mostly). the runner has 16GB, so the
+        # headroom is free
+        ram-size: 4096M
+        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
         disable-animations: false
         script: echo "Generated AVD snapshot for caching."
 
@@ -226,18 +234,23 @@ jobs:
         arch: ${{ matrix.arch }}
         target: google_apis
         force-avd-creation: false
-        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        ram-size: 4096M
+        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
         disable-animations: true
         script: |
           # Clear logcat before tests. Fails with "failed to clear the 'main' log"
           # on some system images (api 26 among them) and must not abort the run.
           adb logcat -c || true
 
-          # Run tests
-          ./gradlew connectedCheck
+          status=0
+          ./gradlew connectedCheck || status=$?
 
-          # Dump logcat after tests
+          # Dump logcat after tests. This used to sit after a bare gradle call, so the
+          # only runs whose logs were worth uploading were the ones that never got here -
+          # "||" keeps it reachable without swallowing the failure.
           adb logcat -d > logcat.txt
+
+          exit $status
 
     - name: Upload test results
       if: always()

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -240,43 +240,9 @@ jobs:
         ram-size: 4096M
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
         disable-animations: true
-        script: |
-          # Clear logcat before tests. Fails with "failed to clear the 'main' log"
-          # on some system images (api 26 among them) and must not abort the run.
-          adb logcat -c || true
-
-          status=0
-          # the test run takes about 4 minutes; anything past 20 is hung, and a hang
-          # has to end as a normal failure so the logcat below still gets dumped and
-          # uploaded - that is the only view into what the guest was doing
-          timeout --kill-after=1m 20m ./gradlew connectedCheck || status=$?
-
-          # Dump logcat after tests. This used to sit after a bare gradle call, so the
-          # only runs whose logs were worth uploading were the ones that never got here -
-          # "||" keeps it reachable without swallowing the failure.
-          adb logcat -d > logcat.txt
-
-          # a hung run says nothing about which test wedged, so add what the device
-          # still knows: anrs and tombstones, plus whether our processes are alive
-          if [ "$status" = 124 ] || [ "$status" = 137 ]; then
-            adb shell ps -A > processes.txt 2>&1 || true
-            adb shell "cat /data/anr/*trace* 2>/dev/null" > anr-traces.txt || true
-            adb shell "ls -l /data/tombstones 2>/dev/null" > tombstones.txt || true
-          fi
-
-          # the step cannot end while the emulator the action started still holds its
-          # output open, and the action's own teardown only sends "adb emu kill" without
-          # checking that anything came of it. on api 26 and 29 nothing does often enough
-          # to matter - both hung for 40 minutes after a finished test run, one of them
-          # green - so kill it here, hard if the polite request is ignored again
-          adb emu kill || true
-          for _ in $(seq 20); do
-            pgrep -f qemu-system > /dev/null || break
-            sleep 1
-          done
-          pkill -9 -f qemu-system || true
-
-          exit $status
+        # one line on purpose: the action runs this input line by line, each in its
+        # own "sh -c", so anything with shell state has to be in the script itself
+        script: bash .github/scripts/run-instrumented-tests.sh
 
     - name: Upload test results
       if: always()

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -264,6 +264,18 @@ jobs:
             adb shell "ls -l /data/tombstones 2>/dev/null" > tombstones.txt || true
           fi
 
+          # the step cannot end while the emulator the action started still holds its
+          # output open, and the action's own teardown only sends "adb emu kill" without
+          # checking that anything came of it. on api 26 and 29 nothing does often enough
+          # to matter - both hung for 40 minutes after a finished test run, one of them
+          # green - so kill it here, hard if the polite request is ignored again
+          adb emu kill || true
+          for _ in $(seq 20); do
+            pgrep -f qemu-system > /dev/null || break
+            sleep 1
+          done
+          pkill -9 -f qemu-system || true
+
           exit $status
 
     - name: Upload test results

--- a/app/src/androidTest/java/app/opendocument/droid/test/CoreTest.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/CoreTest.kt
@@ -190,8 +190,9 @@ class CoreTest {
                 CrashManager(),
             )
 
-            // Give server time to start
-            Thread.sleep(1000)
+            // no waiting for the server here: these tests call host() and edit() straight on
+            // the loader and never fetch a url, so whether the socket is listening yet does
+            // not come into it. it used to sleep a second for it anyway
         }
 
         @JvmStatic

--- a/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
@@ -189,10 +189,7 @@ class MainActivityTests {
 
         val pageView = documentFragment.pageView
         Assert.assertNotNull(pageView)
-        Assert.assertTrue(
-            "ODT should become editable after entering edit mode",
-            waitForEditableState(pageView!!, true, EDIT_MODE_TIMEOUT_MS),
-        )
+        assertBecomesEditable("ODT", pageView!!, documentFragment)
     }
 
     @Test
@@ -204,10 +201,7 @@ class MainActivityTests {
         val pageView = documentFragment.pageView
         Assert.assertNotNull(pageView)
 
-        Assert.assertTrue(
-            "DOCX should become editable after entering edit mode",
-            waitForEditableState(pageView!!, true, EDIT_MODE_TIMEOUT_MS),
-        )
+        assertBecomesEditable("DOCX", pageView!!, documentFragment)
     }
 
     @Test
@@ -373,6 +367,53 @@ class MainActivityTests {
             )
         }
         Assert.assertTrue("Failed to enter edit mode", started.get())
+    }
+
+    /**
+     * Fails with what the page and the file on disk actually contained. testODTEditMode fails on
+     * api 26 without ever being slow - about a second or never - so the interesting question is
+     * which half of the round trip went missing: the reload with translatable=true not producing
+     * editable html, or the webview never showing the html that was produced.
+     */
+    private fun assertBecomesEditable(
+        label: String,
+        pageView: PageView,
+        fragment: DocumentFragment,
+    ) {
+        if (waitForEditableState(pageView, true, EDIT_MODE_TIMEOUT_MS)) {
+            return
+        }
+
+        Assert.fail(
+            "$label should become editable after entering edit mode." +
+                " dom=${describeDom(pageView)} file=${describeLoadedFile(fragment)}"
+        )
+    }
+
+    private fun describeDom(pageView: PageView): String =
+        evaluateJavascript(
+            pageView,
+            "(function(){var b = document.body;var html = b ? b.innerHTML : '';" +
+                "return 'url=' + document.location.href + ' ready=' + document.readyState +" +
+                " ' bodyLength=' + html.length + ' bodyEditable=' + !!(b && b.isContentEditable) +" +
+                " ' editableNodes=' + document.querySelectorAll('[contenteditable]').length +" +
+                " ' odr=' + (typeof odr);})()",
+        ) ?: "no result"
+
+    /** What the loader actually wrote, so a webview that never showed it is distinguishable. */
+    private fun describeLoadedFile(fragment: DocumentFragment): String {
+        val result = fragment.lastResult ?: return "no result"
+        val uri = result.partUris.firstOrNull() ?: return "no part uri"
+        val file = uri.path?.let { File(it) } ?: return "no path in $uri"
+
+        if (!file.exists()) {
+            return "$uri does not exist"
+        }
+
+        val html = file.readText()
+        return "$uri length=${html.length}" +
+            " contenteditable=${html.contains("contenteditable")}" +
+            " translatable=${result.options.translatable}"
     }
 
     private fun waitForEditableState(

--- a/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
@@ -115,7 +115,8 @@ class MainActivityTests {
 
         openDocumentThroughPicker()
 
-        // next onView will be blocked until the idling resource is idle.
+        // next onView will be blocked until the idling resource is idle, which now covers
+        // the load itself and not just the picker round trip.
         clickEditWithOverflowFallback()
     }
 
@@ -125,7 +126,8 @@ class MainActivityTests {
 
         openDocumentThroughPicker()
 
-        // next onView will be blocked until the idling resource is idle.
+        // next onView will be blocked until the idling resource is idle, which now covers
+        // the load itself and not just the picker round trip.
         clickEditWithOverflowFallback()
 
         Thread.sleep(10000)
@@ -157,7 +159,8 @@ class MainActivityTests {
 
         openDocumentThroughPicker()
 
-        // Wait for the password dialog to appear
+        // The dialog is put up by DocumentFragment.onEncrypted, and the idling resource
+        // stays busy until it is on screen - so this does not have to poll for it.
         onView(withText("This document is password-protected")).check(matches(isDisplayed()))
 
         // Enter wrong password first

--- a/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
@@ -40,7 +40,10 @@ import app.opendocument.droid.ui.activity.MainActivity
 import app.opendocument.droid.ui.widget.PageView
 import java.io.File
 import java.io.FileOutputStream
+import java.io.IOException
 import java.io.InputStream
+import java.net.HttpURLConnection
+import java.net.URL
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
@@ -130,17 +133,11 @@ class MainActivityTests {
         // the load itself and not just the picker round trip.
         clickEditWithOverflowFallback()
 
-        // this used to sleep 10s here, asserting nothing afterwards. it was a third of the
-        // whole run's wall time, and it is why "testPDF crashed" was an api 34 bucket of its
-        // own: the app gets killed whenever play services dies under it -
-        //
-        //   Process com.google.android.gms.persistent has died: fg BTOP
-        //   Killing 5333:at.tomtasche.reader.pro (adj 0): depends on provider
-        //       com.google.android.gms/.fonts.provider.FontsProvider in dying proc
-        //
-        // which the instrumentation then reports as "Process crashed". Nothing to do with
-        // pdfs - testPDF just sat still the longest, so it was usually the one holding the
-        // app when gms went down.
+        // there used to be a 10s sleep here that asserted nothing, and it is why "testPDF
+        // crashed" was an api 34 bucket of its own: the app is killed whenever play services
+        // dies under it ("depends on provider ...FontsProvider in dying proc"), which the
+        // instrumentation reports as "Process crashed", and this test sat still the longest
+        // so it was usually the one holding the app when that happened
     }
 
     @Test
@@ -396,7 +393,7 @@ class MainActivityTests {
 
         Assert.fail(
             "$label should become editable after entering edit mode." +
-                " dom=${describeDom(pageView)} file=${describeLoadedFile(fragment)}"
+                " dom=${describeDom(pageView)} document=${describeLoadedDocument(fragment)}"
         )
     }
 
@@ -410,20 +407,34 @@ class MainActivityTests {
                 " ' odr=' + (typeof odr);})()",
         ) ?: "no result"
 
-    /** What the loader actually wrote, so a webview that never showed it is distinguishable. */
-    private fun describeLoadedFile(fragment: DocumentFragment): String {
+    /**
+     * What the loader published, fetched over http the way the webview fetches it.
+     *
+     * Documents are served by the core's own server rather than read off disk, so asking for the
+     * url is the question that matters: a document the test process cannot fetch either was never
+     * served, and one it can fetch was the webview's to lose. When the server had failed to bind
+     * its port, this said "Connection refused" - which is the whole answer.
+     */
+    private fun describeLoadedDocument(fragment: DocumentFragment): String {
         val result = fragment.lastResult ?: return "no result"
-        val uri = result.partUris.firstOrNull() ?: return "no part uri"
-        val file = uri.path?.let { File(it) } ?: return "no path in $uri"
+        val url = result.partUris.firstOrNull() ?: return "no part uri"
 
-        if (!file.exists()) {
-            return "$uri does not exist"
+        return try {
+            val connection = URL(url.toString()).openConnection() as HttpURLConnection
+            connection.connectTimeout = 5000
+            connection.readTimeout = 5000
+
+            try {
+                val html = connection.inputStream.bufferedReader().use { it.readText() }
+                "$url http=${connection.responseCode} length=${html.length}" +
+                    " contenteditable=${html.contains("contenteditable")}" +
+                    " translatable=${result.options.translatable}"
+            } finally {
+                connection.disconnect()
+            }
+        } catch (e: IOException) {
+            "$url unreachable: $e"
         }
-
-        val html = file.readText()
-        return "$uri length=${html.length}" +
-            " contenteditable=${html.contains("contenteditable")}" +
-            " translatable=${result.options.translatable}"
     }
 
     private fun waitForEditableState(
@@ -486,11 +497,10 @@ class MainActivityTests {
         // contenteditable, and on a cold CI emulator that regularly took longer than the 10s
         // this used to wait for - the edit mode tests were the flakiest thing in the suite.
         //
-        // raising it further does not help what is left. when testODTEditMode fails on api 26
-        // it is not slow, it never arrives: the document loads (loader_success_CORE), the dom
-        // simply never reports contenteditable, and 60s failed exactly like 30s did while
-        // testDOCXEditMode passed 1.4s later on the same emulator. that is a webview problem
-        // to chase with the logcat, not a deadline to move
+        // it stays at 30s. the api 26 failures that looked like it needed more were the core
+        // server failing to bind its port, so the document was never served at all and no
+        // deadline would have helped - 60s failed exactly as 30s had. a run that works is
+        // done in about a second
         private const val EDIT_MODE_TIMEOUT_MS = 30000L
 
         // insertion ordered, so the "All test files" log below reads in extraction order

--- a/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
@@ -130,7 +130,17 @@ class MainActivityTests {
         // the load itself and not just the picker round trip.
         clickEditWithOverflowFallback()
 
-        Thread.sleep(10000)
+        // this used to sleep 10s here, asserting nothing afterwards. it was a third of the
+        // whole run's wall time, and it is why "testPDF crashed" was an api 34 bucket of its
+        // own: the app gets killed whenever play services dies under it -
+        //
+        //   Process com.google.android.gms.persistent has died: fg BTOP
+        //   Killing 5333:at.tomtasche.reader.pro (adj 0): depends on provider
+        //       com.google.android.gms/.fonts.provider.FontsProvider in dying proc
+        //
+        // which the instrumentation then reports as "Process crashed". Nothing to do with
+        // pdfs - testPDF just sat still the longest, so it was usually the one holding the
+        // app when gms went down.
     }
 
     @Test

--- a/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
@@ -434,11 +434,13 @@ class MainActivityTests {
         // entering edit mode has to round-trip through the webview before the dom reports
         // contenteditable, and on a cold CI emulator that regularly took longer than the 10s
         // this used to wait for - the edit mode tests were the flakiest thing in the suite.
-        // 30s was still not enough on api 26, the slowest image in the matrix and now the
-        // only one that boots cold, so nothing is warm by the time this runs. waiting longer
-        // costs nothing when it passes: the check polls every 250ms and returns on the first
-        // one that succeeds
-        private const val EDIT_MODE_TIMEOUT_MS = 60000L
+        //
+        // raising it further does not help what is left. when testODTEditMode fails on api 26
+        // it is not slow, it never arrives: the document loads (loader_success_CORE), the dom
+        // simply never reports contenteditable, and 60s failed exactly like 30s did while
+        // testDOCXEditMode passed 1.4s later on the same emulator. that is a webview problem
+        // to chase with the logcat, not a deadline to move
+        private const val EDIT_MODE_TIMEOUT_MS = 30000L
 
         // insertion ordered, so the "All test files" log below reads in extraction order
         private val testFiles = LinkedHashMap<String, File>()

--- a/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
@@ -434,7 +434,11 @@ class MainActivityTests {
         // entering edit mode has to round-trip through the webview before the dom reports
         // contenteditable, and on a cold CI emulator that regularly took longer than the 10s
         // this used to wait for - the edit mode tests were the flakiest thing in the suite.
-        private const val EDIT_MODE_TIMEOUT_MS = 30000L
+        // 30s was still not enough on api 26, the slowest image in the matrix and now the
+        // only one that boots cold, so nothing is warm by the time this runs. waiting longer
+        // costs nothing when it passes: the check polls every 250ms and returns on the first
+        // one that succeeds
+        private const val EDIT_MODE_TIMEOUT_MS = 60000L
 
         // insertion ordered, so the "All test files" log below reads in extraction order
         private val testFiles = LinkedHashMap<String, File>()

--- a/app/src/main/java/app/opendocument/droid/background/CoreLoader.kt
+++ b/app/src/main/java/app/opendocument/droid/background/CoreLoader.kt
@@ -56,8 +56,8 @@ class CoreLoader(context: Context?, private val doOoxml: Boolean) :
     private var lastInputPath: String? = null
     private var lastCachePath: String? = null
 
-    // the port the server actually got, which is not always SERVER_PORT. see choosePort()
-    private var serverPort = SERVER_PORT
+    // the port the server actually got, which is not always the preferred one. see choosePort()
+    private var serverPort = PREFERRED_SERVER_PORT
 
     override fun initialize(
         listener: FileLoaderListener,
@@ -97,7 +97,7 @@ class CoreLoader(context: Context?, private val doOoxml: Boolean) :
     }
 
     /**
-     * Picks the port the server binds to, and says so when [SERVER_PORT] cannot be had.
+     * Picks the port the server binds to, and says so when [PREFERRED_SERVER_PORT] cannot be had.
      *
      * [HttpServer.listen] returns void and does not report a failed bind, so an occupied port left
      * the app with no server at all and nothing to show for it: every document then failed with
@@ -112,22 +112,34 @@ class CoreLoader(context: Context?, private val doOoxml: Boolean) :
      * outright rather than destroyed.
      */
     private fun choosePort(crashManager: CrashManager): Int {
+        // a preference of ANY_PORT is a request for an arbitrary free port, which is what the
+        // fallback below asks for anyway - there is nothing to try first
+        if (PREFERRED_SERVER_PORT != ANY_PORT) {
+            try {
+                return bindable(PREFERRED_SERVER_PORT)
+            } catch (e: IOException) {
+                crashManager.log(
+                    IOException(
+                        "core server cannot bind $SERVER_BIND_ADDRESS:$PREFERRED_SERVER_PORT",
+                        e,
+                    )
+                )
+            }
+        }
+
         try {
-            return bindable(SERVER_PORT)
+            return bindable(ANY_PORT)
         } catch (e: IOException) {
-            crashManager.log(
-                IOException("core server cannot bind $SERVER_BIND_ADDRESS:$SERVER_PORT", e)
-            )
-        }
-
-        return try {
-            bindable(0)
-        } catch (e: IOException) {
-            // nothing is bindable; let listen() fail on the usual port rather than invent one
             crashManager.log(IOException("core server cannot bind any port", e))
-
-            SERVER_PORT
         }
+
+        // [listen] must not be handed ANY_PORT: it would bind a port that nothing here knows,
+        // and every document url would then address :0. A port that cannot be bound at least
+        // fails where it can be seen, now that the webview reports the refused connection. And
+        // the probe is only a moment in time - the port may well be free again by the time the
+        // server gets there.
+        return if (PREFERRED_SERVER_PORT != ANY_PORT) PREFERRED_SERVER_PORT
+        else FALLBACK_SERVER_PORT
     }
 
     /** The port [port] resolves to, if a socket that binds like the native one can have it. */
@@ -353,11 +365,22 @@ class CoreLoader(context: Context?, private val doOoxml: Boolean) :
          */
         private const val SERVER_URL_HOST = "localhost"
 
+        /** What a bind asks for when any free port will do. */
+        private const val ANY_PORT = 0
+
         /**
          * The port the server prefers. Only a preference: it is hardcoded and therefore shared with
-         * the other flavor, so it is not always free. See [choosePort].
+         * the other flavor, so it is not always free. Set it to [ANY_PORT] to always take whatever
+         * is going. See [choosePort].
          */
-        const val SERVER_PORT: Int = 29665
+        const val PREFERRED_SERVER_PORT: Int = 29665
+
+        /**
+         * Handed to [HttpServer.listen] when no port could be bound at all and the preference is
+         * [ANY_PORT], which cannot be passed on - the resulting url would address :0. Only reached
+         * when the device has nothing free, where any choice is as good as the next.
+         */
+        private const val FALLBACK_SERVER_PORT: Int = 29665
 
         /**
          * Whether odrcore renders text documents with page margins. This used to be read from the

--- a/app/src/main/java/app/opendocument/droid/background/CoreLoader.kt
+++ b/app/src/main/java/app/opendocument/droid/background/CoreLoader.kt
@@ -53,6 +53,9 @@ class CoreLoader(context: Context?, private val doOoxml: Boolean) :
     private var lastInputPath: String? = null
     private var lastCachePath: String? = null
 
+    // counts translations, so each one is served under a url of its own. see host()
+    private var hostGeneration = 0
+
     override fun initialize(
         listener: FileLoaderListener,
         mainHandler: Handler,
@@ -208,13 +211,24 @@ class CoreLoader(context: Context?, private val doOoxml: Boolean) :
         cacheDirectory.mkdirs()
 
         val service = Html.translate(file, cachePath, htmlConfig)
-        server.connectService(service, prefix)
+
+        // every translation gets a url of its own. entering edit mode re-hosts the same
+        // document ~85ms after the first load, and with a fixed prefix that produced the
+        // identical url twice: the server.clear() above broke the first fetch while it was
+        // still in flight, the webview committed its own error page for that url, and the
+        // second loadUrl - same url, navigation already in progress - never became a
+        // navigation of its own. On api 26 that left the document sitting on
+        // chrome-error://chromewebdata/ for good, which is what testODTEditMode kept
+        // failing on. A url that has not been navigated to before cannot be folded into
+        // the one that just failed.
+        val hostedPrefix = "$prefix-${++hostGeneration}"
+        server.connectService(service, hostedPrefix)
 
         return selectViews(file, service.listViews()).map { view ->
             Log.i(TAG, "view name=" + view.name() + " path=" + view.path())
             HostedView(
                 view.name(),
-                "http://$SERVER_URL_HOST:$SERVER_PORT/file/$prefix/" + view.path(),
+                "http://$SERVER_URL_HOST:$SERVER_PORT/file/$hostedPrefix/" + view.path(),
             )
         }
     }

--- a/app/src/main/java/app/opendocument/droid/background/CoreLoader.kt
+++ b/app/src/main/java/app/opendocument/droid/background/CoreLoader.kt
@@ -27,6 +27,9 @@ import app.opendocument.droid.nonfree.AnalyticsManager
 import app.opendocument.droid.nonfree.CrashManager
 import com.viliussutkus89.android.assetextractor.AssetExtractor
 import java.io.File
+import java.io.IOException
+import java.net.InetSocketAddress
+import java.net.ServerSocket
 
 /**
  * Loads documents through odrcore and publishes them on a local http server.
@@ -53,8 +56,8 @@ class CoreLoader(context: Context?, private val doOoxml: Boolean) :
     private var lastInputPath: String? = null
     private var lastCachePath: String? = null
 
-    // counts translations, so each one is served under a url of its own. see host()
-    private var hostGeneration = 0
+    // the port the server actually got, which is not always SERVER_PORT. see choosePort()
+    private var serverPort = SERVER_PORT
 
     override fun initialize(
         listener: FileLoaderListener,
@@ -78,10 +81,12 @@ class CoreLoader(context: Context?, private val doOoxml: Boolean) :
         val server = HttpServer(config)
         this.server = server
 
+        serverPort = choosePort(crashManager)
+
         httpThread =
             Thread {
                 try {
-                    server.listen(SERVER_BIND_ADDRESS, SERVER_PORT)
+                    server.listen(SERVER_BIND_ADDRESS, serverPort)
                 } catch (e: Throwable) {
                     crashManager.log(e)
                 }
@@ -90,6 +95,52 @@ class CoreLoader(context: Context?, private val doOoxml: Boolean) :
 
         super.initialize(listener, mainHandler, backgroundHandler, analyticsManager, crashManager)
     }
+
+    /**
+     * Picks the port the server binds to, and says so when [SERVER_PORT] cannot be had.
+     *
+     * [HttpServer.listen] returns void and does not report a failed bind, so an occupied port left
+     * the app with no server at all and nothing to show for it: every document then failed with
+     * ERR_CONNECTION_REFUSED behind chrome's own error page. That is what testODTEditMode kept
+     * failing on, and it took a webview error log to see at all.
+     *
+     * The port is occupied more often than it looks. Both flavors hardcode it, so lite and pro
+     * collide whenever they run on one device - the instrumented tests do exactly that, one flavor
+     * after the other - and a port does not come free the moment its owner goes away: the sockets
+     * the webview opened linger in TIME_WAIT for a minute, and the native bind does not set
+     * SO_REUSEADDR. Clean shutdown does not help either, since the previous app is usually killed
+     * outright rather than destroyed.
+     */
+    private fun choosePort(crashManager: CrashManager): Int {
+        try {
+            return bindable(SERVER_PORT)
+        } catch (e: IOException) {
+            crashManager.log(
+                IOException("core server cannot bind $SERVER_BIND_ADDRESS:$SERVER_PORT", e)
+            )
+        }
+
+        return try {
+            bindable(0)
+        } catch (e: IOException) {
+            // nothing is bindable; let listen() fail on the usual port rather than invent one
+            crashManager.log(IOException("core server cannot bind any port", e))
+
+            SERVER_PORT
+        }
+    }
+
+    /** The port [port] resolves to, if a socket that binds like the native one can have it. */
+    private fun bindable(port: Int): Int =
+        ServerSocket().use { probe ->
+            // deliberately not reuseAddress: the probe has to fail wherever the native bind
+            // would, and java turns SO_REUSEADDR on by default - which is exactly the flag
+            // whose absence makes a TIME_WAIT port unusable
+            probe.reuseAddress = false
+            probe.bind(InetSocketAddress(SERVER_BIND_ADDRESS, port))
+
+            probe.localPort
+        }
 
     override fun isSupported(options: Options): Boolean {
         val fileType = options.fileType ?: return false
@@ -211,24 +262,13 @@ class CoreLoader(context: Context?, private val doOoxml: Boolean) :
         cacheDirectory.mkdirs()
 
         val service = Html.translate(file, cachePath, htmlConfig)
-
-        // every translation gets a url of its own. entering edit mode re-hosts the same
-        // document ~85ms after the first load, and with a fixed prefix that produced the
-        // identical url twice: the server.clear() above broke the first fetch while it was
-        // still in flight, the webview committed its own error page for that url, and the
-        // second loadUrl - same url, navigation already in progress - never became a
-        // navigation of its own. On api 26 that left the document sitting on
-        // chrome-error://chromewebdata/ for good, which is what testODTEditMode kept
-        // failing on. A url that has not been navigated to before cannot be folded into
-        // the one that just failed.
-        val hostedPrefix = "$prefix-${++hostGeneration}"
-        server.connectService(service, hostedPrefix)
+        server.connectService(service, prefix)
 
         return selectViews(file, service.listViews()).map { view ->
             Log.i(TAG, "view name=" + view.name() + " path=" + view.path())
             HostedView(
                 view.name(),
-                "http://$SERVER_URL_HOST:$SERVER_PORT/file/$hostedPrefix/" + view.path(),
+                "http://$SERVER_URL_HOST:$serverPort/file/$prefix/" + view.path(),
             )
         }
     }
@@ -313,6 +353,10 @@ class CoreLoader(context: Context?, private val doOoxml: Boolean) :
          */
         private const val SERVER_URL_HOST = "localhost"
 
+        /**
+         * The port the server prefers. Only a preference: it is hardcoded and therefore shared with
+         * the other flavor, so it is not always free. See [choosePort].
+         */
         const val SERVER_PORT: Int = 29665
 
         /**

--- a/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
@@ -30,6 +30,7 @@ import app.opendocument.droid.background.StreamUtil
 import app.opendocument.droid.nonfree.AnalyticsConstants
 import app.opendocument.droid.nonfree.AnalyticsManager
 import app.opendocument.droid.nonfree.CrashManager
+import app.opendocument.droid.ui.OpenFileIdling
 import app.opendocument.droid.ui.SnackbarHelper
 import app.opendocument.droid.ui.widget.PageView
 import app.opendocument.droid.ui.widget.ProgressDialogFragment
@@ -59,6 +60,13 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
 
     private var resultOnStart: FileLoader.Result? = null
     private var errorOnStart: Throwable? = null
+
+    // whether a load is outstanding as far as OpenFileIdling is concerned. MainActivity
+    // only keeps espresso busy for the document picker round trip, which ends the moment
+    // the picker returns a uri - long before a loader callback has put anything on screen.
+    // one token per fragment is enough: a load started while another is in flight replaces
+    // it, and the surviving callback releases the single token.
+    private var loadIsIdling = false
 
     private lateinit var tabLayout: TabLayout
 
@@ -258,7 +266,30 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
     private fun loadWithType(loaderType: FileLoader.LoaderType, options: FileLoader.Options) {
         prepareLoad(loaderType, true)
 
+        beginLoadIdling()
+
         serviceQueue.addToQueue { service -> service.loadWithType(loaderType, options) }
+    }
+
+    /**
+     * Marks the app busy for espresso until one of the loader callbacks below has run. No-op in
+     * release builds, where [OpenFileIdling] does nothing.
+     */
+    private fun beginLoadIdling() {
+        if (!loadIsIdling) {
+            loadIsIdling = true
+
+            OpenFileIdling.increment()
+        }
+    }
+
+    /** Counterpart of [beginLoadIdling]. Called once the load put its result on screen. */
+    private fun endLoadIdling() {
+        if (loadIsIdling) {
+            loadIsIdling = false
+
+            OpenFileIdling.decrement()
+        }
     }
 
     fun loadUri(uri: Uri, persistentUri: Boolean, editable: Boolean = false) {
@@ -461,6 +492,8 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
 
         dismissProgress()
 
+        endLoadIdling()
+
         // in-app review is requested in the pro flavor only. The lite branch used to
         // consult a "show_in_app_rating" remote config key, which has resolved to nothing
         // since firebase remote config was removed, so lite never asked either way.
@@ -489,6 +522,8 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
 
         // MetadataLoader failed, so there's no point in trying to parse or upload the file
         offerReopen(activity, options, errorDescription, true)
+
+        endLoadIdling()
     }
 
     override fun onEncrypted(result: FileLoader.Result) {
@@ -523,6 +558,9 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
         }
         builder.setNegativeButton(getString(android.R.string.cancel), null)
         builder.show()
+
+        // after show(), so espresso does not go idle until the dialog is on screen
+        endLoadIdling()
     }
 
     override fun onUnsupported(result: FileLoader.Result) {
@@ -545,6 +583,8 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
         } else if (result.loaderType == FileLoader.LoaderType.ONLINE) {
             offerReopen(activity, options, R.string.toast_error_illegal_file_reopen, true)
         }
+
+        endLoadIdling()
     }
 
     override fun onSaveSuccess(outFile: Uri) {
@@ -800,6 +840,11 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
         super.onDestroyView()
 
         serviceQueue.service?.setListener(null)
+
+        // the listener is gone, so a load still in flight will never call back. releasing
+        // the token here keeps the idling resource - a singleton - from staying busy into
+        // the next instrumented test
+        endLoadIdling()
 
         pageView?.destroy()
     }

--- a/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
@@ -61,13 +61,6 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
     private var resultOnStart: FileLoader.Result? = null
     private var errorOnStart: Throwable? = null
 
-    // whether a load is outstanding as far as OpenFileIdling is concerned. MainActivity
-    // only keeps espresso busy for the document picker round trip, which ends the moment
-    // the picker returns a uri - long before a loader callback has put anything on screen.
-    // one token per fragment is enough: a load started while another is in flight replaces
-    // it, and the surviving callback releases the single token.
-    private var loadIsIdling = false
-
     private lateinit var tabLayout: TabLayout
 
     private lateinit var serviceQueue: LoaderServiceQueue
@@ -87,6 +80,45 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
         var lastRequestedUri: Uri? = null
 
         var lastSelectedTab: Int = -1
+
+        // whether a load is outstanding as far as OpenFileIdling is concerned. MainActivity
+        // only keeps espresso busy for the document picker round trip, which ends the moment
+        // the picker returns a uri - long before a loader callback has put anything on screen.
+        // one token per fragment is enough: a load started while another is in flight replaces
+        // it, and the surviving callback releases the single token.
+        //
+        // it lives here rather than in the fragment so a configuration change does not lose it:
+        // the recreated fragment reattaches itself as the service listener and keeps this view
+        // model, so the callback that ends the load still finds a token to release.
+        private var loadIsIdling = false
+
+        /**
+         * Marks the app busy for espresso until one of the loader callbacks has run. No-op in
+         * release builds, where [OpenFileIdling] does nothing.
+         */
+        fun beginLoadIdling() {
+            if (!loadIsIdling) {
+                loadIsIdling = true
+
+                OpenFileIdling.increment()
+            }
+        }
+
+        /** Counterpart of [beginLoadIdling]. Called once the load put its result on screen. */
+        fun endLoadIdling() {
+            if (loadIsIdling) {
+                loadIsIdling = false
+
+                OpenFileIdling.decrement()
+            }
+        }
+
+        // the fragment is gone for good, so a load still in flight will never call back.
+        // releasing the token here keeps the idling resource - a singleton - from staying
+        // busy into the next instrumented test
+        override fun onCleared() {
+            endLoadIdling()
+        }
     }
 
     private lateinit var state: DocumentViewModel
@@ -266,30 +298,9 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
     private fun loadWithType(loaderType: FileLoader.LoaderType, options: FileLoader.Options) {
         prepareLoad(loaderType, true)
 
-        beginLoadIdling()
+        state.beginLoadIdling()
 
         serviceQueue.addToQueue { service -> service.loadWithType(loaderType, options) }
-    }
-
-    /**
-     * Marks the app busy for espresso until one of the loader callbacks below has run. No-op in
-     * release builds, where [OpenFileIdling] does nothing.
-     */
-    private fun beginLoadIdling() {
-        if (!loadIsIdling) {
-            loadIsIdling = true
-
-            OpenFileIdling.increment()
-        }
-    }
-
-    /** Counterpart of [beginLoadIdling]. Called once the load put its result on screen. */
-    private fun endLoadIdling() {
-        if (loadIsIdling) {
-            loadIsIdling = false
-
-            OpenFileIdling.decrement()
-        }
     }
 
     fun loadUri(uri: Uri, persistentUri: Boolean, editable: Boolean = false) {
@@ -492,7 +503,7 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
 
         dismissProgress()
 
-        endLoadIdling()
+        state.endLoadIdling()
 
         // in-app review is requested in the pro flavor only. The lite branch used to
         // consult a "show_in_app_rating" remote config key, which has resolved to nothing
@@ -523,7 +534,7 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
         // MetadataLoader failed, so there's no point in trying to parse or upload the file
         offerReopen(activity, options, errorDescription, true)
 
-        endLoadIdling()
+        state.endLoadIdling()
     }
 
     override fun onEncrypted(result: FileLoader.Result) {
@@ -560,7 +571,7 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
         builder.show()
 
         // after show(), so espresso does not go idle until the dialog is on screen
-        endLoadIdling()
+        state.endLoadIdling()
     }
 
     override fun onUnsupported(result: FileLoader.Result) {
@@ -584,7 +595,7 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
             offerReopen(activity, options, R.string.toast_error_illegal_file_reopen, true)
         }
 
-        endLoadIdling()
+        state.endLoadIdling()
     }
 
     override fun onSaveSuccess(outFile: Uri) {
@@ -841,10 +852,15 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
 
         serviceQueue.service?.setListener(null)
 
-        // the listener is gone, so a load still in flight will never call back. releasing
-        // the token here keeps the idling resource - a singleton - from staying busy into
-        // the next instrumented test
-        endLoadIdling()
+        // the listener is gone, so a load still in flight will never call back - unless this
+        // is a configuration change, where the recreated fragment takes the listener (and the
+        // view model holding the token) over and still gets the callback. anywhere else,
+        // releasing here keeps the idling resource - a singleton - from staying busy into the
+        // next instrumented test. a fragment that goes away for good on top of that has its
+        // view model cleared, which releases as well
+        if (!requireActivity().isChangingConfigurations) {
+            state.endLoadIdling()
+        }
 
         pageView?.destroy()
     }

--- a/app/src/main/java/app/opendocument/droid/ui/widget/PageView.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/widget/PageView.kt
@@ -11,6 +11,8 @@ import android.util.AttributeSet
 import android.util.Base64
 import android.util.Base64InputStream
 import android.webkit.JavascriptInterface
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.annotation.Keep
@@ -94,6 +96,27 @@ constructor(context: Context, attributeSet: AttributeSet?) :
 
                 override fun onPageCommitVisible(view: WebView, url: String) {
                     wasCommitCalled = true
+                }
+
+                // a document that fails to load leaves chrome's own error page on screen and
+                // said nothing to anyone. that cost a full round of ci archaeology to work out
+                // from the outside, so the main frame failing is now reported
+                override fun onReceivedError(
+                    view: WebView,
+                    request: WebResourceRequest,
+                    error: WebResourceError,
+                ) {
+                    super.onReceivedError(view, request, error)
+
+                    if (!request.isForMainFrame) {
+                        return
+                    }
+
+                    crashManager.log(
+                        RuntimeException(
+                            "loading ${request.url} failed: ${error.errorCode} ${error.description}"
+                        )
+                    )
                 }
 
                 @Suppress("DEPRECATION") // the request based overload needs API 24 semantics


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

The test matrix has been failing on roughly every other push. Going through the last 12 failed test jobs, they fell into four buckets:

| failure | count | api levels | cause |
|---|---|---|---|
| `testPasswordProtectedODT` → `NoMatchingViewException` | 7 | 29, 30, 32 | espresso waited for the picker, not the load |
| emulator exits 137 before a single test runs | 2 | 26 | the action's first adb command races a thawing snapshot |
| `testPDF` → "Instrumentation run failed due to Process crashed" | 2 | 34 | play services dies, the app is killed as its dependent |
| `testODTEditMode` 30s timeout | 1 | 26 | the core's http server never bound its port |

All four are fixed, and none of them was what it looked like. The last one turned out to be a real app bug that affects users with both flavors installed. Chasing them also turned up a workflow that was **reporting failed test runs as green**.

Full matrix green: [run 30269827697](https://github.com/opendocument-app/OpenDocument.droid/actions/runs/30269827697), all five api levels, 4-5 minutes each.

## The password dialog race

`OpenFileIdling` only spans the `ACTION_OPEN_DOCUMENT` round trip. `MainActivity` increments before launching the picker and decrements in the result callback — which runs *before* `loadUri()` has even started. Everything the tests actually look for (the password dialog, the rendered document) is put on screen by a `LoaderService` callback well after that, so "the next onView will be blocked until the idling resource is idle" was blocking on the wrong thing and the assertion raced the load.

A token is now held from `loadWithType()` until whichever of `onLoadSuccess` / `onError` / `onEncrypted` / `onUnsupported` ends the load. `onEncrypted` releases it *after* `builder.show()`, so espresso cannot go idle before the dialog is on screen. One token per load is enough: loader chaining (`METADATA → CORE → RAW`) happens inside `LoaderService` without coming back through the fragment.

The token lives in `DocumentViewModel` rather than the fragment, so a configuration change does not lose it — the recreated fragment reattaches as the service listener and keeps the view model, so the callback that ends the load still finds a token to release. `onDestroyView` releases it when the activity is *not* changing configurations, and `onCleared` covers a fragment that is gone for good.

### Verification

A fast Mac would never have reproduced this. With a temporary `Thread.sleep(6000)` injected into `FileLoader.loadAsync`:

- token disabled → `NoMatchingViewException: ... "This document is password-protected"`, byte for byte the CI failure
- token enabled → passes

## testODTEditMode: the core server never got its port

This one looked like the emulator being slow, and it was not. The cap went from 30s to 60s and changed nothing, because the failure is not slow — it is about a second or it is never. So the assertion was made to report what it found:

```
dom="url=chrome-error://chromewebdata/ ready=complete bodyLength=1911
     bodyEditable=false editableNodes=0 odr=undefined"
```

The webview was sitting on chrome's network error page. `PageView` now reports main frame load failures, which named it:

```
loading http://localhost:29665/file/odr/document.html failed: -6 net::ERR_CONNECTION_REFUSED
```

Nothing was listening. `HttpServer.listen()` returns void and reports nothing when the bind fails, so an occupied port leaves the app with **no server and no complaint**, and every document quietly becomes an error page.

The port is occupied more often than it looks. Both flavors hardcode 29665, and `connectedCheck` runs them one after the other on one device. In the failing run the pro process was killed at 12:55:07 and lite started at 12:55:19 — the process was long gone, but the sockets its webview had opened were still in TIME_WAIT. The native bind sets `SO_REUSEPORT` (cpp-httplib's default on linux) and not `SO_REUSEADDR`, and only the latter relaxes TIME_WAIT - `SO_REUSEPORT` additionally shares a port only between sockets of the same uid, which two flavors never are. Clean shutdown cannot help either: the previous app is killed outright, so `close()` never runs.

The port is now probed before `listen()`, with a socket that binds the way the native one does — no `SO_REUSEADDR`, or the probe would succeed exactly where the real bind fails — and the failure is logged either way. If the preferred port cannot be had we take what the system gives us and address the document by that.

**This is not only a test problem.** Lite and pro installed side by side collide the same way, and the loser shows an error page instead of the document.

## Jobs that hung for 40 minutes after the tests had finished

Two jobs sat in "Run tests" until the run was cancelled. Neither was still testing — api 29 was `BUILD SUCCESSFUL in 2m 43s`. Comparing a hung job with a green one at the same point:

| | last emulator line | left behind |
|---|---|---|
| green | `Netsim Wifi ... is gone due to CANCELLED` | adb, gradle daemons |
| hung | `removeAll` | **crashpad_handler**, adb, gradle daemons |

The emulator's crash reporter inherits the step's stdout, and on api 26 and 29 the emulator exits without taking it along. A step cannot end while anything still holds that pipe, and the action's teardown is a single `adb emu kill` with no check that anything came of it.

The test script now ends the emulator itself, and a detached watchdog reaps an orphaned crash reporter from outside the step — which matters because the action can also die *before* the script runs, and then nothing inside it would get a turn.

Backstops, since this cost 6 runner-hours before anyone noticed: `timeout 20m` around gradle so a hung test run still reaches the logcat dump, and `timeout-minutes: 45` on the job. Both have already earned their place.

## The workflow was reporting failures as success

`reactivecircus/android-emulator-runner` runs its `script:` input **line by line, each line in its own `sh -c`**. So this, added earlier in this PR, never worked:

```sh
status=0                                    # one shell
./gradlew connectedCheck || status=$?       # another; the || eats the exit code
adb logcat -d > logcat.txt
exit $status                                # a third; $status is empty, so exit 0
```

A failing test run reported the step **green**. Nothing caught it because nothing had failed since it was introduced. The body now lives in `.github/scripts/run-instrumented-tests.sh` behind a one-line invocation, where variables persist and gradle's exit code reaches the step again.

## Boot races on a restored snapshot

Api 26 kept having the action's `input keyevent 82` SIGKILLed right after a snapshot restore — at the stock 1536MB and again at 4096MB, so the ram was never the whole story. Api 29 then produced the same race with a different symptom: `No service published for: input`. The emulator reports `sys.boot_completed` while the guest is still coming up, the action runs its next adb command immediately, and nothing out here can wait for a thaw.

Every api level boots cold now (`-no-snapshot-load`). A cold boot has nothing to thaw and costs about a minute. Emulator ram stays at 4096M.

## testPDF was never about pdfs

The instrumentation reported "Process crashed", and the logcat — captured for the first time, thanks to the dump fix below — says who did the killing:

```
Process com.google.android.gms.persistent (pid 1417) has died: fg BTOP
Killing 5333:at.tomtasche.reader.pro (adj 0): depends on provider
    com.google.android.gms/.fonts.provider.FontsProvider in dying proc
```

Play services fell over and the app was killed as a dependent of its FontsProvider. `testPDF` ended with a `Thread.sleep(10000)` that asserted nothing — a third of the whole run's wall time — so it was simply the test most likely to be holding the app when gms went down. The sleep is gone.

To be clear about what that does and does not fix: gms dying still kills the app, and it can do that during any test. Removing the sleep shrinks the window it had to aim at from a third of the run to nearly nothing, which is mitigation, not a cure. If it comes back it will come back somewhere else, and the logcat will say so in the same words.

## Logcat on failure

`adb logcat -d > logcat.txt` sat after a bare `./gradlew connectedCheck`, so a failing run aborted the script before the dump. The only runs whose logs were worth uploading were exactly the ones that never produced them. The status is now captured and re-raised after the dump, and a timed-out run also uploads the device's process list, ANR traces and tombstones.

Every diagnosis above came out of logs this change made available.

## Also in here

- **The diagnostics stay.** On failure the edit mode assertion reports what the dom has and fetches the document url over http the way the webview does, and `PageView` reports main frame load failures. Those two are what turned a fourth round of guessing into "Connection refused", and the next person gets them for free.
- **The AVD cache key goes `v3` → `v4`.** What is cached changed (the ram bump, and the snapshot in it is no longer loaded), so the old entries have to go.
- **`-no-metrics`** on both emulator steps, so the emulator does not stop to ask.
- **`CoreTest` no longer sleeps a second** "to give the server time to start". Those tests call `host()` and `edit()` on the loader and never fetch a url, so the socket being up never came into it.

## Not fixed here

- **This belongs upstream in odrcore, and a PR is going there.** `HttpServer::listen()` takes the host and port, returns void, and discards the `bool` that cpp-httplib hands it - so a failed bind is known inside the library and thrown away twice. The probe in `choosePort` is a workaround for that, and a guess about how the native bind behaves rather than a fix. What it should offer instead is a `bind()` that returns the port it got (so `0` becomes usable and no probe is needed) and reports failure, with the accept loop as a separate call. Socket options want exposing too: `SO_REUSEADDR` is what would have made this collision a non-event.

- **`clickEditWithOverflowFallback` is a no-op.** `onView(...).withFailureHandler { ... }` with no terminal `perform`/`check` does nothing at all, so `testODT` and `testPDF` assert nothing and the final assertion of `testPasswordProtectedODT` never runs. Worth fixing, but activating three dormant assertions in a PR whose goal is *less* red CI seemed like the wrong bundle — happy to do it as a follow-up.
- **The CodeQL SARIF upload is broken** on every build: `sarif_file: app/build/reports` picks up both `lint-results-proDebug.sarif` and `lint-results-liteDebug.sarif` under one `android-lint` category, which the action rejects — so lint findings never reach the code scanning tab. Needs one category per flavor.
