### PR TITLE
Ask for an in-app review in the lite flavor again

### DIFF
--- a/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
@@ -489,12 +489,15 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
 
         state.endLoadIdling()
 
-        // in-app review is requested in the pro flavor only. The lite branch used to
-        // consult a "show_in_app_rating" remote config key, which has resolved to nothing
-        // since firebase remote config was removed, so lite never asked either way.
-        if (resources.getBoolean(R.bool.DISABLE_TRACKING)) {
-            requestInAppRating(activity)
-        }
+        // asked for in both flavors, and deliberately not behind a flag. lite used to
+        // consult a "show_in_app_rating" remote config key, which has returned false since
+        // firebase remote config was gutted in v4.2 - the call site was never touched, so
+        // nothing looked broken while the flavor carrying almost every user silently
+        // stopped asking. play decides whether the sheet actually appears (undocumented
+        // per-user quota) and reports nothing back either way, so there is nothing here
+        // worth gating: DISABLE_TRACKING means crash and analytics reporting, which this
+        // is not.
+        requestInAppRating(activity)
     }
 
     override fun onError(result: FileLoader.Result, error: Throwable) {


### PR DESCRIPTION
Lite stopped asking for reviews in **v4.2 (Dec 14, 2025)** and nobody noticed for seven months. This restores it.

## What broke

The call site was never changed. Lite's branch consulted the `show_in_app_rating` remote config key, and when firebase remote config was removed (`14bd3415`, `9ec7f9c5`) `ConfigManager.getBooleanConfig(String)` was gutted:

| | v4.1 | v4.2 |
|---|---|---|
| `getBooleanConfig(key)` | `return remoteConfig.getBoolean(key)` | `return false;` |

Both paths through the gate then dead-end — disabled hands the callback `null` and the null check fails, enabled returns `false` and the value check fails. So the flavor carrying almost every user asked nobody, while pro kept working.

The `if (DISABLE_TRACKING)` form currently in the tree is **not** the cause: it came later, in `713b4e64` / `301593f0` (v4.8.0), and only recorded the state it found.

## What it cost

Monthly ratings from the Play Console review reports:

| | 25-07 | 25-08 | 25-09 | 25-10 | 25-11 | 25-12 | 26-01 | 26-02 | 26-03 | 26-04 | 26-05 | 26-06 | 26-07 |
|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
| **Lite** | 503 | 455 | 540 | 555 | 489 | **317** | **73** | 50 | 21 | 15 | 35 | 39 | 12 |
| **Pro** | 6 | 15 | 16 | 12 | 7 | 13 | 10 | 7 | 11 | 5 | 6 | 8 | 10 |

Pro is flat throughout, which is what points at the flavor gate rather than at demand.

The visible average fell with it, 4.54 → 4.08 for lite, but that is composition rather than regression: what disappeared is the prompted five-star flow, leaving only self-motivated reviewers. Per-version averages after v4.2 sit on samples of 5–27 ratings and should not be read as evidence about those releases.

## Why no flag

A replacement flag would be `true` in both flavors, which makes it a constant rather than a flavor flag. Play decides whether the sheet is shown at all — undocumented per-user quota — and reports nothing back, so there is nothing here for the app to gate.

`DISABLE_TRACKING` is about crash and analytics reporting; it is used that way, inverted, in `LoaderService.kt:81` and `MainActivity.kt:337`. Reusing it as a stand-in for "is pro" in the third site is what made this hard to see. If a degoogled flavor ever lands, it will need more than this one flag — `play.services.ads`, `play.review` and `user.messaging.platform` are all unconditioned `implementation` deps.

## Nothing else has to change

- `requestReviewFlow()` already fails into the existing `in_app_review_error` branch on installs that did not come from Play (F-Droid, sideloaded).
- The `analyticsManager.report(...)` calls inside `requestInAppRating` are no-ops in pro, since `AnalyticsManager` is disabled there. In lite they start reporting again — `in_app_review_eligible` vs `in_app_review_error` is what would have surfaced this in the first place.
- No test asserted the pro-only behaviour.

## Follow-up worth considering separately

The call sits in `onLoadSuccess`, so it fires on every document open. Play's quota absorbs that, but when the quota does allow it the card lands mid-read. Moving it to a quieter moment would be an improvement, and is deliberately not in this PR.

## Verification

`spotlessCheck`, `assembleLiteDebug`, `assembleProDebug`, `lintProDebug` and `testProDebugUnitTest` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)