### PR TITLE
Ask for a review at two earned moments instead of on every load

### DIFF
--- a/app/src/main/java/app/opendocument/droid/background/UsageCounters.kt
+++ b/app/src/main/java/app/opendocument/droid/background/UsageCounters.kt
@@ -1,0 +1,38 @@
+package app.opendocument.droid.background
+
+import android.content.Context
+import android.content.SharedPreferences
+
+/**
+ * How often the user opened the app from the launcher, and how many documents they opened.
+ *
+ * A counter rather than the length of the recently opened list: that list is capped, pruned and
+ * deletable, so it undercounts exactly the returning users this is meant to find.
+ */
+object UsageCounters {
+
+    private const val KEY_APP_OPENS = "usage_app_opens"
+    private const val KEY_DOCUMENT_OPENS = "usage_document_opens"
+
+    fun recordAppOpen(context: Context): Int = increment(context, KEY_APP_OPENS)
+
+    fun recordDocumentOpen(context: Context): Int = increment(context, KEY_DOCUMENT_OPENS)
+
+    fun appOpens(context: Context): Int = preferences(context).getInt(KEY_APP_OPENS, 0)
+
+    fun documentOpens(context: Context): Int = preferences(context).getInt(KEY_DOCUMENT_OPENS, 0)
+
+    private fun increment(context: Context, key: String): Int {
+        val preferences = preferences(context)
+        val next = preferences.getInt(key, 0) + 1
+
+        // apply, not commit: nothing reads this back synchronously
+        preferences.edit().putInt(key, next).apply()
+
+        return next
+    }
+
+    /** The same default preference file [CatchAllSetting] uses. */
+    private fun preferences(context: Context): SharedPreferences =
+        context.getSharedPreferences(context.packageName + "_preferences", Context.MODE_PRIVATE)
+}

--- a/app/src/main/java/app/opendocument/droid/nonfree/InAppReview.kt
+++ b/app/src/main/java/app/opendocument/droid/nonfree/InAppReview.kt
@@ -1,0 +1,47 @@
+package app.opendocument.droid.nonfree
+
+import android.app.Activity
+import com.google.android.play.core.review.ReviewManagerFactory
+
+/**
+ * The play in-app review sheet.
+ *
+ * Play decides from an undocumented per-user quota whether the sheet appears at all, and the
+ * completion listener fires the same way either way. The analytics events below are the only
+ * visibility there is.
+ */
+object InAppReview {
+
+    /**
+     * Opens before the first ask - a fresh install has nothing to say yet, and asking costs stars.
+     */
+    const val MINIMUM_OPENS: Int = 3
+
+    fun requestIfEarned(activity: Activity, analyticsManager: AnalyticsManager, opens: Int) {
+        if (opens < MINIMUM_OPENS) {
+            return
+        }
+
+        request(activity, analyticsManager)
+    }
+
+    fun request(activity: Activity, analyticsManager: AnalyticsManager) {
+        analyticsManager.report("in_app_review_eligible")
+
+        val manager = ReviewManagerFactory.create(activity)
+        manager.requestReviewFlow().addOnCompleteListener { reviewInfoTask ->
+            if (!reviewInfoTask.isSuccessful) {
+                // usually an install that did not come from play, so there is no store to ask
+                analyticsManager.report("in_app_review_error")
+
+                return@addOnCompleteListener
+            }
+
+            analyticsManager.report("in_app_review_start")
+
+            manager.launchReviewFlow(activity, reviewInfoTask.result).addOnCompleteListener {
+                analyticsManager.report("in_app_review_done")
+            }
+        }
+    }
+}

--- a/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
@@ -27,15 +27,16 @@ import app.opendocument.droid.background.FileLoader
 import app.opendocument.droid.background.LoaderService
 import app.opendocument.droid.background.LoaderServiceQueue
 import app.opendocument.droid.background.StreamUtil
+import app.opendocument.droid.background.UsageCounters
 import app.opendocument.droid.nonfree.AnalyticsConstants
 import app.opendocument.droid.nonfree.AnalyticsManager
 import app.opendocument.droid.nonfree.CrashManager
+import app.opendocument.droid.nonfree.InAppReview
 import app.opendocument.droid.ui.OpenFileIdling
 import app.opendocument.droid.ui.SnackbarHelper
 import app.opendocument.droid.ui.widget.PageView
 import app.opendocument.droid.ui.widget.ProgressDialogFragment
 import com.google.android.material.tabs.TabLayout
-import com.google.android.play.core.review.ReviewManagerFactory
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
@@ -60,6 +61,9 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
 
     private var resultOnStart: FileLoader.Result? = null
     private var errorOnStart: Throwable? = null
+
+    /** Set by [loadUri], consumed by the load it belongs to. See [loadUri]. */
+    private var freshOpenPending = false
 
     private lateinit var tabLayout: TabLayout
 
@@ -303,8 +307,18 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
         serviceQueue.addToQueue { service -> service.loadWithType(loaderType, options) }
     }
 
-    fun loadUri(uri: Uri, persistentUri: Boolean, editable: Boolean = false) {
+    /**
+     * [freshOpen] is false for a load the user did not ask for, which then never asks for a review.
+     */
+    fun loadUri(
+        uri: Uri,
+        persistentUri: Boolean,
+        editable: Boolean = false,
+        freshOpen: Boolean = true,
+    ) {
         initializePageView()
+
+        freshOpenPending = freshOpen
 
         state.lastRequestedUri = uri
 
@@ -319,6 +333,9 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
     fun reloadUri(translatable: Boolean) {
         val lastResult = checkNotNull(state.lastResult) { "nothing was loaded yet" }
         lastResult.options.translatable = translatable
+
+        // entering or leaving edit mode is not a new document, and the user is working
+        freshOpenPending = false
 
         loadWithType(lastResult.loaderType, lastResult.options)
     }
@@ -411,25 +428,6 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
         pageView?.toggleDarkMode(fileType?.startsWith("application/pdf") != true)
     }
 
-    private fun requestInAppRating(activity: Activity) {
-        analyticsManager.report("in_app_review_eligible")
-
-        val manager = ReviewManagerFactory.create(activity)
-        manager.requestReviewFlow().addOnCompleteListener { reviewInfoTask ->
-            if (!reviewInfoTask.isSuccessful) {
-                analyticsManager.report("in_app_review_error")
-
-                return@addOnCompleteListener
-            }
-
-            analyticsManager.report("in_app_review_start")
-
-            manager.launchReviewFlow(activity, reviewInfoTask.result).addOnCompleteListener {
-                analyticsManager.report("in_app_review_done")
-            }
-        }
-    }
-
     private fun isActivityReadyForResult(result: FileLoader.Result): Boolean {
         val lastRequestedUri = state.lastRequestedUri
         if (lastRequestedUri != null && lastRequestedUri != result.options.originalUri) {
@@ -489,15 +487,17 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
 
         state.endLoadIdling()
 
-        // asked for in both flavors, and deliberately not behind a flag. lite used to
-        // consult a "show_in_app_rating" remote config key, which has returned false since
-        // firebase remote config was gutted in v4.2 - the call site was never touched, so
-        // nothing looked broken while the flavor carrying almost every user silently
-        // stopped asking. play decides whether the sheet actually appears (undocumented
-        // per-user quota) and reports nothing back either way, so there is nothing here
-        // worth gating: DISABLE_TRACKING means crash and analytics reporting, which this
-        // is not.
-        requestInAppRating(activity)
+        // only a fresh open earns the ask - reloadUri and the webview reach here mid-task.
+        // a save reloads through loadUri and so still counts, which is wanted
+        if (freshOpenPending) {
+            freshOpenPending = false
+
+            InAppReview.requestIfEarned(
+                activity,
+                analyticsManager,
+                UsageCounters.recordDocumentOpen(activity),
+            )
+        }
     }
 
     override fun onError(result: FileLoader.Result, error: Throwable) {

--- a/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
@@ -35,11 +35,13 @@ import app.opendocument.droid.background.LoaderService
 import app.opendocument.droid.background.LoaderServiceQueue
 import app.opendocument.droid.background.PersistedUriPermissions
 import app.opendocument.droid.background.PrintingManager
+import app.opendocument.droid.background.UsageCounters
 import app.opendocument.droid.nonfree.AdManager
 import app.opendocument.droid.nonfree.AnalyticsConstants
 import app.opendocument.droid.nonfree.AnalyticsManager
 import app.opendocument.droid.nonfree.BillingManager
 import app.opendocument.droid.nonfree.CrashManager
+import app.opendocument.droid.nonfree.InAppReview
 import app.opendocument.droid.ui.EditActionModeCallback
 import app.opendocument.droid.ui.FindActionModeCallback
 import app.opendocument.droid.ui.OpenFileIdling
@@ -108,6 +110,9 @@ class MainActivity : AppCompatActivity(), MenuProvider {
     // to that app), while documents opened from within the app go back to the
     // landing screen instead of closing the app
     private var documentOpenedExternally = false
+
+    // launched from the launcher rather than with a document, consumed by the next onStart
+    private var openedDirectly = false
 
     lateinit var loaderServiceQueue: LoaderServiceQueue
         private set
@@ -247,11 +252,15 @@ class MainActivity : AppCompatActivity(), MenuProvider {
                 )
             } else {
                 analyticsManager.setCurrentScreen(this, "screen_main")
+
+                openedDirectly = true
             }
         } else {
             crashManager.log("onCreate empty")
 
             analyticsManager.setCurrentScreen(this, "screen_main")
+
+            openedDirectly = true
         }
 
         addMenuProvider(this, this)
@@ -259,6 +268,13 @@ class MainActivity : AppCompatActivity(), MenuProvider {
 
     override fun onStart() {
         super.onStart()
+
+        if (openedDirectly) {
+            openedDirectly = false
+
+            // the landing screen, before the user has picked anything
+            InAppReview.requestIfEarned(this, analyticsManager, UsageCounters.recordAppOpen(this))
+        }
 
         documentFragment =
             supportFragmentManager.findFragmentByTag(DOCUMENT_FRAGMENT_TAG) as DocumentFragment?

--- a/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
@@ -111,8 +111,9 @@ class MainActivity : AppCompatActivity(), MenuProvider {
     // landing screen instead of closing the app
     private var documentOpenedExternally = false
 
-    // launched from the launcher rather than with a document, consumed by the next onStart
-    private var openedDirectly = false
+    // set before we start an activity of our own, so coming back from it is not counted as
+    // the user opening the app
+    private var leftForOwnActivity = false
 
     lateinit var loaderServiceQueue: LoaderServiceQueue
         private set
@@ -252,15 +253,11 @@ class MainActivity : AppCompatActivity(), MenuProvider {
                 )
             } else {
                 analyticsManager.setCurrentScreen(this, "screen_main")
-
-                openedDirectly = true
             }
         } else {
             crashManager.log("onCreate empty")
 
             analyticsManager.setCurrentScreen(this, "screen_main")
-
-            openedDirectly = true
         }
 
         addMenuProvider(this, this)
@@ -268,13 +265,6 @@ class MainActivity : AppCompatActivity(), MenuProvider {
 
     override fun onStart() {
         super.onStart()
-
-        if (openedDirectly) {
-            openedDirectly = false
-
-            // the landing screen, before the user has picked anything
-            InAppReview.requestIfEarned(this, analyticsManager, UsageCounters.recordAppOpen(this))
-        }
 
         documentFragment =
             supportFragmentManager.findFragmentByTag(DOCUMENT_FRAGMENT_TAG) as DocumentFragment?
@@ -285,6 +275,20 @@ class MainActivity : AppCompatActivity(), MenuProvider {
         }
 
         crashManager.log("onStart")
+
+        // here rather than in onCreate: tapping the launcher while the task is still alive
+        // resumes this activity instead of creating it, and those opens count too
+        if (documentFragment == null && loadOnStart == null) {
+            if (leftForOwnActivity) {
+                leftForOwnActivity = false
+            } else {
+                InAppReview.requestIfEarned(
+                    this,
+                    analyticsManager,
+                    UsageCounters.recordAppOpen(this),
+                )
+            }
+        }
 
         val loadOnStart = this.loadOnStart ?: return
 
@@ -342,6 +346,7 @@ class MainActivity : AppCompatActivity(), MenuProvider {
 
             intent.type = documentFragment.lastFileType
 
+            leftForOwnActivity = true
             createDocumentLauncher.launch(intent)
         } catch (e: ActivityNotFoundException) {
             // happens on a variety devices, e.g. Samsung Galaxy Tab4 7.0 with Android 4.4.2
@@ -706,6 +711,7 @@ class MainActivity : AppCompatActivity(), MenuProvider {
             try {
                 OpenFileIdling.increment()
 
+                leftForOwnActivity = true
                 openDocumentLauncher.launch(intent)
             } catch (e: Exception) {
                 OpenFileIdling.decrement()

--- a/app/src/main/java/app/opendocument/droid/ui/widget/PageView.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/widget/PageView.kt
@@ -222,7 +222,12 @@ constructor(context: Context, attributeSet: AttributeSet?) :
             }
 
             post {
-                documentFragment.loadUri(AndroidFileCache.getCacheFileUri(context, tmpFile), false)
+                // the user is mid-read, not opening something
+                documentFragment.loadUri(
+                    AndroidFileCache.getCacheFileUri(context, tmpFile),
+                    false,
+                    freshOpen = false,
+                )
             }
         } catch (e: IOException) {
             crashManager.log(e)


### PR DESCRIPTION
Follow-up to #559. That PR restored the review request in lite; this one fixes *when* it fires.

## The problem

`onLoadSuccess` is reached by more than "the user opened a document":

| trigger | user state |
|---|---|
| fresh open — `MainActivity.loadUri` (intent, picker, recent list) | just opened ✅ |
| `onStart()` replay — result arrived while stopped | returning ✅ |
| entering edit mode — `EditActionModeCallback:35` → `reloadUri(true)` | mid-task ❌ |
| leaving edit mode — `EditActionModeCallback:59` → `reloadUri(false)` | mid-task ❌ |
| after a save — `onSaveSuccess` → `loadUri(...)` | success, worth asking ✅ |
| webview hands back a file — `PageView.sendFile` → `loadUri(...)` | mid-read ❌ |

Toggling edit mode twice asked twice, while the user was working.

## The change

`loadUri` takes a `freshOpen` flag, `reloadUri` clears it, and `onLoadSuccess` only asks when the load was one the user asked for. `PageView.sendFile` passes `freshOpen = false`.

Saving still counts, because `onSaveSuccess` reloads through `loadUri` — that's a success the user just caused. So "keep it on save, drop it on enter/exit" falls out of one condition rather than three special cases.

The landing screen becomes the second moment, for people who open the app and browse rather than arriving with a document from another app.

## The threshold

Both moments are counted in the new `UsageCounters`, and neither asks until the **third** open. A fresh install has nothing to say yet, and asking anyway costs stars — one of the 1★ reviews in the console is literally *"not used it but asking for a review"*.

A counter rather than the length of the recently opened list: that list is capped, pruned and user-deletable, so it undercounts exactly the returning users this is meant to find, and it counts distinct documents rather than visits. `MINIMUM_OPENS` is one constant if 3 turns out to be the wrong number.

`requestInAppRating` moves out of `DocumentFragment` into `nonfree/InAppReview` so both call sites share it — also where the Play dependency belongs.

## Notes

- The two counters are independent, so someone who only ever opens documents from other apps still earns the ask on the document side.
- No behaviour change for pro beyond the timing: it was already asking.
- `in_app_review_eligible` / `_error` / `_start` / `_done` now report from lite too, which is the visibility that would have caught the v4.2 regression.

## Verification

`spotlessCheck`, `assembleLiteDebug`, `assembleProDebug`, `lintProDebug` and `testProDebugUnitTest` pass locally. The flow itself can't be exercised off a Play install — `requestReviewFlow()` fails into the existing `in_app_review_error` branch — so this is reviewed by reading, not by running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)