### PR TITLE
Fail the upload when the converter returns no document

### DIFF
--- a/app/src/main/java/app/opendocument/droid/background/OnlineLoader.kt
+++ b/app/src/main/java/app/opendocument/droid/background/OnlineLoader.kt
@@ -98,7 +98,16 @@ class OnlineLoader(context: Context?, private val coreLoader: CoreLoader) :
             }
         }
 
+        // a converted document is answered with a redirect to it, so a response without a Location
+        // is the server refusing the file - concatenating the missing header would build a
+        // "...appnull" url that only fails later, inside the webview
+        val responseCode = connection.responseCode
         val redirectUrl = connection.getHeaderField("Location")
+        if (redirectUrl.isNullOrEmpty()) {
+            val error = readError(connection)
+            throw IOException("server couldn't handle request: $responseCode $error")
+        }
+
         return Uri.parse(basePath + redirectUrl)
     }
 


### PR DESCRIPTION
## What

`doOnlineConvert` read the `Location` header without checking it was there:

```kotlin
val redirectUrl = connection.getHeaderField("Location")
return Uri.parse(basePath + redirectUrl)
```

`use.opendocument.app` answers a converted document with a redirect to it, so when it *refuses* a file there is no `Location`, `getHeaderField` returns `null`, and the null goes straight into the concatenation. The loader then reported **success** for the uri `https://use.opendocument.appnull/`.

## How it shows up

Opening a truncated `.odt` on an emulator:

```
D/ODR      CORE failed
E/ODR      app.opendocument.core.OdrException: not a zip file
I/smn      loader_error_CORE
...user accepts the "upload this file?" offer...
I/smn      loader_success_ONLINE content_type content
E/ODR      java.lang.RuntimeException: loading https://use.opendocument.appnull/ failed:
           -2 net::ERR_NAME_NOT_RESOLVED
```

Two things go wrong: the user gets a WebView DNS error page rather than the "could not open" dialog and the offer to reopen, and the log line blames DNS instead of the server refusing the document.

## The fix

Treat a missing `Location` the way `doTransferUpload` already treats an empty body — throw an `IOException` carrying the response code and the error body, so `loadSync` routes it through `callOnError`.

The guard is on the header rather than on the status code alone, so a `2xx`-with-`Location` response keeps working; the code is included for diagnostics.

## Notes

The file that surfaced this is genuinely corrupt — it carries two end-of-central-directory records, and the authoritative last one points at offset 24822, which is zeros, while the real central directory sits at 24089. `unzip` rejects it too, so the core's `not a zip file` is correct and unchanged here. This PR is only about the fallback path lying about having succeeded.

The bug predates the Kotlin conversion; the pre-conversion Java had the identical two lines.

Not covered by a unit test: `doOnlineConvert` is private, needs a live `HttpURLConnection`, and `Uri.parse` needs a real Android runtime — the existing `OnlineLoaderTest` only exercises the pure `isSupported`/`isConvertible` predicates, and there is no MockWebServer/Robolectric setup to hang a test on.

## Test plan

- [x] `./gradlew spotlessCheck testProDebugUnitTest` — green