### PR TITLE
Upload only to internal and promote in the console

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,10 @@ name: release
 # Releases used to be built and uploaded from a maintainer laptop, which was the
 # only machine holding the keystore. This does the same steps in CI:
 #   1. build the signed lite and pro bundles and apks with gradle
-#   2. hand the bundles to fastlane, which uploads them to the play store
+#   2. hand the bundles to fastlane, which uploads them to the play store's
+#      internal track, and only ever that one. a wider track is a promotion in
+#      the play console, which moves the very bundle that was tested rather than
+#      uploading a second one, and is where the release notes are written anyway
 #   3. on a tag, attach the signed pro apk to that tag's github release, which
 #      every release up to v4.6 carried and the laptop build produced by hand.
 #      the release has to exist already. this is a second job, so that it can
@@ -35,11 +38,6 @@ name: release
 on:
   workflow_dispatch:
     inputs:
-      track:
-        description: play store track
-        type: choice
-        options: [internal, alpha, beta, production]
-        default: internal
       # both flavors are always built and archived - this is only about what
       # leaves the run. none is the dry run: build everything, publish nothing.
       # pro or lite finishes a half uploaded release, which is otherwise a dead
@@ -69,9 +67,6 @@ permissions:
 
 env:
   ndk_version: 28.2.13676358
-  # tag pushes go to the internal track, same as the manual lanes always did.
-  # anything wider has to be dispatched deliberately.
-  track: ${{ inputs.track || 'internal' }}
   uploads: ${{ inputs.uploads || 'both' }}
 
 jobs:
@@ -256,8 +251,11 @@ jobs:
           lite) lanes="uploadLite" ;;
           *)    lanes="uploadPro uploadLite" ;;
         esac
+        # no track: the Fastfile's DEFAULT_TRACK is internal, and this workflow
+        # has no way of naming another one. everything wider is a promotion in
+        # the play console
         for lane in $lanes; do
-          bundle exec fastlane android "$lane" track:"${{ env.track }}"
+          bundle exec fastlane android "$lane"
         done
 
     - name: drop credentials

--- a/README.md
+++ b/README.md
@@ -53,7 +53,13 @@ from a laptop. It also builds the signed Pro APK and attaches it to the GitHub r
 of that tag, which has to exist already - the workflow does not create one, it fails
 instead. That APK is the sideloadable copy every release up to v4.6 carried, and both APKs are
 archived on the run itself. Both flavors always go out together. Running the workflow
-manually additionally allows picking the track and what to publish.
+manually additionally allows picking what to publish.
+
+Internal is the only track it uploads to. Anything wider - closed, open, production -
+is a promotion in the Play Console, which moves the same bundle and version code that
+was tested onto the wider track instead of uploading a second one, and is where the
+release notes get written. It is also where the review that a production release waits
+on actually happens, so the workflow finishing is not the same as the release being out.
 
 That last one, `uploads`, defaults to `both`. `none` is a dry run: everything gets
 built, signed and attached to the run, nothing leaves it. `pro` or `lite` finishes a


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

The release workflow could be dispatched with `track: production`, which uploads straight to a track that ships. Nothing about that is safer than promoting the internal release in the Play Console: promotion moves the same bundle and version code that was actually installed and tested, rather than pushing a second upload nobody has run. It is also where the release notes are written either way — `uploadBundle` passes `skip_upload_changelogs: true`, and `fastlane/metadata/android/*/changelogs/` stops at `137.txt` while we are on version code 40800.

So the `track` input is gone, and with it the `env.track` that carried it. Both lanes are now called without a track and land on the Fastfile's `DEFAULT_TRACK`, which is `internal`. The workflow has no way of naming another track at all, which is the point.

`fastlane android deployPro track:beta` still works from a laptop, for the same reason it always did — the Fastfile keeps the parameter.

Also spells out in the README that the workflow finishing is not the same as the release being out: the review a production release waits on happens at promotion time, not at upload.