### PR TITLE
Ask odrcore which formats it has instead of listing them here

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,14 @@ and not JVM ones - none of them opens a file, they just cannot ask the table fro
 JVM. What the core decides *after* the file is in the cache is unchanged: `MetadataLoader`
 runs libmagic over the copy, and `CoreLoader.isDocumentEditable` asks the opened document.
 
+One consequence of claiming every spelling: `MetadataLoader` puts whatever mime type it ended
+up with through `SupportedDocumentTypes.canonicalMimeType`, so the loaders behind it see one
+per format. `CoreLoader` matches the whole set and does not care, but `RawLoader` routes by
+mime type *prefix* - a provider volunteering `application/x-zip-compressed` or
+`application/csv` would be offered the app and then told the file is unsupported.
+`SupportedFormatsTest.everythingTheAppClaimsIsLoadedBySomebody` is what holds that: every mime
+type the app claims has to reach a loader that takes it.
+
 ### Editability comes from the core, never from a mime type
 
 `Document.isEditable()`/`isSavable()` is what decides whether `DocumentFragment` puts the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Anything the bindings use must exist on **android API 26**, which is far below what
   their `--release 17` compiler accepts. That is a runtime-only failure, on device
   (`java.lang.ref.Cleaner` and `List.of` both had to be fixed upstream for this reason)
+- **odrcore's cmake needs a JDK on the conan build machine to produce the jar at all.**
+  Since 6.1 the android branch of `jni/CMakeLists.txt` calls `find_package(Java 11
+  COMPONENTS Development)` without `REQUIRED` - so a build with no `JAVA_HOME`/`javac`
+  in the environment quietly builds `libodr_jni.so` and returns before `add_jar`. It is
+  not silent for long, `conandeployer.py` then fails with `No such file or directory:
+  .../share/java/odr-core-java.jar`, but the fix is to give conan a JDK and rebuild the
+  package (`--build=odrcore/<version>`), not to look for the file. Reported upstream as
+  opendocument-app/OpenDocument.core#637
 - Supports multiple architectures: armv8, armv7, x86, x86_64
 - Assets deployed to `assets/core` and native libraries to `jniLibs/<abi>` via the custom
   Conan deployer (`app/conandeployer.py`)
@@ -145,40 +153,36 @@ the `.pro` suffix) differ on purpose - do not "fix" the mismatch:
   `AndroidFileCache`, the SharedPreferences name in `MainActivity`) follows
   `applicationId` and must stay that way, or existing users lose their saved prefs.
 
-### Supported file types are declared twice, and a test keeps them in step
+### Supported file types come from odrcore, and a test keeps the manifest in step
 
-`SupportedDocumentTypes` is the single kotlin table: mime prefixes for what the core
-renders, mime prefixes for what `RawLoader` shows, plus an extension fallback for the
-`application/octet-stream` a provider volunteers when it knows nothing better.
-`CoreLoader.isSupported()` defers to it - it used to keep a second copy of the same
-prefixes.
+`SupportedDocumentTypes` used to be a hand written table of mime *prefixes*. Since odrcore
+6.1 it is derived: `Odr.allFileTypes()` filtered by `Odr.capabilitiesByFileType(...)
+.translateHtml` and `Odr.fileCategoryByFileType(...) == DOCUMENT` is what `CoreLoader`
+renders, and `Odr.mimetypesByFileType` / `Odr.fileExtensionsByFileType` expand each of those
+into every spelling the core accepts - the templates, the macro-enabled variants, the
+`application/x-vnd.oasis...` family and the `-flat-xml` ones. Do not put a list of mime
+prefixes back; the whole point is that the app cannot claim a format the core does not have,
+or miss one it does. A prefix match is also what made the app claim `.xlsb`
+(`application/vnd.ms-excel.sheet.binary.macroEnabled.12` starts like every other excel type)
+and then fail to open it - the core gives it a file type of its own with an empty capability
+row now.
 
-The `STRICT_CATCH` `activity-alias` in `AndroidManifest.xml` is the second declaration and
-cannot be collapsed into the first, because XML cannot read a kotlin list. It is covered
-instead: `SupportedFormatsTest` (instrumented) walks odrcore's own `FileType` values, asks
-`Odr.mimetypeByFileType` for each, and asserts that `SupportedDocumentTypes` and the package
-manager give the same answer - so a format added on one side and forgotten on the other
-fails CI rather than shipping.
+Two declarations are left. The app's own choice of which of the core's formats go to
+`CoreLoader` and which to `RawLoader` - text, csv, zip and `image/` are named in
+`SupportedDocumentTypes`, because that is an app decision the core knows nothing about. And
+the `STRICT_CATCH` `activity-alias` in `AndroidManifest.xml`, which cannot be collapsed into
+the first because XML cannot read any of this. Its three intent-filters are *generated* from
+the same table (an intent-filter matches a mime type exactly, so all 40 spellings and 41
+extensions are written out) and covered by a test rather than by discipline:
+`SupportedFormatsTest` (instrumented) walks every mime type of every `FileType` and asserts
+that `SupportedDocumentTypes` and the package manager give the same answer, so a format added
+upstream and forgotten in the manifest fails CI rather than shipping.
 
-That walk has a blind spot, and a second test covers it. The table matches by *prefix*, so
-it also claims the ooxml templates, slideshows and macro-enabled variants - spellings
-odrcore never produces, because `mimetypeByFileType` names one canonical mime per format. An
-intent-filter, on the other hand, matches a mime type exactly, so every one of those has to
-be spelled out in the manifest. `theOoxmlVariantsReachUsToo` lists them and asserts both
-sides say yes.
-
-The set follows odrcore: whatever it keeps reference html output for in
-`test/data/reference-output` is what the app claims - odf, ooxml, the legacy binary
-doc/ppt/xls and pdf. Text, csv and images are the core's too but belong to `RawLoader`,
-which only gets its turn when `CoreLoader.isSupported()` says no.
-
-Why the app has a table at all when odrcore has `Odr.fileTypeByMimetype` /
-`Odr.fileTypeByFileExtension`: both are native calls into `libodr_jni`, and both know exactly
-one canonical mime type per format - no templates, no macro-enabled variants, no
-`application/x-vnd.oasis...`, which are the spellings content providers actually hand out.
-The guessing stage needs to be broader than the core's own lookup. What the core *does*
-decide is everything after the file is in the cache: `MetadataLoader` runs libmagic over the
-copy, and `CoreLoader.isDocumentEditable` asks the opened document.
+The tables live in `libodr_jni`, so anything that reads them needs a device. That is why
+`CoreLoaderTest`, `SupportedDocumentTypesTest` and `OnlineLoaderTest` are instrumented tests
+and not JVM ones - none of them opens a file, they just cannot ask the table from a plain
+JVM. What the core decides *after* the file is in the cache is unchanged: `MetadataLoader`
+runs libmagic over the copy, and `CoreLoader.isDocumentEditable` asks the opened document.
 
 ### Editability comes from the core, never from a mime type
 
@@ -190,6 +194,11 @@ Do not reintroduce a list of editable formats in the UI. The core already says n
 legacy binary doc/ppt/xls, to ooxml spreadsheets and presentations, and to every spreadsheet
 including odf (its own TODO, the same gap as issue #442) - all of which the app used to spell
 out by mime prefix and got wrong the moment a new format started going through `CoreLoader`.
+
+`DecodedFile.capabilities()` is asked first, and only as a shortcut: opening a document costs
+a second parse of the whole file, so a format whose declared `edit`/`save` are already false
+is never opened just to be told no. It is an upper bound by definition - the document is
+still what answers.
 
 ### Language
 

--- a/app/conanfile.txt
+++ b/app/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-odrcore/6.0.1
+odrcore/6.1.0
 
 [generators]
 CMakeToolchain

--- a/app/src/androidTest/java/app/opendocument/droid/background/CoreLoaderTest.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/background/CoreLoaderTest.kt
@@ -1,14 +1,24 @@
 package app.opendocument.droid.background
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SmallTest
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 
 /**
  * What the core is expected to render. odrcore v6 keeps reference html output for every format
  * asserted here, so these are the types a load is expected to succeed for.
+ *
+ * Instrumented rather than a JVM test since odrcore 6.1: [SupportedDocumentTypes] reads the core's
+ * own format table now instead of keeping a list of mime prefixes, and that table lives in
+ * `libodr_jni`. Nothing here opens a file - the loader only asks the table - but a device is what
+ * has the library.
  */
+@SmallTest
+@RunWith(AndroidJUnit4::class)
 class CoreLoaderTest {
 
     private lateinit var coreLoader: CoreLoader
@@ -35,6 +45,8 @@ class CoreLoaderTest {
         assertTrue(isSupported("application/vnd.oasis.opendocument.text-master"))
         // the spelling some providers use
         assertTrue(isSupported("application/x-vnd.oasis.opendocument.text"))
+        // and the single file xml flavor, which the core learned to name in 6.1
+        assertTrue(isSupported("application/vnd.oasis.opendocument.text-flat-xml"))
     }
 
     @Test
@@ -53,8 +65,8 @@ class CoreLoaderTest {
 
     @Test
     fun theMacroEnabledOoxmlVariantsAreSupported() {
-        // spelled outside the openxmlformats family, which is why the legacy types below are
-        // matched by their prefix and vnd.ms-word is listed at all
+        // spelled outside the openxmlformats family, and each one named in the core's table -
+        // this used to be a prefix match on "application/vnd.ms-word" and friends
         assertTrue(isSupported("application/vnd.ms-word.document.macroEnabled.12"))
         assertTrue(isSupported("application/vnd.ms-excel.sheet.macroEnabled.12"))
         assertTrue(isSupported("application/vnd.ms-powerpoint.presentation.macroEnabled.12"))
@@ -65,11 +77,15 @@ class CoreLoaderTest {
         assertTrue(isSupported("application/msword"))
         assertTrue(isSupported("application/vnd.ms-excel"))
         assertTrue(isSupported("application/vnd.ms-powerpoint"))
+        // the aliases the core names for them, which the old prefix list did not reach
+        assertTrue(isSupported("application/msexcel"))
+        assertTrue(isSupported("application/mspowerpoint"))
     }
 
     @Test
     fun pdfIsSupported() {
         assertTrue(isSupported("application/pdf"))
+        assertTrue(isSupported("application/x-pdf"))
     }
 
     @Test
@@ -88,5 +104,15 @@ class CoreLoaderTest {
         assertFalse(isSupported("application/vnd.apple.pages"))
         assertFalse(isSupported("application/octet-stream"))
         assertFalse(isSupported(null))
+    }
+
+    /**
+     * The binary excel package: an ooxml container whose parts are not spreadsheetml, so there is
+     * no decoder for it. Claimed until odrcore 6.1 gave it a file type of its own, because the mime
+     * type starts like every other excel one and the app matched excel by prefix.
+     */
+    @Test
+    fun theBinaryExcelWorkbookIsNotClaimed() {
+        assertFalse(isSupported("application/vnd.ms-excel.sheet.binary.macroEnabled.12"))
     }
 }

--- a/app/src/androidTest/java/app/opendocument/droid/background/OnlineLoaderTest.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/background/OnlineLoaderTest.kt
@@ -1,9 +1,19 @@
 package app.opendocument.droid.background
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SmallTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 
+/**
+ * Instrumented rather than a JVM test since odrcore 6.1: [OnlineLoader.isConvertible] falls through
+ * to [CoreLoader.isSupported], which reads the core's format table out of `libodr_jni` now instead
+ * of matching mime prefixes in kotlin. Nothing here uploads anything or touches the network.
+ */
+@SmallTest
+@RunWith(AndroidJUnit4::class)
 class OnlineLoaderTest {
 
     private lateinit var onlineLoader: OnlineLoader

--- a/app/src/androidTest/java/app/opendocument/droid/background/SupportedDocumentTypesTest.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/background/SupportedDocumentTypesTest.kt
@@ -1,9 +1,24 @@
 package app.opendocument.droid.background
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SmallTest
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
 
+/**
+ * What the app offers itself for, by example.
+ *
+ * `SupportedFormatsTest` walks odrcore's whole table and holds the manifest against it; this one
+ * spells out the cases the table cannot express - that a known extension beats an unhelpful mime
+ * type, that a format the core merely recognises is not offered for, and that nothing at all is
+ * still nothing.
+ *
+ * Instrumented rather than a JVM test since odrcore 6.1, which is where the lists come from now.
+ */
+@SmallTest
+@RunWith(AndroidJUnit4::class)
 class SupportedDocumentTypesTest {
 
     @Test
@@ -13,6 +28,9 @@ class SupportedDocumentTypesTest {
         assertTrue(supported("application/vnd.oasis.opendocument.presentation", "deck.odp"))
         assertTrue(supported("application/vnd.oasis.opendocument.graphics", "drawing.odg"))
         assertTrue(supported("application/vnd.oasis.opendocument.text-template", "letter.ott"))
+        // the master document and its template, whose extensions the core names since 6.1
+        assertTrue(supported(null, "book.odm"))
+        assertTrue(supported(null, "book.otm"))
     }
 
     @Test
@@ -44,6 +62,10 @@ class SupportedDocumentTypesTest {
         assertTrue(supported("application/octet-stream", "deck.pptx"))
         assertTrue(supported("application/octet-stream", "deck.ppt"))
         assertTrue(supported("application/octet-stream", "budget.xls"))
+        // and the templates of the legacy formats, another 6.1 addition
+        assertTrue(supported("application/octet-stream", "letter.dot"))
+        assertTrue(supported("application/octet-stream", "slides.pot"))
+        assertTrue(supported("application/octet-stream", "sheet.xlt"))
     }
 
     @Test
@@ -69,6 +91,19 @@ class SupportedDocumentTypesTest {
         assertFalse(supported("application/octet-stream", "firmware.bin"))
     }
 
+    /**
+     * Formats odrcore can name but has no decoder for. They used to slip through: rtf and word
+     * perfect by never being claimed at all, but a `.xlsb` by its mime type starting like an excel
+     * one, which is exactly what a prefix match cannot tell apart.
+     */
+    @Test
+    fun formatsWithoutADecoderAreNotSupported() {
+        assertFalse(supported("application/vnd.ms-excel.sheet.binary.macroEnabled.12", "old.xlsb"))
+        assertFalse(supported("application/rtf", "letter.rtf"))
+        assertFalse(supported("application/vnd.wordperfect", "letter.wpd"))
+        assertFalse(supported("text/markdown", "readme.md"))
+    }
+
     @Test
     fun nothingKnownAtAllIsNotSupported() {
         assertFalse(supported(null, null))
@@ -80,6 +115,8 @@ class SupportedDocumentTypesTest {
     fun matchingIsCaseInsensitive() {
         assertTrue(supported("APPLICATION/PDF", "MANUAL.PDF"))
         assertTrue(supported(null, "Report.ODT"))
+        // the core spells this one with capitals of its own
+        assertTrue(supported("APPLICATION/VND.MS-WORD.DOCUMENT.MACROENABLED.12", null))
     }
 
     private fun supported(mimeType: String?, filename: String?) =

--- a/app/src/androidTest/java/app/opendocument/droid/test/SupportedFormatsTest.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/SupportedFormatsTest.kt
@@ -9,6 +9,8 @@ import androidx.test.platform.app.InstrumentationRegistry
 import app.opendocument.core.Odr
 import app.opendocument.droid.background.CatchAllSetting
 import app.opendocument.droid.background.CoreLoader
+import app.opendocument.droid.background.FileLoader
+import app.opendocument.droid.background.RawLoader
 import app.opendocument.droid.background.SupportedDocumentTypes
 import org.junit.Assert
 import org.junit.BeforeClass
@@ -87,6 +89,32 @@ class SupportedFormatsTest {
                     SupportedDocumentTypes.isRenderedByCore(mimeType),
                 )
             }
+        }
+    }
+
+    /**
+     * Everything the app offers itself for reaches a loader that takes it.
+     *
+     * Claiming a mime type nobody loads is the "cannot open" the user gets on a file they picked us
+     * for, and it is what reading the core's whole table risks: [CoreLoader] matches every spelling
+     * of a format, but [RawLoader] goes by mime type prefix and so only ever sees the canonical one
+     * that [MetadataLoader] resolves to - `application/csv` and `multipart/x-zip` are claimed and
+     * would otherwise be dropped between the two.
+     */
+    @Test
+    fun everythingTheAppClaimsIsLoadedBySomebody() {
+        val coreLoader = CoreLoader(null)
+        val rawLoader = RawLoader(null, coreLoader)
+
+        for (mimeType in SupportedDocumentTypes.MIME_TYPES) {
+            val options = FileLoader.Options()
+            options.fileType = SupportedDocumentTypes.canonicalMimeType(mimeType)
+
+            Assert.assertTrue(
+                "$mimeType is claimed by the app, but neither loader takes it" +
+                    " (as ${options.fileType})",
+                coreLoader.isSupported(options) || rawLoader.isSupported(options),
+            )
         }
     }
 

--- a/app/src/androidTest/java/app/opendocument/droid/test/SupportedFormatsTest.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/SupportedFormatsTest.kt
@@ -6,7 +6,6 @@ import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
 import androidx.test.platform.app.InstrumentationRegistry
-import app.opendocument.core.FileType
 import app.opendocument.core.Odr
 import app.opendocument.droid.background.CatchAllSetting
 import app.opendocument.droid.background.CoreLoader
@@ -20,23 +19,25 @@ import org.junit.runner.RunWith
  * Keeps the two remaining declarations of what the app opens in step with each other, so that
  * changing one and forgetting the other is a failing test rather than a bug report.
  *
- * [SupportedDocumentTypes] is one of them. The other is the STRICT_CATCH `activity-alias` in
- * AndroidManifest.xml, which is XML and cannot read a kotlin list - but it can be *asked*: an
+ * [SupportedDocumentTypes] is one of them, and since odrcore 6.1 it is barely a declaration at
+ * all - it reads the core's own format table. The other is the STRICT_CATCH `activity-alias` in
+ * AndroidManifest.xml, which is XML and cannot read that table - but it can be *asked*: an
  * intent-filter is only worth anything if the package manager resolves a real intent through it,
- * which is what [resolvesToUs] does here. There used to be a third copy in `CoreLoader`; that one
- * is gone, it defers to [SupportedDocumentTypes] now.
+ * which is what [resolvesToUs] does here.
  *
- * The mime side needs no list of its own at all: [FileType] is the core's complete set of formats
- * and [Odr.mimetypeByFileType] names each one, so the test walks what odrcore knows and demands
- * that the app and the manifest give the same answer for every entry.
+ * So neither side needs a list of formats of its own. The test walks every mime type spelling
+ * odrcore accepts, [Odr.mimetypesByFileType] for each of [Odr.allFileTypes], and demands that the
+ * app and the manifest give the same answer for all of them. That reaches the templates, the macro
+ * enabled variants and the `x-vnd` spellings, which used to need a hand written list here because
+ * the core only named one canonical mime type per format.
  */
 @SmallTest
 @RunWith(AndroidJUnit4::class)
 class SupportedFormatsTest {
 
     /**
-     * For every format odrcore can name a mime type for, what the app offers itself for and what
-     * the manifest offers it for have to be the same answer.
+     * For every mime type odrcore accepts, what the app offers itself for and what the manifest
+     * offers it for have to be the same answer.
      *
      * This is the assertion that catches a format being added to the loader without being added to
      * the manifest, which is the failure the user sees as "the app is not in the share sheet".
@@ -45,56 +46,47 @@ class SupportedFormatsTest {
     fun theManifestClaimsExactlyWhatTheAppClaims() {
         var checked = 0
 
-        for (fileType in FileType.values()) {
-            val mimeType = mimeTypeOrNull(fileType) ?: continue
-            checked++
+        for (fileType in Odr.allFileTypes()) {
+            for (mimeType in Odr.mimetypesByFileType(fileType)) {
+                checked++
 
-            val claimedByApp = SupportedDocumentTypes.isSupported(mimeType, null)
-            val claimedByManifest = resolvesToUs(mimeType, "document")
+                val claimedByApp = SupportedDocumentTypes.isSupported(mimeType, null)
+                val claimedByManifest = resolvesToUs(mimeType, "document")
 
-            Assert.assertEquals(
-                "$fileType ($mimeType): the app says $claimedByApp, the manifest says" +
-                    " $claimedByManifest - AndroidManifest.xml and SupportedDocumentTypes have" +
-                    " drifted apart",
-                claimedByApp,
-                claimedByManifest,
-            )
+                Assert.assertEquals(
+                    "$fileType ($mimeType): the app says $claimedByApp, the manifest says" +
+                        " $claimedByManifest - AndroidManifest.xml and SupportedDocumentTypes have" +
+                        " drifted apart",
+                    claimedByApp,
+                    claimedByManifest,
+                )
+            }
         }
 
         // a guard on the guard: if the core ever stops naming mime types the loop above would
         // silently assert nothing at all
-        Assert.assertTrue("no file type was checked", checked > 10)
-    }
-
-    /** Every extension named after the core's own table has to be one odrcore still recognises. */
-    @Test
-    fun theExtensionFallbackNamesFormatsTheCoreKnows() {
-        for (extension in SupportedDocumentTypes.CORE_EXTENSIONS) {
-            Assert.assertNotEquals(
-                "odrcore does not know the extension .$extension",
-                FileType.UNKNOWN,
-                Odr.fileTypeByFileExtension(extension),
-            )
-        }
+        Assert.assertTrue("only $checked mime types were checked", checked > 50)
     }
 
     /**
-     * The other half of the fallback, and why it is kept apart: odrcore's extension table names one
-     * suffix per format, so it answers UNKNOWN for the ooxml templates, macro enabled documents and
-     * slideshows even though it renders all of them - a `.dotx` is the same wordprocessing package
-     * as a `.docx`, and libmagic identifies it by content once the file is in the cache.
-     *
-     * Kept as an assertion rather than a comment so that a future core which does learn them turns
-     * this red instead of leaving the split in place for no reason.
+     * The app never claims a format the core cannot decode, which is the invariant the old prefix
+     * list could not hold: `application/vnd.ms-excel.sheet.binary.macroEnabled.12` starts like an
+     * excel mime type, so a `.xlsb` was offered for and then failed to open. odrcore 6.1 gives it a
+     * file type of its own with an empty capability row, and the app follows that instead.
      */
     @Test
-    fun theOoxmlVariantExtensionsAreOnesTheCoreDoesNotName() {
-        for (extension in SupportedDocumentTypes.OOXML_VARIANT_EXTENSIONS) {
-            Assert.assertEquals(
-                "odrcore now knows .$extension - move it to CORE_EXTENSIONS",
-                FileType.UNKNOWN,
-                Odr.fileTypeByFileExtension(extension),
-            )
+    fun whatTheCoreCannotDecodeIsNotClaimed() {
+        for (fileType in Odr.allFileTypes()) {
+            if (Odr.capabilitiesByFileType(fileType).open) {
+                continue
+            }
+
+            for (mimeType in Odr.mimetypesByFileType(fileType)) {
+                Assert.assertFalse(
+                    "$fileType ($mimeType) has no decoder, but the core loader claims it",
+                    SupportedDocumentTypes.isRenderedByCore(mimeType),
+                )
+            }
         }
     }
 
@@ -127,8 +119,8 @@ class SupportedFormatsTest {
      * happen to say.
      *
      * This is what pins the pattern list against [SupportedDocumentTypes.EXTENSIONS]: leaving an
-     * extension out of the manifest was invisible until now, and `.ott` had been missing from it
-     * for as long as the table has claimed it.
+     * extension out of the manifest was invisible until a test asked for it, and `.ott` had been
+     * missing for as long as the table had claimed it.
      */
     @Test
     fun aFileWithNoMimeTypeReachesUsByItsExtension() {
@@ -143,48 +135,10 @@ class SupportedFormatsTest {
     /** And the same route stays shut for what the app does not claim. */
     @Test
     fun aFileWithNoMimeTypeAndAnUnrelatedExtensionReachesNobody() {
-        for (extension in listOf("vcf", "mp3", "mp4", "bin", "apk")) {
+        for (extension in listOf("vcf", "mp3", "mp4", "bin", "apk", "xlsb")) {
             Assert.assertFalse(
                 "the manifest offers for .$extension",
                 resolvesToUs(null, "document.$extension"),
-            )
-        }
-    }
-
-    /**
-     * The spellings the mime *prefixes* carry along - the ooxml templates, slideshows and macro
-     * enabled variants - which [theManifestClaimsExactlyWhatTheAppClaims] cannot reach: odrcore
-     * names one canonical mime type per format, so its [FileType] walk never produces any of these.
-     *
-     * They still have to hold, because an intent-filter matches a mime type exactly. Without them
-     * spelled out in the manifest a .dotx opened from the folder browser while the same file from
-     * another app did not offer OpenDocument at all.
-     */
-    @Test
-    fun theOoxmlVariantsReachUsToo() {
-        val variants =
-            listOf(
-                "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
-                "application/vnd.openxmlformats-officedocument.spreadsheetml.template",
-                "application/vnd.openxmlformats-officedocument.presentationml.template",
-                "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
-                "application/vnd.ms-word.document.macroEnabled.12",
-                "application/vnd.ms-word.template.macroEnabled.12",
-                "application/vnd.ms-excel.sheet.macroEnabled.12",
-                "application/vnd.ms-excel.template.macroEnabled.12",
-                "application/vnd.ms-powerpoint.presentation.macroEnabled.12",
-                "application/vnd.ms-powerpoint.template.macroEnabled.12",
-                "application/vnd.ms-powerpoint.slideshow.macroEnabled.12",
-            )
-
-        for (mimeType in variants) {
-            Assert.assertTrue(
-                "the app does not offer for $mimeType",
-                SupportedDocumentTypes.isSupported(mimeType, null),
-            )
-            Assert.assertTrue(
-                "the manifest does not offer for $mimeType",
-                resolvesToUs(mimeType, "document"),
             )
         }
     }
@@ -228,14 +182,6 @@ class SupportedFormatsTest {
             .queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY)
             .any { it.activityInfo?.packageName == context.packageName }
     }
-
-    /** Null for the types odrcore has no mime type for - word perfect, rtf, cfb and the like. */
-    private fun mimeTypeOrNull(fileType: FileType): String? =
-        try {
-            Odr.mimetypeByFileType(fileType)
-        } catch (e: RuntimeException) {
-            null
-        }
 
     companion object {
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -234,62 +234,104 @@
             android:label="@string/app_title"
             android:targetActivity="app.opendocument.droid.ui.activity.MainActivity"
             tools:ignore="AppLinkUrlError">
-            <!-- STRICT_CATCH: Supports ODT, ODS, ODP, ODG, PDF, DOCX, XLSX, PPTX, DOC, XLS, PPT -->
+            <!--
+                 STRICT_CATCH: what the app actually opens - opendocument, ooxml, the legacy
+                 binary doc/ppt/xls and pdf through the core, plus text, csv, images and zip
+                 through RawLoader. The three filters below are generated from odrcore's own
+                 format table and must not be edited by hand alone; SupportedDocumentTypes
+                 reads that same table at runtime, and SupportedFormatsTest fails when the two
+                 stop agreeing.
+            -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data android:mimeType="application/vnd.oasis.opendocument.text" />
-                <data android:mimeType="application/vnd.oasis.opendocument.text-template" />
-                <data android:mimeType="application/vnd.oasis.opendocument.spreadsheet" />
-                <data android:mimeType="application/vnd.oasis.opendocument.spreadsheet-template" />
-                <data android:mimeType="application/vnd.oasis.opendocument.presentation" />
-                <data android:mimeType="application/vnd.oasis.opendocument.presentation-template" />
-                <data android:mimeType="application/vnd.oasis.opendocument.graphics" />
-                <data android:mimeType="application/vnd.oasis.opendocument.graphics-template" />
-                <data android:mimeType="application/octet-stream" />
-                <data android:mimeType="application/pdf" />
-                <data android:mimeType="application/vnd.openxmlformats-officedocument.wordprocessingml.document" />
-                <data android:mimeType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" />
-                <data android:mimeType="application/vnd.openxmlformats-officedocument.presentationml.presentation" />
-                <data android:mimeType="application/msword" />
-                <data android:mimeType="application/vnd.ms-excel" />
-                <data android:mimeType="application/vnd.ms-powerpoint" />
                 <!--
-                     the ooxml templates, slideshows and macro enabled variants. an intent-filter
-                     matches a mime type exactly, so each spelling has to be named here - where
-                     SupportedDocumentTypes takes the whole family in two prefixes. leaving these
-                     out let a .dotx open when browsed to inside the app while the same file was
-                     not offered to us from another one. SupportedFormatsTest pins the pair.
+                     every mime type spelling odrcore accepts for a format it turns into
+                     html. an intent-filter matches a mime type exactly, so the templates, the
+                     macro enabled variants and the x-vnd spellings all have to be named -
+                     where the old prefix list took each family in one line, and got .xlsb
+                     wrong for it.
                 -->
+                <data android:mimeType="application/vnd.oasis.opendocument.text" />
+                <data android:mimeType="application/x-vnd.oasis.opendocument.text" />
+                <data android:mimeType="application/vnd.oasis.opendocument.text-template" />
+                <data android:mimeType="application/vnd.oasis.opendocument.text-master" />
+                <data android:mimeType="application/vnd.oasis.opendocument.text-master-template" />
+                <data android:mimeType="application/vnd.oasis.opendocument.text-flat-xml" />
+                <data android:mimeType="application/vnd.oasis.opendocument.presentation" />
+                <data android:mimeType="application/x-vnd.oasis.opendocument.presentation" />
+                <data android:mimeType="application/vnd.oasis.opendocument.presentation-template" />
+                <data android:mimeType="application/vnd.oasis.opendocument.presentation-flat-xml" />
+                <data android:mimeType="application/vnd.oasis.opendocument.spreadsheet" />
+                <data android:mimeType="application/x-vnd.oasis.opendocument.spreadsheet" />
+                <data android:mimeType="application/vnd.oasis.opendocument.spreadsheet-template" />
+                <data android:mimeType="application/vnd.oasis.opendocument.spreadsheet-flat-xml" />
+                <data android:mimeType="application/vnd.oasis.opendocument.graphics" />
+                <data android:mimeType="application/x-vnd.oasis.opendocument.graphics" />
+                <data android:mimeType="application/vnd.oasis.opendocument.graphics-template" />
+                <data android:mimeType="application/vnd.oasis.opendocument.graphics-flat-xml" />
+                <data android:mimeType="application/vnd.openxmlformats-officedocument.wordprocessingml.document" />
                 <data android:mimeType="application/vnd.openxmlformats-officedocument.wordprocessingml.template" />
-                <data android:mimeType="application/vnd.openxmlformats-officedocument.spreadsheetml.template" />
-                <data android:mimeType="application/vnd.openxmlformats-officedocument.presentationml.template" />
-                <data android:mimeType="application/vnd.openxmlformats-officedocument.presentationml.slideshow" />
                 <data android:mimeType="application/vnd.ms-word.document.macroEnabled.12" />
                 <data android:mimeType="application/vnd.ms-word.template.macroEnabled.12" />
+                <data android:mimeType="application/vnd.openxmlformats-officedocument.presentationml.presentation" />
+                <data android:mimeType="application/vnd.openxmlformats-officedocument.presentationml.slideshow" />
+                <data android:mimeType="application/vnd.openxmlformats-officedocument.presentationml.template" />
+                <data android:mimeType="application/vnd.ms-powerpoint.presentation.macroEnabled.12" />
+                <data android:mimeType="application/vnd.ms-powerpoint.slideshow.macroEnabled.12" />
+                <data android:mimeType="application/vnd.ms-powerpoint.template.macroEnabled.12" />
+                <data android:mimeType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" />
+                <data android:mimeType="application/vnd.openxmlformats-officedocument.spreadsheetml.template" />
                 <data android:mimeType="application/vnd.ms-excel.sheet.macroEnabled.12" />
                 <data android:mimeType="application/vnd.ms-excel.template.macroEnabled.12" />
-                <data android:mimeType="application/vnd.ms-powerpoint.presentation.macroEnabled.12" />
-                <data android:mimeType="application/vnd.ms-powerpoint.template.macroEnabled.12" />
-                <data android:mimeType="application/vnd.ms-powerpoint.slideshow.macroEnabled.12" />
-                <!-- raw types handled by RawLoader; text/plain (not text/*) avoids re-matching text/vcard contacts (#477) -->
+                <data android:mimeType="application/msword" />
+                <data android:mimeType="application/vnd.ms-word" />
+                <data android:mimeType="application/vnd.ms-powerpoint" />
+                <data android:mimeType="application/mspowerpoint" />
+                <data android:mimeType="application/vnd.ms-excel" />
+                <data android:mimeType="application/msexcel" />
+                <data android:mimeType="application/pdf" />
+                <data android:mimeType="application/x-pdf" />
+                <!--
+                     the octet-stream a provider volunteers when it knows nothing better.
+                     claimed outright, because only the filename can answer for it - which is
+                     what the pathPattern filter below does.
+                -->
+                <data android:mimeType="application/octet-stream" />
+                <!--
+                     raw types handled by RawLoader: text/plain rather than text/*, which
+                     would re-match the vcard contacts of #477, and image/* rather than the
+                     five image formats odrcore names, because the WebView shows webp and
+                     heic just as well.
+                -->
                 <data android:mimeType="text/plain" />
                 <data android:mimeType="text/csv" />
-                <data android:mimeType="image/*" />
+                <data android:mimeType="application/csv" />
+                <data android:mimeType="text/comma-separated-values" />
                 <data android:mimeType="application/zip" />
+                <data android:mimeType="application/x-zip-compressed" />
+                <data android:mimeType="multipart/x-zip" />
+                <data android:mimeType="image/*" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
-                <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:scheme="content" />
                 <data android:scheme="file" />
                 <data android:host="*" />
+                <!--
+                     a file manager that sends ACTION_VIEW with no mime type at all leaves
+                     the name as the only thing to go on. one pattern per leading dot,
+                     because pathPattern has no way to say "ends with" before API 31, and one
+                     extension per line - the same extensions SupportedDocumentTypes gets
+                     from the core.
+                -->
                 <data android:pathPattern=".*\\.odt" />
                 <data android:pathPattern=".*\\..*\\.odt" />
                 <data android:pathPattern=".*\\..*\\..*\\.odt" />
@@ -297,27 +339,13 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.odt" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.odt" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.odt" />
-                <data android:pathPattern=".*\\.ods" />
-                <data android:pathPattern=".*\\..*\\.ods" />
-                <data android:pathPattern=".*\\..*\\..*\\.ods" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.ods" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.ods" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.ods" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.ods" />
-                <data android:pathPattern=".*\\.odp" />
-                <data android:pathPattern=".*\\..*\\.odp" />
-                <data android:pathPattern=".*\\..*\\..*\\.odp" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.odp" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.odp" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.odp" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.odp" />
-                <data android:pathPattern=".*\\.odg" />
-                <data android:pathPattern=".*\\..*\\.odg" />
-                <data android:pathPattern=".*\\..*\\..*\\.odg" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.odg" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.odg" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.odg" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.odg" />
+                <data android:pathPattern=".*\\.fodt" />
+                <data android:pathPattern=".*\\..*\\.fodt" />
+                <data android:pathPattern=".*\\..*\\..*\\.fodt" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.fodt" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.fodt" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.fodt" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.fodt" />
                 <data android:pathPattern=".*\\.ott" />
                 <data android:pathPattern=".*\\..*\\.ott" />
                 <data android:pathPattern=".*\\..*\\..*\\.ott" />
@@ -325,13 +353,34 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.ott" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.ott" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.ott" />
-                <data android:pathPattern=".*\\.ots" />
-                <data android:pathPattern=".*\\..*\\.ots" />
-                <data android:pathPattern=".*\\..*\\..*\\.ots" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.ots" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.ots" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.ots" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.ots" />
+                <data android:pathPattern=".*\\.odm" />
+                <data android:pathPattern=".*\\..*\\.odm" />
+                <data android:pathPattern=".*\\..*\\..*\\.odm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.odm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.odm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.odm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.odm" />
+                <data android:pathPattern=".*\\.otm" />
+                <data android:pathPattern=".*\\..*\\.otm" />
+                <data android:pathPattern=".*\\..*\\..*\\.otm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.otm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.otm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.otm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.otm" />
+                <data android:pathPattern=".*\\.odp" />
+                <data android:pathPattern=".*\\..*\\.odp" />
+                <data android:pathPattern=".*\\..*\\..*\\.odp" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.odp" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.odp" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.odp" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.odp" />
+                <data android:pathPattern=".*\\.fodp" />
+                <data android:pathPattern=".*\\..*\\.fodp" />
+                <data android:pathPattern=".*\\..*\\..*\\.fodp" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.fodp" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.fodp" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.fodp" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.fodp" />
                 <data android:pathPattern=".*\\.otp" />
                 <data android:pathPattern=".*\\..*\\.otp" />
                 <data android:pathPattern=".*\\..*\\..*\\.otp" />
@@ -339,6 +388,41 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.otp" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.otp" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.otp" />
+                <data android:pathPattern=".*\\.ods" />
+                <data android:pathPattern=".*\\..*\\.ods" />
+                <data android:pathPattern=".*\\..*\\..*\\.ods" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.ods" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.ods" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.ods" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.ods" />
+                <data android:pathPattern=".*\\.fods" />
+                <data android:pathPattern=".*\\..*\\.fods" />
+                <data android:pathPattern=".*\\..*\\..*\\.fods" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.fods" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.fods" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.fods" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.fods" />
+                <data android:pathPattern=".*\\.ots" />
+                <data android:pathPattern=".*\\..*\\.ots" />
+                <data android:pathPattern=".*\\..*\\..*\\.ots" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.ots" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.ots" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.ots" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.ots" />
+                <data android:pathPattern=".*\\.odg" />
+                <data android:pathPattern=".*\\..*\\.odg" />
+                <data android:pathPattern=".*\\..*\\..*\\.odg" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.odg" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.odg" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.odg" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.odg" />
+                <data android:pathPattern=".*\\.fodg" />
+                <data android:pathPattern=".*\\..*\\.fodg" />
+                <data android:pathPattern=".*\\..*\\..*\\.fodg" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.fodg" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.fodg" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.fodg" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.fodg" />
                 <data android:pathPattern=".*\\.otg" />
                 <data android:pathPattern=".*\\..*\\.otg" />
                 <data android:pathPattern=".*\\..*\\..*\\.otg" />
@@ -346,13 +430,6 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.otg" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.otg" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.otg" />
-                <data android:pathPattern=".*\\.pdf" />
-                <data android:pathPattern=".*\\..*\\.pdf" />
-                <data android:pathPattern=".*\\..*\\..*\\.pdf" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.pdf" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.pdf" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.pdf" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.pdf" />
                 <data android:pathPattern=".*\\.docx" />
                 <data android:pathPattern=".*\\..*\\.docx" />
                 <data android:pathPattern=".*\\..*\\..*\\.docx" />
@@ -381,48 +458,6 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.dotm" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.dotm" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.dotm" />
-                <data android:pathPattern=".*\\.doc" />
-                <data android:pathPattern=".*\\..*\\.doc" />
-                <data android:pathPattern=".*\\..*\\..*\\.doc" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.doc" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.doc" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.doc" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.doc" />
-                <data android:pathPattern=".*\\.xlsx" />
-                <data android:pathPattern=".*\\..*\\.xlsx" />
-                <data android:pathPattern=".*\\..*\\..*\\.xlsx" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.xlsx" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xlsx" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xlsx" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xlsx" />
-                <data android:pathPattern=".*\\.xlsm" />
-                <data android:pathPattern=".*\\..*\\.xlsm" />
-                <data android:pathPattern=".*\\..*\\..*\\.xlsm" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.xlsm" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xlsm" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xlsm" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xlsm" />
-                <data android:pathPattern=".*\\.xltx" />
-                <data android:pathPattern=".*\\..*\\.xltx" />
-                <data android:pathPattern=".*\\..*\\..*\\.xltx" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.xltx" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xltx" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xltx" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xltx" />
-                <data android:pathPattern=".*\\.xltm" />
-                <data android:pathPattern=".*\\..*\\.xltm" />
-                <data android:pathPattern=".*\\..*\\..*\\.xltm" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.xltm" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xltm" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xltm" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xltm" />
-                <data android:pathPattern=".*\\.xls" />
-                <data android:pathPattern=".*\\..*\\.xls" />
-                <data android:pathPattern=".*\\..*\\..*\\.xls" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.xls" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xls" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xls" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xls" />
                 <data android:pathPattern=".*\\.pptx" />
                 <data android:pathPattern=".*\\..*\\.pptx" />
                 <data android:pathPattern=".*\\..*\\..*\\.pptx" />
@@ -465,6 +500,48 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.ppsm" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.ppsm" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.ppsm" />
+                <data android:pathPattern=".*\\.xlsx" />
+                <data android:pathPattern=".*\\..*\\.xlsx" />
+                <data android:pathPattern=".*\\..*\\..*\\.xlsx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.xlsx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xlsx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xlsx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xlsx" />
+                <data android:pathPattern=".*\\.xlsm" />
+                <data android:pathPattern=".*\\..*\\.xlsm" />
+                <data android:pathPattern=".*\\..*\\..*\\.xlsm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.xlsm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xlsm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xlsm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xlsm" />
+                <data android:pathPattern=".*\\.xltx" />
+                <data android:pathPattern=".*\\..*\\.xltx" />
+                <data android:pathPattern=".*\\..*\\..*\\.xltx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.xltx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xltx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xltx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xltx" />
+                <data android:pathPattern=".*\\.xltm" />
+                <data android:pathPattern=".*\\..*\\.xltm" />
+                <data android:pathPattern=".*\\..*\\..*\\.xltm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.xltm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xltm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xltm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xltm" />
+                <data android:pathPattern=".*\\.doc" />
+                <data android:pathPattern=".*\\..*\\.doc" />
+                <data android:pathPattern=".*\\..*\\..*\\.doc" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.doc" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.doc" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.doc" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.doc" />
+                <data android:pathPattern=".*\\.dot" />
+                <data android:pathPattern=".*\\..*\\.dot" />
+                <data android:pathPattern=".*\\..*\\..*\\.dot" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.dot" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.dot" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.dot" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.dot" />
                 <data android:pathPattern=".*\\.ppt" />
                 <data android:pathPattern=".*\\..*\\.ppt" />
                 <data android:pathPattern=".*\\..*\\..*\\.ppt" />
@@ -472,6 +549,48 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.ppt" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.ppt" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.ppt" />
+                <data android:pathPattern=".*\\.pot" />
+                <data android:pathPattern=".*\\..*\\.pot" />
+                <data android:pathPattern=".*\\..*\\..*\\.pot" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.pot" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.pot" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.pot" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.pot" />
+                <data android:pathPattern=".*\\.pps" />
+                <data android:pathPattern=".*\\..*\\.pps" />
+                <data android:pathPattern=".*\\..*\\..*\\.pps" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.pps" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.pps" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.pps" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.pps" />
+                <data android:pathPattern=".*\\.xls" />
+                <data android:pathPattern=".*\\..*\\.xls" />
+                <data android:pathPattern=".*\\..*\\..*\\.xls" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.xls" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xls" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xls" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xls" />
+                <data android:pathPattern=".*\\.xlt" />
+                <data android:pathPattern=".*\\..*\\.xlt" />
+                <data android:pathPattern=".*\\..*\\..*\\.xlt" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.xlt" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xlt" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xlt" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xlt" />
+                <data android:pathPattern=".*\\.xlm" />
+                <data android:pathPattern=".*\\..*\\.xlm" />
+                <data android:pathPattern=".*\\..*\\..*\\.xlm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.xlm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xlm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xlm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xlm" />
+                <data android:pathPattern=".*\\.pdf" />
+                <data android:pathPattern=".*\\..*\\.pdf" />
+                <data android:pathPattern=".*\\..*\\..*\\.pdf" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.pdf" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.pdf" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.pdf" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.pdf" />
                 <data android:pathPattern=".*\\.txt" />
                 <data android:pathPattern=".*\\..*\\.txt" />
                 <data android:pathPattern=".*\\..*\\..*\\.txt" />
@@ -479,6 +598,13 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.txt" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.txt" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.txt" />
+                <data android:pathPattern=".*\\.text" />
+                <data android:pathPattern=".*\\..*\\.text" />
+                <data android:pathPattern=".*\\..*\\..*\\.text" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.text" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.text" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.text" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.text" />
                 <data android:pathPattern=".*\\.csv" />
                 <data android:pathPattern=".*\\..*\\.csv" />
                 <data android:pathPattern=".*\\..*\\..*\\.csv" />
@@ -497,13 +623,20 @@
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
-                <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:mimeType="*/*" />
                 <data android:scheme="content" />
                 <data android:scheme="file" />
                 <data android:host="*" />
+                <!--
+                     a file manager that sends ACTION_VIEW with no mime type at all leaves
+                     the name as the only thing to go on. one pattern per leading dot,
+                     because pathPattern has no way to say "ends with" before API 31, and one
+                     extension per line - the same extensions SupportedDocumentTypes gets
+                     from the core.
+                -->
                 <data android:pathPattern=".*\\.odt" />
                 <data android:pathPattern=".*\\..*\\.odt" />
                 <data android:pathPattern=".*\\..*\\..*\\.odt" />
@@ -511,27 +644,13 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.odt" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.odt" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.odt" />
-                <data android:pathPattern=".*\\.ods" />
-                <data android:pathPattern=".*\\..*\\.ods" />
-                <data android:pathPattern=".*\\..*\\..*\\.ods" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.ods" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.ods" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.ods" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.ods" />
-                <data android:pathPattern=".*\\.odp" />
-                <data android:pathPattern=".*\\..*\\.odp" />
-                <data android:pathPattern=".*\\..*\\..*\\.odp" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.odp" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.odp" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.odp" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.odp" />
-                <data android:pathPattern=".*\\.odg" />
-                <data android:pathPattern=".*\\..*\\.odg" />
-                <data android:pathPattern=".*\\..*\\..*\\.odg" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.odg" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.odg" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.odg" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.odg" />
+                <data android:pathPattern=".*\\.fodt" />
+                <data android:pathPattern=".*\\..*\\.fodt" />
+                <data android:pathPattern=".*\\..*\\..*\\.fodt" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.fodt" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.fodt" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.fodt" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.fodt" />
                 <data android:pathPattern=".*\\.ott" />
                 <data android:pathPattern=".*\\..*\\.ott" />
                 <data android:pathPattern=".*\\..*\\..*\\.ott" />
@@ -539,13 +658,34 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.ott" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.ott" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.ott" />
-                <data android:pathPattern=".*\\.ots" />
-                <data android:pathPattern=".*\\..*\\.ots" />
-                <data android:pathPattern=".*\\..*\\..*\\.ots" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.ots" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.ots" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.ots" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.ots" />
+                <data android:pathPattern=".*\\.odm" />
+                <data android:pathPattern=".*\\..*\\.odm" />
+                <data android:pathPattern=".*\\..*\\..*\\.odm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.odm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.odm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.odm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.odm" />
+                <data android:pathPattern=".*\\.otm" />
+                <data android:pathPattern=".*\\..*\\.otm" />
+                <data android:pathPattern=".*\\..*\\..*\\.otm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.otm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.otm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.otm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.otm" />
+                <data android:pathPattern=".*\\.odp" />
+                <data android:pathPattern=".*\\..*\\.odp" />
+                <data android:pathPattern=".*\\..*\\..*\\.odp" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.odp" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.odp" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.odp" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.odp" />
+                <data android:pathPattern=".*\\.fodp" />
+                <data android:pathPattern=".*\\..*\\.fodp" />
+                <data android:pathPattern=".*\\..*\\..*\\.fodp" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.fodp" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.fodp" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.fodp" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.fodp" />
                 <data android:pathPattern=".*\\.otp" />
                 <data android:pathPattern=".*\\..*\\.otp" />
                 <data android:pathPattern=".*\\..*\\..*\\.otp" />
@@ -553,6 +693,41 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.otp" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.otp" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.otp" />
+                <data android:pathPattern=".*\\.ods" />
+                <data android:pathPattern=".*\\..*\\.ods" />
+                <data android:pathPattern=".*\\..*\\..*\\.ods" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.ods" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.ods" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.ods" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.ods" />
+                <data android:pathPattern=".*\\.fods" />
+                <data android:pathPattern=".*\\..*\\.fods" />
+                <data android:pathPattern=".*\\..*\\..*\\.fods" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.fods" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.fods" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.fods" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.fods" />
+                <data android:pathPattern=".*\\.ots" />
+                <data android:pathPattern=".*\\..*\\.ots" />
+                <data android:pathPattern=".*\\..*\\..*\\.ots" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.ots" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.ots" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.ots" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.ots" />
+                <data android:pathPattern=".*\\.odg" />
+                <data android:pathPattern=".*\\..*\\.odg" />
+                <data android:pathPattern=".*\\..*\\..*\\.odg" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.odg" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.odg" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.odg" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.odg" />
+                <data android:pathPattern=".*\\.fodg" />
+                <data android:pathPattern=".*\\..*\\.fodg" />
+                <data android:pathPattern=".*\\..*\\..*\\.fodg" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.fodg" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.fodg" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.fodg" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.fodg" />
                 <data android:pathPattern=".*\\.otg" />
                 <data android:pathPattern=".*\\..*\\.otg" />
                 <data android:pathPattern=".*\\..*\\..*\\.otg" />
@@ -560,13 +735,6 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.otg" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.otg" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.otg" />
-                <data android:pathPattern=".*\\.pdf" />
-                <data android:pathPattern=".*\\..*\\.pdf" />
-                <data android:pathPattern=".*\\..*\\..*\\.pdf" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.pdf" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.pdf" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.pdf" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.pdf" />
                 <data android:pathPattern=".*\\.docx" />
                 <data android:pathPattern=".*\\..*\\.docx" />
                 <data android:pathPattern=".*\\..*\\..*\\.docx" />
@@ -595,48 +763,6 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.dotm" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.dotm" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.dotm" />
-                <data android:pathPattern=".*\\.doc" />
-                <data android:pathPattern=".*\\..*\\.doc" />
-                <data android:pathPattern=".*\\..*\\..*\\.doc" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.doc" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.doc" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.doc" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.doc" />
-                <data android:pathPattern=".*\\.xlsx" />
-                <data android:pathPattern=".*\\..*\\.xlsx" />
-                <data android:pathPattern=".*\\..*\\..*\\.xlsx" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.xlsx" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xlsx" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xlsx" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xlsx" />
-                <data android:pathPattern=".*\\.xlsm" />
-                <data android:pathPattern=".*\\..*\\.xlsm" />
-                <data android:pathPattern=".*\\..*\\..*\\.xlsm" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.xlsm" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xlsm" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xlsm" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xlsm" />
-                <data android:pathPattern=".*\\.xltx" />
-                <data android:pathPattern=".*\\..*\\.xltx" />
-                <data android:pathPattern=".*\\..*\\..*\\.xltx" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.xltx" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xltx" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xltx" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xltx" />
-                <data android:pathPattern=".*\\.xltm" />
-                <data android:pathPattern=".*\\..*\\.xltm" />
-                <data android:pathPattern=".*\\..*\\..*\\.xltm" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.xltm" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xltm" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xltm" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xltm" />
-                <data android:pathPattern=".*\\.xls" />
-                <data android:pathPattern=".*\\..*\\.xls" />
-                <data android:pathPattern=".*\\..*\\..*\\.xls" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.xls" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xls" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xls" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xls" />
                 <data android:pathPattern=".*\\.pptx" />
                 <data android:pathPattern=".*\\..*\\.pptx" />
                 <data android:pathPattern=".*\\..*\\..*\\.pptx" />
@@ -679,6 +805,48 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.ppsm" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.ppsm" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.ppsm" />
+                <data android:pathPattern=".*\\.xlsx" />
+                <data android:pathPattern=".*\\..*\\.xlsx" />
+                <data android:pathPattern=".*\\..*\\..*\\.xlsx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.xlsx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xlsx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xlsx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xlsx" />
+                <data android:pathPattern=".*\\.xlsm" />
+                <data android:pathPattern=".*\\..*\\.xlsm" />
+                <data android:pathPattern=".*\\..*\\..*\\.xlsm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.xlsm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xlsm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xlsm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xlsm" />
+                <data android:pathPattern=".*\\.xltx" />
+                <data android:pathPattern=".*\\..*\\.xltx" />
+                <data android:pathPattern=".*\\..*\\..*\\.xltx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.xltx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xltx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xltx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xltx" />
+                <data android:pathPattern=".*\\.xltm" />
+                <data android:pathPattern=".*\\..*\\.xltm" />
+                <data android:pathPattern=".*\\..*\\..*\\.xltm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.xltm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xltm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xltm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xltm" />
+                <data android:pathPattern=".*\\.doc" />
+                <data android:pathPattern=".*\\..*\\.doc" />
+                <data android:pathPattern=".*\\..*\\..*\\.doc" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.doc" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.doc" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.doc" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.doc" />
+                <data android:pathPattern=".*\\.dot" />
+                <data android:pathPattern=".*\\..*\\.dot" />
+                <data android:pathPattern=".*\\..*\\..*\\.dot" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.dot" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.dot" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.dot" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.dot" />
                 <data android:pathPattern=".*\\.ppt" />
                 <data android:pathPattern=".*\\..*\\.ppt" />
                 <data android:pathPattern=".*\\..*\\..*\\.ppt" />
@@ -686,6 +854,48 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.ppt" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.ppt" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.ppt" />
+                <data android:pathPattern=".*\\.pot" />
+                <data android:pathPattern=".*\\..*\\.pot" />
+                <data android:pathPattern=".*\\..*\\..*\\.pot" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.pot" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.pot" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.pot" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.pot" />
+                <data android:pathPattern=".*\\.pps" />
+                <data android:pathPattern=".*\\..*\\.pps" />
+                <data android:pathPattern=".*\\..*\\..*\\.pps" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.pps" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.pps" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.pps" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.pps" />
+                <data android:pathPattern=".*\\.xls" />
+                <data android:pathPattern=".*\\..*\\.xls" />
+                <data android:pathPattern=".*\\..*\\..*\\.xls" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.xls" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xls" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xls" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xls" />
+                <data android:pathPattern=".*\\.xlt" />
+                <data android:pathPattern=".*\\..*\\.xlt" />
+                <data android:pathPattern=".*\\..*\\..*\\.xlt" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.xlt" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xlt" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xlt" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xlt" />
+                <data android:pathPattern=".*\\.xlm" />
+                <data android:pathPattern=".*\\..*\\.xlm" />
+                <data android:pathPattern=".*\\..*\\..*\\.xlm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.xlm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.xlm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.xlm" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.xlm" />
+                <data android:pathPattern=".*\\.pdf" />
+                <data android:pathPattern=".*\\..*\\.pdf" />
+                <data android:pathPattern=".*\\..*\\..*\\.pdf" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.pdf" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.pdf" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.pdf" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.pdf" />
                 <data android:pathPattern=".*\\.txt" />
                 <data android:pathPattern=".*\\..*\\.txt" />
                 <data android:pathPattern=".*\\..*\\..*\\.txt" />
@@ -693,6 +903,13 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.txt" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.txt" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.txt" />
+                <data android:pathPattern=".*\\.text" />
+                <data android:pathPattern=".*\\..*\\.text" />
+                <data android:pathPattern=".*\\..*\\..*\\.text" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.text" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.text" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.text" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.text" />
                 <data android:pathPattern=".*\\.csv" />
                 <data android:pathPattern=".*\\..*\\.csv" />
                 <data android:pathPattern=".*\\..*\\..*\\.csv" />

--- a/app/src/main/java/app/opendocument/droid/background/CoreLoader.kt
+++ b/app/src/main/java/app/opendocument/droid/background/CoreLoader.kt
@@ -86,8 +86,8 @@ class CoreLoader(context: Context?) : FileLoader(context, LoaderType.CORE) {
     }
 
     /**
-     * What the core renders itself, out of [SupportedDocumentTypes] so the folder browser and this
-     * cannot disagree about it.
+     * What the core renders itself, out of [SupportedDocumentTypes] - which asks odrcore's own
+     * format table rather than keeping a list, so this and the manifest cannot disagree about it.
      *
      * Text, csv and images are left out although the core takes those too - [RawLoader] is what
      * gives them their player or their viewer, and this answer is what lets it have its turn. The
@@ -182,13 +182,22 @@ class CoreLoader(context: Context?) : FileLoader(context, LoaderType.CORE) {
 
         if (keepDocument) {
             closeDocument()
-            if (file.isDocumentFile) {
+
+            // what the format could ever allow, which odrcore 6.1 answers without decoding
+            // anything. A document is only opened here when it might be kept, and opening one
+            // costs a second parse of the whole file (the TODO below) - so the formats that
+            // declare no editing, which is pdf and every spreadsheet and presentation the app
+            // renders, no longer pay for an answer that was always going to be no.
+            val capabilities = file.capabilities()
+
+            if (file.isDocumentFile && capabilities.edit && capabilities.save) {
                 // TODO this will cause a second load
                 val document = file.asDocumentFile().document()
 
                 // keep only what [edit] can do something with, and let the core be the one to say
-                // so - see [isDocumentEditable]. Holding a read only document open buys a second
-                // parse and nothing else.
+                // so - see [isDocumentEditable]. The declaration above is an upper bound; the
+                // document itself is the precise answer, and a read only one held open buys a
+                // second parse and nothing else.
                 if (document.isEditable && document.isSavable) {
                     this.document = document
                 } else {
@@ -246,7 +255,11 @@ class CoreLoader(context: Context?) : FileLoader(context, LoaderType.CORE) {
     fun edit(htmlDiff: String, outputPathPrefix: String): File {
         val document = checkNotNull(document) { "no editable document is open" }
 
-        val extension = Odr.fileTypeToString(document.fileType())
+        // the file type's own extension, not [Odr.fileTypeToString], which is its *name*: the two
+        // read alike for most formats but are not the same table, and the name is not always
+        // something a file can be called (odrcore 6.1 spells the encrypted ooxml one
+        // "ooxml_encrypted")
+        val extension = Odr.fileExtensionByFileType(document.fileType())
         val outputFile = File("$outputPathPrefix.$extension")
 
         Log.d(TAG, "HTML diff: $htmlDiff")
@@ -283,25 +296,22 @@ class CoreLoader(context: Context?) : FileLoader(context, LoaderType.CORE) {
         /**
          * The one http server of the process, started on the first [initialize] and never stopped.
          *
-         * Never stopped on purpose. Both of the ways odrcore lets a server go are unsafe while the
-         * thread that called [HttpServer.listen] is still inside it, and that thread only comes
-         * back some time after `stop()` asks it to:
+         * Never stopped, though no longer because stopping it was unsafe. Both of the ways odrcore
+         * let a server go used to drop the native server while the thread that called
+         * [HttpServer.listen] was still inside it - `close()` as a use after free that surfaced as
+         * a SIGSEGV in `httplib::Server::listen_internal`, and `stop()` by closing the listening
+         * socket twice, the second time after its fd number had been handed to whatever opened a
+         * file next (which android's fdsan catches by aborting the process, "attempted to close
+         * file descriptor N, actually owned by ZipArchive"). That was
+         * opendocument-app/OpenDocument.core#631, and odrcore 6.1 fixed it: `stop()` now closes the
+         * socket and waits for the accept loop to leave before releasing anything, so nothing is
+         * serving by the time it returns.
          *
-         * - `HttpServer.close()` destroys the native server there and then, which is a use after
-         *   free that surfaces as a SIGSEGV in `httplib::Server::listen_internal`. Dropping the
-         *   reference instead is no better - odrcore's `NativeResource` frees the handle from a
-         *   reference queue too.
-         * - `stop()` on its own closes the listening socket while the accept loop is still using
-         *   it, and closes it a second time on the way out. In between, the fd number is handed to
-         *   whatever opens a file next; on android fdsan catches that and aborts the process
-         *   ("attempted to close file descriptor N, actually owned by ZipArchive"), and on a
-         *   platform without fdsan it would quietly close someone else's file.
-         *
-         * Both are teardown only, so the loader does not tear down: [close] calls
-         * [HttpServer.clear] to drop the documents it published and leaves the socket listening.
-         * The process exit reclaims it, which is what was really doing the work before - nothing
-         * here ever outlived its process. Reported upstream as
-         * opendocument-app/OpenDocument.core#631.
+         * What is left is that there is nobody to stop it *for*. The server is process wide and
+         * shared - [RawLoader] publishes text files on it too - so no single loader's teardown is
+         * the end of it, and [close] drops what it published with [HttpServer.clear] and leaves the
+         * socket listening. The process exit reclaims it, which is what was really doing the work
+         * all along; nothing here ever outlived its process.
          *
          * A second consequence is that the port is bound once rather than once per service
          * lifetime, so [bind]'s fallback stops being reached by our own teardown.

--- a/app/src/main/java/app/opendocument/droid/background/MetadataLoader.kt
+++ b/app/src/main/java/app/opendocument/droid/background/MetadataLoader.kt
@@ -113,6 +113,11 @@ class MetadataLoader(context: Context?) : FileLoader(context, LoaderType.METADAT
                 }
             }
 
+            // whatever spelling this came out as, go on with the core's own from here: a provider
+            // is free to volunteer application/x-zip-compressed or application/csv, and the app
+            // claims those now, but the loaders behind us go by one mime type per format
+            mimetype = SupportedDocumentTypes.canonicalMimeType(mimetype)
+
             val resolution = MimeTypeResolver.resolve(mimetype, extension, MIME_TYPE_LOOKUP)
             mimetype = resolution.mimeType
 

--- a/app/src/main/java/app/opendocument/droid/background/RawLoader.kt
+++ b/app/src/main/java/app/opendocument/droid/background/RawLoader.kt
@@ -172,6 +172,10 @@ class RawLoader(
     }
 
     private companion object {
+        // one line per format rather than per spelling, because what reaches this loader has been
+        // through SupportedDocumentTypes.canonicalMimeType: a zip is application/zip here even when
+        // the provider called it application/x-zip-compressed. These are wider than what the app
+        // offers itself for - audio and video are worth playing once someone hands us one.
         val MIME_WHITELIST =
             arrayOf(
                 "text/",

--- a/app/src/main/java/app/opendocument/droid/background/SupportedDocumentTypes.kt
+++ b/app/src/main/java/app/opendocument/droid/background/SupportedDocumentTypes.kt
@@ -88,6 +88,33 @@ object SupportedDocumentTypes {
             .toSet()
     }
 
+    /**
+     * The spelling of [mimeType] the rest of the app goes by: odrcore's canonical one whenever the
+     * core recognizes what a provider handed us, and the original otherwise.
+     *
+     * Reading the core's table means the app now claims every spelling in it - `application/csv`,
+     * `application/x-zip-compressed`, `multipart/x-zip` - and not just the one the core happens to
+     * name first. [CoreLoader] does not care, it matches the whole set; [RawLoader] routes by mime
+     * type *prefix* and would refuse a file the app had just offered itself for, which the user
+     * sees as "cannot open" on a file they picked us for. [MetadataLoader] collapses them here
+     * instead, so every loader downstream sees one spelling per format.
+     *
+     * Anything the core does not name - audio and video, which only [RawLoader] deals with - passes
+     * through untouched.
+     */
+    fun canonicalMimeType(mimeType: String?): String? {
+        if (mimeType == null) {
+            return null
+        }
+
+        val fileType = Odr.fileTypeByMimetype(mimeType) ?: return mimeType
+        if (fileType == FileType.UNKNOWN) {
+            return mimeType
+        }
+
+        return Odr.mimetypeByFileType(fileType) ?: mimeType
+    }
+
     /** Whether [CoreLoader] is expected to render this - see [CORE_FILE_TYPES]. */
     fun isRenderedByCore(mimeType: String?): Boolean =
         mimeType != null && mimeType.lowercase() in CORE_MIME_TYPES

--- a/app/src/main/java/app/opendocument/droid/background/SupportedDocumentTypes.kt
+++ b/app/src/main/java/app/opendocument/droid/background/SupportedDocumentTypes.kt
@@ -1,136 +1,98 @@
 package app.opendocument.droid.background
 
+import app.opendocument.core.FileCategory
+import app.opendocument.core.FileType
+import app.opendocument.core.Odr
+
 /**
- * The one list of what the app claims to open, for both of the places that have to guess.
+ * What the app claims to open, read out of odrcore instead of kept here.
  *
- * There used to be two copies of this - one here for the folder browser, one in [CoreLoader] for
- * the loader - which is one copy too many for a set that only ever changes as a whole.
- * [isRenderedByCore] is what [CoreLoader.isSupported] answers with, [isSupported] adds what
- * [RawLoader] shows and the extension fallback on top, and the STRICT_CATCH `activity-alias` in
- * AndroidManifest.xml is the third and last declaration, which XML keeps out of reach.
- * `SupportedFormatsTest` walks this table and asks the package manager whether the manifest still
- * agrees, so the two cannot drift silently any more.
+ * This used to be three hand written lists - mime prefixes for the core, mime prefixes for
+ * [RawLoader] and an extension fallback - because odrcore only knew one canonical mime type and one
+ * extension per format, and none of the spellings a content provider actually hands out. odrcore
+ * 6.1 publishes its whole format table instead ([Odr.allFileTypes], [Odr.mimetypesByFileType],
+ * [Odr.fileExtensionsByFileType] and [Odr.capabilitiesByFileType]), so the lists are derived now
+ * and the app cannot claim a format the core does not have, or miss one it does.
  *
- * Deliberately free of Android dependencies, and of the core's own tables - odrcore does know
- * [app.opendocument.core.Odr.fileTypeByMimetype] and `fileTypeByFileExtension`, but both are native
- * calls into libodr_jni, and both only know one canonical mime type per format: no templates, no
- * macro enabled variants, no `application/x-vnd.oasis...`, which are exactly the spellings a
- * content provider hands out. What the core does decide is everything *after* the file is in the
- * cache - [MetadataLoader] runs its libmagic over it, and [CoreLoader.isDocumentEditable] asks the
- * opened document itself.
+ * Two declarations are left. The app's own choice of which of the core's formats to route
+ * where - [CORE_FILE_TYPES] against [RAW_FILE_TYPES] - and the STRICT_CATCH `activity-alias` in
+ * AndroidManifest.xml, which is XML and cannot read any of this. `SupportedFormatsTest` walks the
+ * core's table and asks the package manager whether the manifest still agrees, so the two cannot
+ * drift silently.
  *
- * So this is a guess, not the real answer: a folder listing only has a name and whatever mime type
- * the provider volunteered, and it has to go on appearances.
+ * These are still a guess, not the real answer: a folder listing only has a name and whatever mime
+ * type the provider volunteered, and it has to go on appearances. What the core *decides* is
+ * everything after the file is in the cache - [MetadataLoader] runs its libmagic over the copy, and
+ * [CoreLoader.isDocumentEditable] asks the opened document itself.
  */
 object SupportedDocumentTypes {
 
     /**
-     * What the core renders itself: opendocument, ooxml, the three legacy binary microsoft formats
-     * and pdf. odrcore keeps reference html output for every one of them, doc, ppt and xls
-     * included.
+     * What [CoreLoader] renders: every format odrcore declares it can turn into html and files as a
+     * document.
      *
-     * Matching by prefix carries the variants along: the ooxml prefix covers the templates, and the
-     * macro enabled ones are spelled `vnd.ms-word.document.macroEnabled.12` and so on, which is why
-     * the legacy powerpoint and excel types appear here without their subtypes and why
-     * `vnd.ms-word` is listed next to `msword`.
+     * That is the same rule the loader follows, so it is the core's answer rather than a list -
+     * today it selects opendocument, ooxml, the legacy binary doc/ppt/xls and pdf. The category
+     * narrows it to what belongs in a document viewer: the core translates text, csv, images, zip
+     * and fonts too, and the first three of those get their own viewer in [RawLoader] below.
+     *
+     * A format the core can name but not decode stays out on its own - `.xlsb` is the current
+     * example, an ooxml package with binary parts that the app used to claim because the mime type
+     * starts like an excel one.
      */
-    private val CORE_MIME_PREFIXES =
-        listOf(
-            // odf, including the master documents and the x- spelling some providers use
-            "application/vnd.oasis.opendocument",
-            "application/x-vnd.oasis.opendocument",
-            // ooxml: word, excel and powerpoint, their templates and their macro variants
-            "application/vnd.openxmlformats-officedocument",
-            "application/vnd.ms-word",
-            // legacy binary microsoft: doc, xls and ppt
-            "application/msword",
-            "application/vnd.ms-excel",
-            "application/vnd.ms-powerpoint",
-            // not a document, but the core renders it just the same
-            "application/pdf",
-        )
+    private val CORE_FILE_TYPES: List<FileType> by lazy {
+        Odr.allFileTypes().filter {
+            Odr.capabilitiesByFileType(it).translateHtml &&
+                Odr.fileCategoryByFileType(it) == FileCategory.DOCUMENT
+        }
+    }
 
     /**
-     * What [RawLoader] shows instead - text, csv, images and zip - which the core would take too
-     * but which get their own player or viewer here.
+     * What [RawLoader] shows instead, which the core would take too but which get their own player
+     * or viewer here.
      *
-     * Narrower than [RawLoader.isSupported], which also takes audio and video: those are worth
-     * playing once someone hands us one, but not worth offering the app for.
+     * Named rather than derived, because this is the app's own decision and nothing the core knows
+     * about: it is narrower than [RawLoader.isSupported], which also takes audio and video - those
+     * are worth playing once someone hands us one, but not worth offering the app for - and it
+     * leaves out json and markdown, which the core files as text but which nobody opens a document
+     * viewer for.
      */
-    private val RAW_MIME_PREFIXES = listOf("text/plain", "text/csv", "image/", "application/zip")
+    private val RAW_FILE_TYPES =
+        listOf(FileType.TEXT_FILE, FileType.COMMA_SEPARATED_VALUES, FileType.ZIP)
 
     /**
-     * The extensions odrcore's own `fileTypeByFileExtension` names, one suffix per format.
+     * Images, as a prefix rather than a set of file types.
      *
-     * Public so `SupportedFormatsTest` can hold each of them against that table - the assertion
-     * that this list stays a subset of what the core recognises.
+     * The core names png, gif, jpeg, bmp and starview metafiles; [RawLoader] hands anything at all
+     * to the WebView under a name it recognizes, so webp, heic and svg are worth offering for as
+     * well. The manifest declares the whole `image` type with a wildcard for the same reason.
      */
-    val CORE_EXTENSIONS: Set<String> =
-        setOf(
-            "odt",
-            "ods",
-            "odp",
-            "odg",
-            "ott",
-            "ots",
-            "otp",
-            "otg",
-            "doc",
-            "docx",
-            "xls",
-            "xlsx",
-            "ppt",
-            "pptx",
-            "pdf",
-            "txt",
-            "csv",
-            "zip",
-        )
+    private val RAW_MIME_PREFIXES = listOf("image/")
+
+    /** Every mime type spelling odrcore accepts for a format [CoreLoader] renders. */
+    val CORE_MIME_TYPES: Set<String> by lazy { mimeTypesOf(CORE_FILE_TYPES) }
+
+    /** The same for everything the app offers itself for, [RawLoader]'s share included. */
+    val MIME_TYPES: Set<String> by lazy { CORE_MIME_TYPES + mimeTypesOf(RAW_FILE_TYPES) }
 
     /**
-     * The ooxml templates, macro enabled documents and slideshows, which odrcore's extension table
-     * leaves out although it renders every one of them - they are the same packages as the `x`
-     * suffixed ones, and libmagic identifies them by content once the file is in the cache.
-     *
-     * Kept apart from [CORE_EXTENSIONS] so that a test can say which of the two invariants applies
-     * to which half, rather than quietly dropping the check for all of them.
+     * The extensions to fall back on, because providers regularly volunteer nothing better than
+     * `application/octet-stream` - and because a file manager that sends `ACTION_VIEW` with no mime
+     * type at all leaves the name as the only thing anyone can go on. That second case is what the
+     * `pathPattern` filters in AndroidManifest.xml cover, and they have to list exactly this set.
      */
-    val OOXML_VARIANT_EXTENSIONS: Set<String> =
-        setOf(
-            "docm",
-            "dotx",
-            "dotm",
-            "xlsm",
-            "xltx",
-            "xltm",
-            "pptm",
-            "potx",
-            "potm",
-            "ppsx",
-            "ppsm",
-        )
+    val EXTENSIONS: Set<String> by lazy {
+        (CORE_FILE_TYPES + RAW_FILE_TYPES)
+            .flatMap { Odr.fileExtensionsByFileType(it) }
+            .map { it.lowercase() }
+            .toSet()
+    }
 
-    /**
-     * The extensions to fall back on, spelling out the same set once more because providers
-     * regularly volunteer nothing better than `application/octet-stream` - and because a file
-     * manager that sends `ACTION_VIEW` with no mime type at all leaves the name as the only thing
-     * anyone can go on. That second case is what the `pathPattern` filters in AndroidManifest.xml
-     * cover, and they have to list exactly this set.
-     *
-     * The ooxml variants are here for the same reason [CORE_MIME_PREFIXES] matches by prefix: a
-     * `.dotx` is the same wordprocessing package as a `.docx`. Note that odrcore's own
-     * `fileTypeByFileExtension` does *not* know them - its extension table names one suffix per
-     * format - which is why [SupportedFormatsTest] holds only [CORE_EXTENSIONS] against it.
-     *
-     * Public so `SupportedFormatsTest` can walk it: it holds every one of these against the
-     * manifest.
-     */
-    val EXTENSIONS: Set<String> = CORE_EXTENSIONS + OOXML_VARIANT_EXTENSIONS
+    /** Whether [CoreLoader] is expected to render this - see [CORE_FILE_TYPES]. */
+    fun isRenderedByCore(mimeType: String?): Boolean =
+        mimeType != null && mimeType.lowercase() in CORE_MIME_TYPES
 
-    /** Whether [CoreLoader] is expected to render this - see [CORE_MIME_PREFIXES]. */
-    fun isRenderedByCore(mimeType: String?): Boolean = matches(mimeType, CORE_MIME_PREFIXES)
-
-    /** Whether the folder browser should offer this at all. */
+    /** Whether the app should offer itself for this at all. */
     fun isSupported(mimeType: String?, filename: String?): Boolean {
         // a recognised extension has to be able to win on its own, or every octet-stream is lost
         val extension = MimeTypeResolver.parseExtension(filename)?.lowercase()
@@ -138,16 +100,15 @@ object SupportedDocumentTypes {
             return true
         }
 
-        return isRenderedByCore(mimeType) || matches(mimeType, RAW_MIME_PREFIXES)
-    }
-
-    private fun matches(mimeType: String?, prefixes: List<String>): Boolean {
         if (mimeType == null) {
             return false
         }
 
         val normalized = mimeType.lowercase()
 
-        return prefixes.any { normalized.startsWith(it) }
+        return normalized in MIME_TYPES || RAW_MIME_PREFIXES.any { normalized.startsWith(it) }
     }
+
+    private fun mimeTypesOf(fileTypes: List<FileType>): Set<String> =
+        fileTypes.flatMap { Odr.mimetypesByFileType(it) }.map { it.lowercase() }.toSet()
 }


### PR DESCRIPTION
Updates the `conan-odr-index` submodule to `0e10e96` and takes **odrcore 6.1.0**, then
uses what 6.1 added.

## The app stops keeping its own format table

odrcore 6.1 publishes the whole thing — `allFileTypes`, `mimetypesByFileType`,
`fileExtensionsByFileType` and a per file type `capabilitiesByFileType` — which is
exactly what `SupportedDocumentTypes` existed to work around. It was three hand
written lists of mime *prefixes*, because the core only ever named one canonical mime
type and one extension per format, and none of the spellings a content provider hands
out.

It derives all of it now. What `CoreLoader` renders is every file type whose declared
capabilities include `translateHtml` and whose category is `document`; which of the
core's formats go to `RawLoader` instead — text, csv, zip and `image/` — stays an app
decision, since the core knows nothing about that.

The result is 40 mime types where the prefixes matched 8, and 41 extensions where
there were 29:

| now reaches the app | was not claimed before |
| --- | --- |
| `application/vnd.oasis.opendocument.*-flat-xml`, `-master-template` | the single file xml flavors |
| `.fodt` `.fods` `.fodp` `.fodg` `.odm` `.otm` | the same, by name |
| `.dot` `.pot` `.pps` `.xlt` `.xlm` | legacy templates |
| `application/msexcel`, `application/mspowerpoint`, `application/x-pdf` | aliases the core names |
| `.potm` `.text` | filled in the gaps in the ooxml/text sets |

and one format is dropped: `.xlsb` is an ooxml package with binary parts and no
decoder, and its mime type starts like every other excel one, so the prefix match
claimed it and then failed to open it. 6.1 gives it a file type of its own with an
all-false capability row.

The `STRICT_CATCH` intent-filters are generated from the same table (XML cannot read
it), and `SupportedFormatsTest` is what proves the two agree — it now walks *every*
mime type of every file type rather than one per format, so the hand written ooxml
variant list it used to need is gone.

## Two smaller uses of the new API

- `host()` asks `DecodedFile.capabilities()` before opening a document. Opening one
  costs a second parse of the whole file (the `TODO` that is still there), and the
  formats that declare no editing — pdf and every spreadsheet and presentation the app
  renders — were paying it only to be told no. The document itself is still the
  precise answer for the formats that get that far.
- `edit()` names the output file with `fileExtensionByFileType` instead of
  `fileTypeToString`, which is the type's *name* and not always something a file can
  be called.

## What comes along without changes here

- `fix(jni): keep a wrapper reachable while its handle is in a native call` (#635)
- `fix(http-server): make stop() and destruction wait for listen()` (#633), which
  closes OpenDocument.core#631 — the crash the long comment in `startSharedServer` was
  written around. The comment is updated: the server is still never stopped, but now
  because it is process wide and shared with `RawLoader` and there is nobody to stop
  it for, not because stopping it would SIGSEGV or trip fdsan.

The maven artifacts of `feat(maven): publish both artifacts to maven central` (#630)
are deliberately not used — the jar and the `.so` keep coming out of the one conan
package, per CLAUDE.md.

## Tests

`CoreLoaderTest`, `SupportedDocumentTypesTest` and `OnlineLoaderTest` move from unit
tests to instrumented ones. The tables live in `libodr_jni`; none of these opens a
file, they just cannot ask the table from a plain JVM.

- `./gradlew assembleProDebug testProDebugUnitTest lintProDebug lintLiteDebug spotlessCheck` ✅
- `./gradlew connectedProDebugAndroidTest` on a Pixel 6 Pro AVD (API 31): **46 tests, 0 failed** ✅

## One thing to know about building this

odrcore 6.1 made the JDK lookup non-`REQUIRED` on android, so a conan build with no
`JAVA_HOME`/`javac` in its environment now silently produces `libodr_jni.so` and no
`odr-core-java.jar`, and the deployer fails much later with a confusing
`FileNotFoundError`. Filed as opendocument-app/OpenDocument.core#637; noted in
CLAUDE.md until it is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)