### PR TITLE
Take the version from the git tag instead of the manifest

### DIFF
--- a/.github/scripts/resolve-version.py
+++ b/.github/scripts/resolve-version.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+#
+# Works out which version a release run is building, and refuses the runs that
+# cannot sensibly build one.
+#
+# There is no version number in the repository: it is the git tag, which
+# app/build.gradle turns into a version name and a version code (v4.8.0 -> 4.8.0
+# and 40800, two digits per part). What is left to decide is which string gradle
+# is handed, and that is only interesting when the run has no tag to read:
+#
+#   tag push                   the tag, and the version input has to agree with
+#                              it or stay empty - the apk of a run is attached to
+#                              the release of the tag it ran on, so building
+#                              anything else would file it there under the wrong
+#                              version
+#   dispatched off a branch    the version input, which is how a release whose
+#                              upload half failed gets finished off the branch it
+#                              was cut from
+#   neither                    only a dry run, on gradle's unversioned fallback.
+#                              uploading that would mean uploading a version code
+#                              the store refuses, six minutes into the run
+#
+# The shape is checked here rather than left to gradle, which checks it again and
+# is the one that counts: a typo in a dispatched version should not cost the
+# conan and gradle setup first. The version code is deliberately not computed
+# here - one derivation of it, in the build, is enough.
+#
+# Prints the resolved version and writes it to GITHUB_OUTPUT as `version`, empty
+# when there is none. Run it by hand to see what a dispatch would build.
+
+import argparse
+import os
+import re
+import sys
+
+# what app/build.gradle accepts: an optional v, one to three parts, each below
+# 100 so that two digits per part stays unambiguous
+VERSION = re.compile(r"^v?[0-9]{1,2}(\.[0-9]{1,2}){0,2}$")
+
+
+def fail(message):
+    if os.environ.get("GITHUB_ACTIONS"):
+        # shown in the log the same way, and additionally as an annotation on the
+        # run itself rather than only somewhere in the middle of a step
+        print(f"::error::{message}")
+    else:
+        print(message, file=sys.stderr)
+    return 1
+
+
+def resolve(tag, given, uploads, log=print):
+    """The version to build, or "" for none. Raises ValueError with the reason."""
+    tag, given = tag.strip(), given.strip()
+
+    if tag and given and given.removeprefix("v") != tag.removeprefix("v"):
+        raise ValueError(
+            f"the version input ({given}) is not the tag this ran on ({tag}). "
+            "leave it blank to build the tag."
+        )
+
+    version = tag or given
+    if not version:
+        if uploads != "none":
+            raise ValueError(
+                "nothing to take a version from. push this as a v* tag, dispatch "
+                "it on one, or fill in the version input."
+            )
+        log("no version given - building gradle's unversioned fallback")
+        return ""
+
+    if not VERSION.match(version):
+        raise ValueError(
+            f"'{version}' is not a version: expected something like v4.8.0, each part below 100"
+        )
+    log(f"building {version}")
+    return version
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Resolve the version a release run builds."
+    )
+    parser.add_argument("--tag", default="", help="tag the run was triggered by, if any")
+    parser.add_argument("--input", default="", help="version input of a dispatched run")
+    parser.add_argument(
+        "--uploads",
+        default="none",
+        help="what the run publishes; only 'none' may go without a version",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        version = resolve(args.tag, args.input, args.uploads)
+    except ValueError as reason:
+        return fail(str(reason))
+
+    output = os.environ.get("GITHUB_OUTPUT")
+    if output:
+        with open(output, "a") as out:
+            out.write(f"version={version}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/verify-keystore.sh
+++ b/.github/scripts/verify-keystore.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Checks that the release keystore can be opened and that both signing keys can
+# actually be used with the passwords supplied for them.
+#
+# Signing is the very last thing a release build does, so a wrong password
+# otherwise surfaces as a signProReleaseBundle failure six minutes in - and
+# gradle wraps both failures in the same "Failed to read key <alias> from store",
+# which does not say which of the two it was. keytool tells them apart in a
+# second: -list proves the store password, and -certreq proves a key password,
+# because it needs the private key itself. Neither writes to the keystore.
+#
+# Takes the same environment variables the build takes (see the "Release signing"
+# section in the README), so it can be run against a keystore by hand:
+#
+#   ODR_KEYSTORE=google_play.keystore ODR_KEYSTORE_PASSWORD=... verify-keystore.sh
+#
+set -uo pipefail
+
+keystore="${1:-${ODR_KEYSTORE:-}}"
+store_password="${ODR_KEYSTORE_PASSWORD:-}"
+
+# the aliases the two flavors are signed with, as app/build.gradle names them
+pro_alias="reader-pro"
+lite_alias="reader"
+
+fail() {
+    if [ -n "${GITHUB_ACTIONS:-}" ]; then
+        # shown in the log the same way, and additionally as an annotation on the
+        # run itself rather than only somewhere in the middle of a step
+        echo "::error::$1"
+    else
+        echo "$1" >&2
+    fi
+    exit 1
+}
+
+[ -n "$keystore" ] || fail "no keystore given: pass one as an argument or set ODR_KEYSTORE"
+[ -f "$keystore" ] || fail "$keystore does not exist"
+[ -n "$store_password" ] || fail "ODR_KEYSTORE_PASSWORD is not set"
+
+if ! keytool -list -keystore "$keystore" -storepass "$store_password" > /dev/null; then
+    fail "ODR_KEYSTORE_PASSWORD does not open the keystore, or ODR_KEYSTORE_BASE64 did not decode to it. A trailing newline in either secret is enough to do this."
+fi
+
+# an unset key password falls back to the store one, the same way app/build.gradle
+# resolves it
+verify_key() {
+    local alias="$1" password="${2:-$store_password}"
+    if ! keytool -certreq -alias "$alias" -keystore "$keystore" \
+            -storepass "$store_password" -keypass "${password:-$store_password}" > /dev/null; then
+        fail "the $alias key cannot be used - check its key password secret"
+    fi
+    echo "usable: $alias"
+}
+
+verify_key "$pro_alias" "${ODR_KEY_PASSWORD_PRO:-}"
+verify_key "$lite_alias" "${ODR_KEY_PASSWORD_LITE:-}"

--- a/.github/scripts/verify-signed.sh
+++ b/.github/scripts/verify-signed.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Checks that every release bundle and apk a build produced is signed.
+#
+# A release that silently produced an unsigned bundle would be rejected by the
+# play store with a much less obvious error, and an unsigned apk on the github
+# release would not install at all. Release variants build unsigned rather than
+# failing when the credentials are absent (see app/build.gradle), which is what
+# makes this worth checking rather than assuming.
+#
+# Takes the directory to look under, app/build/outputs by default:
+#
+#   .github/scripts/verify-signed.sh
+#
+set -uo pipefail
+shopt -s nullglob
+
+outputs="${1:-app/build/outputs}"
+
+fail() {
+    if [ -n "${GITHUB_ACTIONS:-}" ]; then
+        echo "::error::$1"
+    else
+        echo "$1" >&2
+    fi
+    exit 1
+}
+
+bundles=("$outputs"/bundle/*/*.aab)
+apks=("$outputs"/apk/*/release/*.apk)
+
+# nullglob turns an unmatched pattern into nothing at all, so the loops below
+# would pass an empty build without a word. Verifying nothing has to be the
+# failure it is: that is the state a wrong path leaves this in
+[ ${#bundles[@]} -gt 0 ] || fail "no bundles under $outputs/bundle - nothing was verified"
+[ ${#apks[@]} -gt 0 ] || fail "no apks under $outputs/apk - nothing was verified"
+
+for aab in "${bundles[@]}"; do
+    # an aab is not an apk and apksigner cannot read one; a bundle carries the
+    # jar signature the store expects, which does show up in the zip listing.
+    # read once into a variable rather than piped into grep -q: -q stops at the
+    # first match, and the SIGPIPE that leaves unzip with would fail the pipeline
+    # under pipefail whenever it had not finished writing yet - which is a signed
+    # bundle reported as unsigned, sometimes
+    if ! listing=$(unzip -l "$aab" 2>&1); then
+        fail "$aab cannot be read as a zip: $listing"
+    fi
+    if ! grep -qE " META-INF/[^/]+\.(RSA|DSA)$" <<< "$listing"; then
+        fail "$aab is not signed"
+    fi
+    echo "signed: $aab"
+done
+
+# the apks take apksigner rather than the same grep: from minSdk 24 up agp leaves
+# v1 signing off, so there is no META-INF/*.RSA to find and the signature sits in
+# a block the zip listing does not show
+apksigner=$(find "${ANDROID_HOME:-}/build-tools" -maxdepth 2 -name apksigner -type f 2>/dev/null | sort -V | tail -1)
+[ -n "$apksigner" ] || fail "found no apksigner under ${ANDROID_HOME:-\$ANDROID_HOME}/build-tools"
+
+for apk in "${apks[@]}"; do
+    # what apksigner said goes into the message: it exits non-zero both for an
+    # unsigned apk and for not being able to run at all, and "not signed" is a
+    # bad way to learn that the runner has no java
+    if ! output=$("$apksigner" verify "$apk" 2>&1); then
+        fail "$apk did not verify: ${output:-apksigner said nothing}"
+    fi
+    echo "signed: $apk"
+done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,26 +104,37 @@ jobs:
       id: version
       env:
         given: ${{ inputs.version }}
+        tag: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
       run: |
-        version="$given"
-        if [ -z "$version" ] && [ "${{ github.ref_type }}" = "tag" ]; then
-          version="${{ github.ref_name }}"
+        # on a tag the tag is the version, and an input saying otherwise is a mistake
+        # rather than an override: the attach job puts the built apk on the release of
+        # this very tag, so a run that built something else would clobber that release
+        # with an apk whose version is not the one it is filed under
+        if [ -n "$tag" ] && [ -n "$given" ] && [ "${given#v}" != "${tag#v}" ]; then
+          echo "::error::the version input ($given) is not the tag this ran on ($tag). leave it blank to build the tag."
+          exit 1
         fi
+
+        version="${tag:-$given}"
         if [ -z "$version" ]; then
+          # nothing to go on: only the dry run can carry on, on gradle's unversioned
+          # fallback. anything else would build a version code the store refuses,
+          # after the six minutes it takes to get there
           if [ "${{ env.uploads }}" != "none" ]; then
             echo "::error::nothing to take a version from. push this as a v* tag, dispatch it on one, or fill in the version input."
             exit 1
           fi
-          version="0.0.0"
-        fi
-        # the same shape app/build.gradle accepts, checked here so a typo fails in
-        # seconds rather than after the conan and gradle setup
-        if ! echo "$version" | grep -qE '^v?[0-9]{1,2}(\.[0-9]{1,2}){0,2}$'; then
-          echo "::error::'$version' is not a version: expected something like v4.8.0, each part below 100"
-          exit 1
+          echo "no version given - building gradle's unversioned fallback"
+        else
+          # the same shape app/build.gradle accepts, checked here so a typo fails in
+          # seconds rather than after the conan and gradle setup
+          if ! echo "$version" | grep -qE '^v?[0-9]{1,2}(\.[0-9]{1,2}){0,2}$'; then
+            echo "::error::'$version' is not a version: expected something like v4.8.0, each part below 100"
+            exit 1
+          fi
+          echo "building $version"
         fi
         echo "version=$version" >> "$GITHUB_OUTPUT"
-        echo "building $version"
 
     - name: checkout
       uses: actions/checkout@v4
@@ -240,10 +251,14 @@ jobs:
         ODR_KEYSTORE_PASSWORD: ${{ secrets.ODR_KEYSTORE_PASSWORD }}
         ODR_KEY_PASSWORD_PRO: ${{ secrets.ODR_KEY_PASSWORD_PRO }}
         ODR_KEY_PASSWORD_LITE: ${{ secrets.ODR_KEY_PASSWORD_LITE }}
+        version: ${{ steps.version.outputs.version }}
       run: |
+        # left out entirely when there is no version, rather than passed as 0.0.0:
+        # gradle's fallback is that name with a version code of 1, since AGP refuses
+        # the 0 the name itself would derive to
         ./gradlew bundleProRelease bundleLiteRelease \
                   assembleProRelease assembleLiteRelease \
-                  -Podr.version="${{ steps.version.outputs.version }}" --stacktrace
+                  ${version:+-Podr.version=$version} --stacktrace
 
     # a release that silently produced an unsigned bundle would be rejected by
     # the play store with a much less obvious error, and an unsigned apk on the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ name: release
 # and release notes, and a release of one without the other is not a thing that
 # has ever been wanted.
 #
+# The version is the tag and nothing else. The repository holds no version number
+# at all any more - gradle takes it from the -Podr.version passed below, and turns
+# v4.8.0 into version code 40800, two digits per part. A dispatched run has no tag
+# to read, so it fills in the version input instead.
+#
 # Requires these repository secrets (see the "Release signing" section in the
 # README for what they mean):
 #   ODR_KEYSTORE_BASE64           base64 of google_play.keystore
@@ -45,6 +50,12 @@ on:
         type: choice
         options: [both, pro, lite, none]
         default: both
+      # a tag push needs nothing here: the tag is the version. this is for dispatched
+      # runs, which have no tag to read - finishing a half uploaded release off the
+      # branch it was cut from, or putting a real version on a dry run
+      version:
+        description: version to build, e.g. v4.8.0 - defaults to the tag
+        type: string
   push:
     tags:
       - 'v*'
@@ -83,6 +94,36 @@ jobs:
           echo "::error::missing repository secrets:$missing"
           exit 1
         fi
+
+    # the version is not in the checkout - it is the tag, handed to gradle below as
+    # -Podr.version. A dispatched run has no tag, so it has to say which version it is
+    # building; without one only a dry run is possible, since a build that fell back to
+    # 0.0.0 carries the version code an unversioned build gets, which the store would
+    # refuse - after the six minutes it takes to get there
+    - name: resolve version
+      id: version
+      env:
+        given: ${{ inputs.version }}
+      run: |
+        version="$given"
+        if [ -z "$version" ] && [ "${{ github.ref_type }}" = "tag" ]; then
+          version="${{ github.ref_name }}"
+        fi
+        if [ -z "$version" ]; then
+          if [ "${{ env.uploads }}" != "none" ]; then
+            echo "::error::nothing to take a version from. push this as a v* tag, dispatch it on one, or fill in the version input."
+            exit 1
+          fi
+          version="0.0.0"
+        fi
+        # the same shape app/build.gradle accepts, checked here so a typo fails in
+        # seconds rather than after the conan and gradle setup
+        if ! echo "$version" | grep -qE '^v?[0-9]{1,2}(\.[0-9]{1,2}){0,2}$'; then
+          echo "::error::'$version' is not a version: expected something like v4.8.0, each part below 100"
+          exit 1
+        fi
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+        echo "building $version"
 
     - name: checkout
       uses: actions/checkout@v4
@@ -201,7 +242,8 @@ jobs:
         ODR_KEY_PASSWORD_LITE: ${{ secrets.ODR_KEY_PASSWORD_LITE }}
       run: |
         ./gradlew bundleProRelease bundleLiteRelease \
-                  assembleProRelease assembleLiteRelease --stacktrace
+                  assembleProRelease assembleLiteRelease \
+                  -Podr.version="${{ steps.version.outputs.version }}" --stacktrace
 
     # a release that silently produced an unsigned bundle would be rejected by
     # the play store with a much less obvious error, and an unsigned apk on the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,32 +131,15 @@ jobs:
     - name: decode keystore
       run: echo "${{ secrets.ODR_KEYSTORE_BASE64 }}" | base64 -d > "${RUNNER_TEMP}/google_play.keystore"
 
-    # keytool reports the same two failures in a second, and tells them apart, which
-    # gradle does not: it wraps both in "Failed to read key <alias> from store". A
-    # -list only proves the store password, so the key passwords get their own check
-    # via -certreq, which needs the private key itself. Neither writes to the keystore.
+    # the script says why keytool rather than gradle gets to be the one that reports a
+    # bad password. it takes the same ODR_* variables the build takes, so the same
+    # check can be run against a keystore by hand
     - name: verify keystore
       env:
-        keystore_password: ${{ secrets.ODR_KEYSTORE_PASSWORD }}
-        key_password_pro: ${{ secrets.ODR_KEY_PASSWORD_PRO }}
-        key_password_lite: ${{ secrets.ODR_KEY_PASSWORD_LITE }}
-      run: |
-        keystore="${RUNNER_TEMP}/google_play.keystore"
-        if ! keytool -list -keystore "$keystore" -storepass "$keystore_password" > /dev/null; then
-          echo "::error::ODR_KEYSTORE_PASSWORD does not open the keystore, or ODR_KEYSTORE_BASE64 did not decode to it. A trailing newline in either secret is enough to do this."
-          exit 1
-        fi
-        # an unset key password falls back to the store one, the same way
-        # app/build.gradle resolves it
-        verify_key() {
-          if ! keytool -certreq -alias "$1" -keystore "$keystore" \
-              -storepass "$keystore_password" -keypass "${2:-$keystore_password}" > /dev/null; then
-            echo "::error::the $1 key cannot be used - check its key password secret"
-            exit 1
-          fi
-        }
-        verify_key reader-pro "$key_password_pro"
-        verify_key reader "$key_password_lite"
+        ODR_KEYSTORE_PASSWORD: ${{ secrets.ODR_KEYSTORE_PASSWORD }}
+        ODR_KEY_PASSWORD_PRO: ${{ secrets.ODR_KEY_PASSWORD_PRO }}
+        ODR_KEY_PASSWORD_LITE: ${{ secrets.ODR_KEY_PASSWORD_LITE }}
+      run: .github/scripts/verify-keystore.sh "${RUNNER_TEMP}/google_play.keystore"
 
     # written here rather than next to the upload, for the same reason the
     # keystore is decoded up front: a key the play store cannot be opened with
@@ -235,32 +218,10 @@ jobs:
 
     # a release that silently produced an unsigned bundle would be rejected by
     # the play store with a much less obvious error, and an unsigned apk on the
-    # release page would not install at all
+    # release page would not install at all. the script checks the same outputs
+    # against a local build
     - name: verify bundles and apks are signed
-      run: |
-        for aab in app/build/outputs/bundle/*/*.aab; do
-          if unzip -l "$aab" | grep -qE " META-INF/[^/]+\.(RSA|DSA)$"; then
-            echo "signed: $aab"
-          else
-            echo "::error::$aab is not signed"
-            exit 1
-          fi
-        done
-        # the apks take apksigner rather than the same grep: from minSdk 24 up
-        # agp leaves v1 signing off, so there is no META-INF/*.RSA to find and
-        # the signature sits in a block the zip listing does not show
-        apksigner=$(ls -1 "${ANDROID_HOME}"/build-tools/*/apksigner 2>/dev/null | sort -V | tail -1)
-        if [ -z "$apksigner" ]; then
-          echo "::error::found no apksigner under ${ANDROID_HOME}/build-tools"
-          exit 1
-        fi
-        for apk in app/build/outputs/apk/*/release/*.apk; do
-          if ! "$apksigner" verify "$apk" > /dev/null; then
-            echo "::error::$apk is not signed"
-            exit 1
-          fi
-          echo "signed: $apk"
-        done
+      run: .github/scripts/verify-signed.sh
 
     # ndk.debugSymbolLevel puts the symbols inside the bundle itself, under
     # BUNDLE-METADATA/com.android.tools.build.debugsymbols, so the play store

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,49 +95,22 @@ jobs:
           exit 1
         fi
 
-    # the version is not in the checkout - it is the tag, handed to gradle below as
-    # -Podr.version. A dispatched run has no tag, so it has to say which version it is
-    # building; without one only a dry run is possible, since a build that fell back to
-    # 0.0.0 carries the version code an unversioned build gets, which the store would
-    # refuse - after the six minutes it takes to get there
-    - name: resolve version
-      id: version
-      env:
-        given: ${{ inputs.version }}
-        tag: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
-      run: |
-        # on a tag the tag is the version, and an input saying otherwise is a mistake
-        # rather than an override: the attach job puts the built apk on the release of
-        # this very tag, so a run that built something else would clobber that release
-        # with an apk whose version is not the one it is filed under
-        if [ -n "$tag" ] && [ -n "$given" ] && [ "${given#v}" != "${tag#v}" ]; then
-          echo "::error::the version input ($given) is not the tag this ran on ($tag). leave it blank to build the tag."
-          exit 1
-        fi
-
-        version="${tag:-$given}"
-        if [ -z "$version" ]; then
-          # nothing to go on: only the dry run can carry on, on gradle's unversioned
-          # fallback. anything else would build a version code the store refuses,
-          # after the six minutes it takes to get there
-          if [ "${{ env.uploads }}" != "none" ]; then
-            echo "::error::nothing to take a version from. push this as a v* tag, dispatch it on one, or fill in the version input."
-            exit 1
-          fi
-          echo "no version given - building gradle's unversioned fallback"
-        else
-          # the same shape app/build.gradle accepts, checked here so a typo fails in
-          # seconds rather than after the conan and gradle setup
-          if ! echo "$version" | grep -qE '^v?[0-9]{1,2}(\.[0-9]{1,2}){0,2}$'; then
-            echo "::error::'$version' is not a version: expected something like v4.8.0, each part below 100"
-            exit 1
-          fi
-          echo "building $version"
-        fi
-        echo "version=$version" >> "$GITHUB_OUTPUT"
-
     - name: checkout
       uses: actions/checkout@v4
+
+    # the version is not in the checkout - it is the tag, handed to gradle below as
+    # -Podr.version. The script says which runs can build which version, and why;
+    # it is here, right behind the checkout it needs, because a run that cannot name
+    # a version should end before the six minutes of setup and building, not after
+    - name: resolve version
+      id: version
+      # through the environment rather than interpolated into the command: a tag name
+      # and a dispatch input are both strings from outside the workflow, and a run:
+      # line is the one place where that would be a shell injection
+      env:
+        tag: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+        given: ${{ inputs.version }}
+      run: .github/scripts/resolve-version.py --tag "$tag" --input "$given" --uploads "$uploads"
 
     - name: install ninja
       run: sudo apt-get install -y ninja-build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Configuration cache enabled for parallel Conan installs
 - Release signing credentials come from gradle properties or environment variables (see
   README); without them release variants build unsigned rather than failing
+- The version is the git tag, not a number in the tree. `AndroidManifest.xml` carries no
+  `versionCode`/`versionName`; `app/build.gradle` derives both from `-Podr.version`
+  (`v4.8.0` -> name `4.8.0`, code `40800`, two digits per part, parts above 99 are an
+  error), and a build handed no version is `0.0.0`. Do not put the attributes back in the
+  manifest: gradle's values win in the merged manifest, so a second copy can only ever
+  disagree with the tag. The release workflow passes the tag it ran on; a dispatched run
+  passes its `version` input
 
 ### Package names
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ half uploaded release - if one of the two lanes fails on its own the run cannot 
 be repeated, since the Play Store refuses a version code it has already accepted, so
 dispatch it again for the flavor that did not make it.
 
+A dispatched run has no tag to take the version from, so it either gets one in the
+`version` input or is a dry run; see below.
+
 It needs these repository secrets:
 
 | secret | contents |
@@ -76,8 +79,26 @@ unedited - base64 of it is accepted too, but nothing else is: the workflow check
 a `service_account` key before the build starts rather than letting fastlane trip over
 it once the build is done.
 
-Releasing from a laptop still works: `fastlane android deployPro` builds and uploads,
-and takes an optional `track:` (`fastlane android deployPro track:beta`). That reads the
-key from `fastlane_google_play.json` in the repository root, as the `Appfile` says.
+Releasing from a laptop still works: `fastlane android deployPro version:v4.8.0` builds
+and uploads, and takes an optional `track:` (`... track:beta`). The version can come from
+`ODR_VERSION` instead, but it cannot be left out - see below. That reads the key from
+`fastlane_google_play.json` in the repository root, as the `Appfile` says.
 
-Remember to raise `versionCode` in `app/src/main/AndroidManifest.xml` before tagging.
+## Versioning
+
+The version is the git tag, and no version number is checked in anywhere. The release
+workflow hands the tag it was triggered by to gradle as `-Podr.version`, and
+`app/build.gradle` derives both halves of it: `v4.8.0` becomes version name `4.8.0` and
+version code `40800`, two digits per part. Every part therefore has to stay below 100,
+which the build refuses rather than folding `4.100.0` onto the same code as `5.0.0`.
+Nothing has to be raised by hand before tagging, and no number on `main` can describe a
+release that already went out.
+
+Builds handed no version - local ones, PR builds, `assembleProDebug` - are `0.0.0`.
+Nothing reads it: no code in the app looks at its own version, and only what the release
+workflow builds ever leaves the machine. Any build can be given a real one anyway, with
+`./gradlew assembleProRelease -Podr.version=v4.8.0`.
+
+Version codes up to 204 were counted by hand in `AndroidManifest.xml`, which is why the
+first derived one is a five digit jump. That is one way: the Play Store only ever accepts
+a code above the last one it saw.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ be repeated, since the Play Store refuses a version code it has already accepted
 dispatch it again for the flavor that did not make it.
 
 A dispatched run has no tag to take the version from, so it either gets one in the
-`version` input or is a dry run; see below.
+`version` input or is a dry run; see below. Dispatched on a tag it is the tag that
+counts, and the input may only repeat it: the APK a run produces is attached to the
+release of the tag it ran on, so a run that built some other version would file it
+there under the wrong one.
 
 It needs these repository secrets:
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,6 +30,46 @@ def releaseKeyPasswordPro = signingSetting('odr.keyPasswordPro', 'ODR_KEY_PASSWO
 def releaseKeyPasswordLite = signingSetting('odr.keyPasswordLite', 'ODR_KEY_PASSWORD_LITE')
 def hasReleaseSigning = releaseKeystore.isPresent() && releaseKeystorePassword.isPresent()
 
+// The version is the tag, and lives nowhere in the tree. A number checked in on main
+// describes either a release that already went out or a guess at the next one, so it is
+// wrong almost all of the time, and versionCode and versionName had to be walked forward
+// together by hand. The release workflow passes the tag it was triggered by as
+// -Podr.version (ODR_VERSION works too, the way the signing settings above take either).
+//
+// Everything else - a local build, a PR build, a dry run - is 0.0.0, which nothing reads:
+// no code in the app looks at its own version, and only what the release workflow builds
+// is ever uploaded anywhere.
+def parseVersion = { String version ->
+    // split rather than tokenize, which would swallow the empty part in '4..8'
+    def parts = (version - ~/^v/).split('\\.', -1) as List
+    if (parts.isEmpty() || parts.size() > 3 || !parts.every { it ==~ /\d+/ }) {
+        throw new GradleException(
+                "odr.version must look like 4.8 or v4.8.0, not '${version}'")
+    }
+    def numbers = parts*.toInteger()
+    while (numbers.size() < 3) {
+        numbers << 0
+    }
+    // two digits per component: v4.8.0 is 40800. That is a one way step past the codes
+    // that used to be counted by hand (204 and below) - the play store accepts a higher
+    // code than the last one it saw and never a lower one.
+    if (numbers.any { it > 99 }) {
+        // silently carrying would make 4.100.0 and 5.0.0 the same code, and a collision
+        // is only discoverable once the store rejects the upload
+        throw new GradleException("every part of '${version}' has to be below 100 for the " +
+                "two-digits-per-part version code to stay unambiguous")
+    }
+    [name: numbers.join('.'), code: numbers[0] * 10000 + numbers[1] * 100 + numbers[2]]
+}
+def requestedVersion = providers.gradleProperty('odr.version')
+        .orElse(providers.environmentVariable('ODR_VERSION'))
+        .filter { !it.isEmpty() }
+// spelled out rather than parsed from '0.0.0', because the formula would make that
+// version code 0 and AGP insists on a positive one
+def appVersion = requestedVersion.isPresent()
+        ? parseVersion(requestedVersion.get())
+        : [name: '0.0.0', code: 1]
+
 android {
     ndkVersion = "28.2.13676358"
 }
@@ -74,6 +114,12 @@ android {
         applicationId = "at.tomtasche.reader"
         minSdk = 26
         targetSdk = 36
+
+        // derived from the tag above, and set here rather than in AndroidManifest.xml:
+        // both spellings end up in the merged manifest, and this one wins, so keeping
+        // the attributes there too would only leave a second number to disagree with
+        versionCode = appVersion.code
+        versionName = appVersion.name
 
         // likewise an applicationId, for the test apk. never published, so it is only
         // pinned here to keep it from drifting with the namespace.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,8 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:installLocation="auto"
-    android:versionCode="204"
-    android:versionName="4.8.0"
     tools:ignore="GoogleAppIndexingWarning">
 
     <uses-permission android:name="android.permission.INTERNET" />

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,13 +11,13 @@ DEFAULT_TRACK = "internal".freeze
 platform :android do
   desc "Build and upload the Pro version to Google Play"
   lane :deployPro do |options|
-    buildBundle(flavor: "Pro")
+    buildBundle(flavor: "Pro", version: options[:version])
     uploadBundle(flavor: "Pro", track: options[:track])
   end
 
   desc "Build and upload the Lite version to Google Play"
   lane :deployLite do |options|
-    buildBundle(flavor: "Lite")
+    buildBundle(flavor: "Lite", version: options[:version])
     uploadBundle(flavor: "Lite", track: options[:track])
   end
 
@@ -37,8 +37,25 @@ platform :android do
   end
 
   private_lane :buildBundle do |options|
+    # there is no version number in the repository - it is the git tag, so a build
+    # started by hand has to say which one it is producing. Left out, gradle would fall
+    # back to 0.0.0, and the store would refuse that version code once the whole build
+    # and upload had already run
+    version = options[:version] || ENV["ODR_VERSION"]
+    if version.to_s.empty?
+      UI.user_error!("no version to build. pass one as version:v4.8.0, or set ODR_VERSION")
+    end
+
     gradle(task: "clean")
-    gradle(task: "bundle", flavor: options[:flavor], build_type: "Release")
+    gradle(
+      task: "bundle",
+      flavor: options[:flavor],
+      build_type: "Release",
+      # as a property rather than an environment variable: the gradle daemon captures
+      # its environment when it starts, so an ODR_VERSION exported afterwards is not
+      # necessarily the one an already running daemon would read
+      properties: { "odr.version" => version }
+    )
   end
 
   private_lane :uploadBundle do |options|


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

`versionCode` and `versionName` lived in `AndroidManifest.xml` and had to be raised by hand before tagging. Between releases that number is wrong: it describes a release that already went out, or guesses the next one. Forgetting it only surfaces at the very end of a release run, as `Version code 203 has already been used` — six minutes in, and unrepeatable, since the upload step failing takes the `attach` job with it.

The tag is the one place a version cannot be stale: it does not exist until the version is true. So the repository now carries no version number at all.

## What changes

- `app/build.gradle` derives both halves from `-Podr.version` (or `ODR_VERSION`): `v4.8.0` → name `4.8.0`, code `40800`, two digits per part. `v4.8` and `4.8.0` are accepted too.
- A part above 99 is a build error, not a silently folded code — `4.100.0` and `5.0.0` would both be `50000`.
- The two attributes come out of `AndroidManifest.xml`. Nothing replaces them there: both spellings reach the merged manifest and the gradle one wins, so a second copy could only ever disagree with the tag.
- The release workflow passes the tag it ran on. A dispatched run has no tag, so it takes a `version` input — which is also how a half-uploaded release gets finished off the branch it was cut from. Without either, it can only be a dry run, and says so before the build rather than after it.
- `fastlane android deployPro version:v4.8.0` for the laptop path, as a gradle property rather than an env var, since the daemon captures its environment at startup.

## Version codes jump to five digits

Codes up to 204 were counted by hand, so the first derived one is `40800`. That is one way — Play only ever accepts a code above the last one it saw.

## Unversioned builds

A build handed no version is `0.0.0`. Nothing reads it: no code in the app looks at its own version, and only what the release workflow builds is ever uploaded. Its code is spelled out as `1` rather than derived, because AGP rejects `0` (`versionCode is set to 0, but it should be a positive integer`).

## F-Droid

This drops the `versionCode` that F-Droid's `UpdateCheckData` greps out of the manifest, so their auto-update stops finding releases. Their metadata needs rewriting regardless: the build recipe seds `.java` files under `at/tomtasche/reader/`, which the kotlin migration and the package rename removed, and the listing has been stuck at 4.3 since December. Worth a follow-up MR to fdroiddata either way.

## Verified locally

- merged manifest for `-Podr.version=v4.8.0` → `versionCode="40800"`, `versionName="4.8.0-pro"`; `v4.9.1` via `ODR_VERSION` → `40901`; no version → `1` / `0.0.0-pro`
- rejected as expected: `v4.100.0`, `lol`, `v4.8.0.1`, `4..8`
- `spotlessCheck`, `testProDebugUnitTest`, `lintProDebug` all pass (no `MissingVersion` finding)

Does not touch the other half of the problem — the upload step is still not idempotent, so a duplicate code still fails the run and skips `attach`. That is a separate change.