### PR TITLE
Correct what the native bind actually sets

### DIFF
--- a/app/src/main/java/app/opendocument/droid/background/CoreLoader.kt
+++ b/app/src/main/java/app/opendocument/droid/background/CoreLoader.kt
@@ -107,9 +107,11 @@ class CoreLoader(context: Context?, private val doOoxml: Boolean) :
      * The port is occupied more often than it looks. Both flavors hardcode it, so lite and pro
      * collide whenever they run on one device - the instrumented tests do exactly that, one flavor
      * after the other - and a port does not come free the moment its owner goes away: the sockets
-     * the webview opened linger in TIME_WAIT for a minute, and the native bind does not set
-     * SO_REUSEADDR. Clean shutdown does not help either, since the previous app is usually killed
-     * outright rather than destroyed.
+     * the webview opened linger in TIME_WAIT for a minute. The native bind sets SO_REUSEPORT,
+     * cpp-httplib's default on linux, and not SO_REUSEADDR; only the latter relaxes TIME_WAIT, and
+     * SO_REUSEPORT shares a port only between sockets of the same uid - which two flavors never
+     * are. Clean shutdown does not help either, since the previous app is usually killed outright
+     * rather than destroyed.
      */
     private fun choosePort(crashManager: CrashManager): Int {
         // a preference of ANY_PORT is a request for an arbitrary free port, which is what the


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Follow-up to #536, comment only.

That PR's `choosePort` doc says the native bind "does not set SO_REUSEADDR". Checking cpp-httplib rather than assuming: `default_socket_options` sets `SO_REUSEPORT` on linux, falling back to `SO_REUSEADDR` only where `SO_REUSEPORT` is undefined, and odrcore does not override it.

The distinction cuts both ways, which is why it is worth correcting rather than leaving as a near-enough:

- only `SO_REUSEADDR` relaxes TIME_WAIT, and TIME_WAIT is what blocked the bind
- `SO_REUSEPORT` shares a port only between sockets of the same effective uid, so it was never going to let lite and pro share one either (10077 vs 10079 in the logcat)

Nothing about the fix changes: the port is not reliably available, and the probe stays until odrcore can report a failed bind itself.