### PR TITLE
Take the empty toolbar off the screen

### DIFF
--- a/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
@@ -177,7 +177,13 @@ class MainActivity : AppCompatActivity(), MenuProvider {
             WindowInsetsCompat.CONSUMED
         }
 
-        title = ""
+        // nothing lives in the toolbar any more - the landing screen has its own header and the
+        // document its buttons - so the bar would just be an empty strip of colour. Hiding it
+        // rather than moving to a .NoActionBar theme keeps it as the host the action modes are
+        // raised in: appcompat shows the container again for as long as one is up, and takes it
+        // back down afterwards, so find, tts and edit still get their bar without the app
+        // having to put one on screen itself.
+        supportActionBar?.hide()
 
         onBackPressedDispatcher.addCallback(this, backCallback)
 
@@ -480,8 +486,6 @@ class MainActivity : AppCompatActivity(), MenuProvider {
                         WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
                     insetsController.hide(WindowInsetsCompat.Type.statusBars())
 
-                    supportActionBar?.hide()
-
                     // delay offer to wait for fullscreen animation to finish
                     handler.postDelayed(
                         {
@@ -590,8 +594,6 @@ class MainActivity : AppCompatActivity(), MenuProvider {
         if (!fullscreen) {
             return
         }
-
-        supportActionBar?.show()
 
         WindowCompat.getInsetsController(window, window.decorView)
             .show(WindowInsetsCompat.Type.statusBars())

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -6,8 +6,13 @@
         have to add what is specific to them. Copying the whole theme per qualifier is what let
         the colours drift apart before.
 
-        Not a .NoActionBar variant: there is no Toolbar view anywhere, the app relies on the
-        default ActionBar and drives it through supportActionBar / startSupportActionMode.
+        Not a .NoActionBar variant, even though no screen puts anything in the bar any more:
+        the ActionBar's container is what startSupportActionMode() raises find, tts and edit
+        in, and appcompat only shows it for as long as one of them is up. MainActivity hides
+        the bar itself on start, so the container is off screen the rest of the time and the
+        window inset math stays the one ActionBarOverlayLayout does - which a NoActionBar
+        theme would swap for a decor that pads itself, on top of the padding MainActivity
+        applies.
     -->
     <style name="Base.MainTheme" parent="Theme.Material3.DayNight">
         <item name="colorPrimary">@color/md_primary</item>


### PR DESCRIPTION
Last one in the stack, and the one that makes the rest of it look finished: after the open action, the ad removal and the document buttons all moved out of the options menu, the toolbar is an empty strip of colour at the top of every screen.

It cannot just be deleted, because it is also where the action modes live. `find`, `tts` and `edit` are raised with `startSupportActionMode()`, and appcompat puts those in the ActionBar's own container in place of the toolbar. So instead of a `.NoActionBar` theme, `MainActivity` hides the bar on start, and appcompat brings the container back on its own for as long as a mode is up - `checkShowingFlags()` shows it whenever an action mode is showing, whatever the app asked for.

That also keeps the window insets as they are. `ActionBarOverlayLayout` holds the system bar insets off the content and reports the toolbar's height onwards as an inset of its own, which is what `MainActivity`'s listener pads `main_root` with: the find bar pushes the page down by exactly its own height, and nothing is padded while no mode is up. A `NoActionBar` theme swaps that decor for a `FitWindowsLinearLayout`, which pads itself by the system bars on top of the padding `MainActivity` already applies.

The fullscreen `hide()`/`show()` pair goes with it - with the bar hidden for good there is nothing to toggle, and `show()` would have put the empty bar back on leaving fullscreen.

## Checked on a Pixel 6 Pro (API 36)

- landing screen and open document: no bar, content starts at the status bar
- search: the find bar slides in below the status bar and pushes the page down
- edit: same, with its own title and save button
- leaving either: the bar goes away again

`./gradlew spotlessCheck lintProDebug testProDebugUnitTest` clean, and all 20 instrumented tests pass on the emulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)