### PR TITLE
Keep the room database constructor r8 full mode strips

### DIFF
--- a/app/proguard-rules.txt
+++ b/app/proguard-rules.txt
@@ -29,6 +29,18 @@
 # shows up in minified builds, at runtime, as a null field id or a NoSuchMethodError.
 -keep class app.opendocument.core.** { *; }
 
+# play-services-ads drags in androidx.work 2.7, whose WorkDatabase is a room database
+# built on room 2.2.5, and androidx.startup instantiates it on every cold start whether
+# the app uses WorkManager or not. room 2.2.5 ships '-keep class * extends
+# androidx.room.RoomDatabase' without a member spec, and r8 in full mode - the default
+# since AGP 8 - reads that as "keep the class, the members are fair game", so it drops
+# WorkDatabase_Impl's no-arg constructor. room then calls Class.newInstance() on it and
+# the process dies at startup with "Failed to create an instance of
+# androidx.work.impl.WorkDatabase". room only fixed its own rule in 2.7.0; this is that
+# rule, and it can go once work-runtime pulls room that far (work 2.11 does, 2.10 still
+# lands on room 2.6.1 with the broken one).
+-keep class * extends androidx.room.RoomDatabase { <init>(); }
+
 -keepattributes *Annotation*
 -keepattributes SourceFile,LineNumberTable
 -keep public class * extends java.lang.Exception


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

4.8.0 dies on launch, before `MainActivity` ever runs:

```
java.lang.RuntimeException: Unable to get provider androidx.startup.InitializationProvider
Caused by: androidx.startup.StartupException: java.lang.RuntimeException:
           Failed to create an instance of androidx.work.impl.WorkDatabase
    at androidx.work.WorkManagerInitializer.create(...)
```

The app has nothing to do with WorkManager. `play-services-ads` pulls
`androidx.work:work-runtime:2.7.0` in through `play-services-ads-api`, and its
manifest registers `WorkManagerInitializer` with `androidx.startup`, so its room
database is built on every cold start regardless.

Dumping the dex out of the published apk shows `androidx.work.impl.WorkDatabase_Impl`
present and unrenamed, with its seven virtual methods and **no direct methods at all** -
r8 dropped the no-arg constructor. work 2.7.0 sits on room 2.2.5, which instantiates the
implementation with `Class.newInstance()`, and that throws `InstantiationException`
exactly when there is no nullary constructor; room turns it into the message above.

The reason it gets dropped: room 2.2.5 ships `-keep class * extends
androidx.room.RoomDatabase` with no member spec, and r8 in full mode - the default since
AGP 8 - reads that as "keep the class, the members are fair game". Room only fixed its
own rule in 2.7.0 (`{ void <init>(); }` in `room-runtime-android`); everything through
2.6.1 still ships the broken one.

So the rule is asked for by hand here, with a note saying when it can go.

### Why not just update room

Bumping room alone is not on: work 2.7.0's `WorkDatabase_Impl` was generated against room
2.2.5, and 2.7 is the kotlin/kmp rewrite. Getting the fixed rule means moving
work-runtime, and only 2.11.0 lands on room 2.7.0 - 2.10.5 still pins room-ktx 2.6.1.
That route was tried: with a constraint on work 2.11.0 and this rule removed the build
works, `WorkDatabase_Impl` keeps its constructor from room's own rule, and the apk grows
69 KB. It is the better long term answer and can happen on its own, but overriding a
transitive version the ads sdk was tested against is not what a launch-crash fix should
be doing.

### Verified

- pro release built, dex dumped: `WorkDatabase_Impl` now has `<init>()V` under direct methods
- signed with a debug key, installed on a Pixel 9 Pro next to the crashing beta, launched:
  process stays up, `MainActivity` resumes, the landing screen renders and the core loads
  (`CoreLoader: odrcore 5.7.1`), no exceptions in the log