### PR TITLE
Hold on to a grant until the recent list names it

### DIFF
--- a/app/src/main/java/app/opendocument/droid/background/PersistedUriPermissions.kt
+++ b/app/src/main/java/app/opendocument/droid/background/PersistedUriPermissions.kt
@@ -17,12 +17,32 @@ object PersistedUriPermissions {
     private const val READ_FLAG = Intent.FLAG_GRANT_READ_URI_PERMISSION
 
     /**
+     * The grants taken during this process that the recent list does not name yet.
+     *
+     * Taking a grant and writing down what needs it are not one step: a document only reaches the
+     * list once [MetadataLoader] has read it, which is long after [takeRead] ran - `loadUri` merely
+     * queues the load. A [prune] in that window would enumerate the fresh grant, find nothing
+     * referring to it and hand it straight back, leaving the entry that is about to be written
+     * unreadable on the next launch - the very failure releasing on close used to cause.
+     *
+     * Empty on a fresh process, so a grant whose document never made it onto the list is reclaimed
+     * on the next launch rather than leaking for good.
+     */
+    private val pendingGrants = HashSet<String>()
+
+    /**
      * Takes a persistable read permission for [uri].
      *
      * @return whether a persisted grant is held afterwards. False for providers that do not offer
      *   persistable permissions at all, and for uris that did not arrive on an intent of ours.
      */
     fun takeRead(context: Context, uri: Uri): Boolean {
+        // marked before the grant exists rather than after, so there is no instant in which a
+        // concurrent prune could enumerate it while nothing speaks for it. a uri that turns out not
+        // to be persistable is left in the set: we are reading it either way, and if an earlier
+        // session did persist it, that grant is exactly the one to hold on to
+        markPending(uri.toString())
+
         return try {
             context.contentResolver.takePersistableUriPermission(uri, READ_FLAG)
 
@@ -63,14 +83,21 @@ object PersistedUriPermissions {
      * Does file and binder work, so it must not run on the main thread.
      */
     fun prune(context: Context) {
+        // the three reads are in this order on purpose. a grant taken while this runs is either
+        // missing from the snapshot, or still pending when the pending set is read - which happens
+        // after the list that would have settled it, so it cannot fall through both
+        val held = context.contentResolver.persistedUriPermissions
+
         val keep = HashSet<String>()
         for (entry in RecentDocumentsUtil.getRecentDocuments(context)) {
             keep.add(entry.uri)
         }
 
-        for (permission in context.contentResolver.persistedUriPermissions) {
-            val held = permission.uri.toString()
-            if (held in keep) {
+        keep.addAll(settlePending(keep))
+
+        for (permission in held) {
+            val uri = permission.uri.toString()
+            if (uri in keep) {
                 continue
             }
 
@@ -89,5 +116,22 @@ object PersistedUriPermissions {
                 // nothing to do about it, and it will be retried on the next launch
             }
         }
+    }
+
+    /** Remembers a grant until the recent list names it. */
+    @Synchronized
+    internal fun markPending(uri: String) {
+        pendingGrants.add(uri)
+    }
+
+    /**
+     * Drops the pending grants [keep] has caught up with - those are reclaimable the ordinary way
+     * from now on - and hands back the ones whose document is still on its way onto the list.
+     */
+    @Synchronized
+    internal fun settlePending(keep: Set<String>): Set<String> {
+        pendingGrants.removeAll(keep)
+
+        return HashSet(pendingGrants)
     }
 }

--- a/app/src/test/java/app/opendocument/droid/background/PersistedUriPermissionsTest.kt
+++ b/app/src/test/java/app/opendocument/droid/background/PersistedUriPermissionsTest.kt
@@ -1,0 +1,34 @@
+package app.opendocument.droid.background
+
+import org.junit.Assert
+import org.junit.Test
+
+/**
+ * Covers the bookkeeping that keeps a grant alive between taking it and the recent list naming it.
+ * Taking and releasing the grants themselves needs a content resolver, so that part is device work.
+ */
+class PersistedUriPermissionsTest {
+
+    @Test
+    fun keepsAGrantUntilTheListNamesIt() {
+        val uri = "content://com.google.android.apps.docs.storage/document/acc%3D1%3Bdoc%3D5"
+
+        PersistedUriPermissions.markPending(uri)
+
+        // the document is still being read, so nothing on disk points at the grant yet
+        Assert.assertTrue(uri in PersistedUriPermissions.settlePending(emptySet()))
+
+        // and once the entry is written, the ordinary reconciliation takes over
+        Assert.assertFalse(uri in PersistedUriPermissions.settlePending(setOf(uri)))
+        Assert.assertFalse(uri in PersistedUriPermissions.settlePending(emptySet()))
+    }
+
+    @Test
+    fun leavesGrantsItDidNotTakeAlone() {
+        // what an earlier process left behind is nobody's in flight document, and prune reclaiming
+        // those is the whole point of reconciling rather than bookkeeping every removal
+        val leaked = "content://com.android.providers.downloads.documents/document/17"
+
+        Assert.assertFalse(leaked in PersistedUriPermissions.settlePending(emptySet()))
+    }
+}


### PR DESCRIPTION
Follow-up to #523, from the automated review on it.

`loadUri` takes the grant and `MetadataLoader` writes the recent entry — one queues the load, the other runs once the document has been read, so there is a gap between them where the grant is held and nothing on disk refers to it. `MainActivity` starts `prune()` on its own thread in `onCreate` and takes the grant in `onStart`, so a document opened from another app races the two.

Losing that race releases the grant of the document being loaded right then. The load still succeeds on the transient grant that arrived with the intent and the entry lands in the recent list, so nothing looks wrong until the next launch, where the entry is unreadable — the failure #523 set out to fix, reached through a narrower window.

Grants taken during a process are now held until one of the stored lists names them:

- `takeRead` marks the uri before the grant exists, so there is no instant where a concurrent `prune` could enumerate it while nothing speaks for it.
- `prune` reads the permissions, then the list, then the pending set. A grant taken while it runs is either missing from the permission snapshot or still pending when that is read, and cannot fall through both.
- The set is empty on a fresh process, so a grant whose document never reached the list is still reclaimed on the next launch instead of leaking.

The other comment on #523 — that `prune` releases the tree grant a browsed document depends on — does not apply: `keep` takes in the folder list as well as the recent list, and a tree grant is only released once the folder itself is gone.

### Verification
- `testProDebugUnitTest` — two cases over the hand-off between marking and settling
- `spotlessCheck` and `lintProDebug` clean

The race is a thread interleaving, so it is not assertable on device; the reasoning above is what stands in for it.