### PR TITLE
Stop a failed save from destroying the document it was saving

### DIFF
--- a/app/src/main/java/app/opendocument/droid/background/LoaderService.kt
+++ b/app/src/main/java/app/opendocument/droid/background/LoaderService.kt
@@ -15,6 +15,7 @@ import app.opendocument.droid.nonfree.CrashManager
 import app.opendocument.droid.ui.activity.DocumentFragment
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
+import java.io.File
 
 /**
  * Owns the four loaders and the background thread they run on, and decides what to try next when
@@ -203,11 +204,21 @@ class LoaderService : Service(), FileLoader.FileLoaderListener {
     private fun saveSync(lastResult: FileLoader.Result, outFile: Uri, htmlDiff: String?) {
         val options = lastResult.options
 
+        // only the retranslated file is ours to remove afterwards - the other branch hands back
+        // the cache file of the document that is still open
+        var retranslated: File? = null
+        var backup: File? = null
+        var backupIsTheLastCopy = false
+
         try {
             val fileToSave =
                 if (htmlDiff != null) {
-                    coreLoader.retranslate(options, htmlDiff)
-                        ?: throw RuntimeException("retranslate failed")
+                    val edited =
+                        coreLoader.retranslate(options, htmlDiff)
+                            ?: throw RuntimeException("retranslate failed")
+                    retranslated = edited
+
+                    edited
                 } else {
                     // "full save" from the main UI
                     checkNotNull(
@@ -217,13 +228,16 @@ class LoaderService : Service(), FileLoader.FileLoaderListener {
                     }
                 }
 
-            val outputStream =
-                checkNotNull(contentResolver.openOutputStream(outFile)) { "cannot write $outFile" }
-            StreamUtil.copy(fileToSave, outputStream)
-            outputStream.close()
+            // the write goes straight into the user's own document, so keep what is there
+            // until the new content has landed whole
+            backup = backUp(outFile)
 
-            if (htmlDiff != null) {
-                fileToSave.delete()
+            try {
+                writeTo(outFile, fileToSave)
+            } catch (e: Throwable) {
+                backupIsTheLastCopy = !restore(outFile, backup)
+
+                throw e
             }
 
             mainHandler.post { withListener { it.onSaveSuccess(outFile) } }
@@ -235,7 +249,75 @@ class LoaderService : Service(), FileLoader.FileLoaderListener {
             )
             crashManager.log(e, options.originalUri)
 
-            withListener { it.onSaveError() }
+            mainHandler.post { withListener { it.onSaveError() } }
+        } finally {
+            retranslated?.delete()
+
+            // if the rollback did not get the old content back in, this copy is all that is
+            // left of it - leave it in the cache rather than finishing the job
+            if (!backupIsTheLastCopy) {
+                backup?.delete()
+            }
+        }
+    }
+
+    /** Copies [source] over [uri], truncating whatever was there. */
+    private fun writeTo(uri: Uri, source: File) {
+        // "wt" and not the default "w": not every provider truncates for "w", which leaves the
+        // tail of a longer previous document sitting behind the new content. for a zip container
+        // like odt or docx that trailing garbage is what makes the file stop opening
+        val outputStream =
+            try {
+                contentResolver.openOutputStream(uri, "wt")
+            } catch (e: Exception) {
+                // a provider that rejects the mode outright - saving at all beats truncating
+                crashManager.log(e, uri)
+
+                contentResolver.openOutputStream(uri)
+            }
+
+        checkNotNull(outputStream) { "cannot write $uri" }.use { StreamUtil.copy(source, it) }
+    }
+
+    /** What [uri] holds right now, so a half finished write can be rolled back. */
+    private fun backUp(uri: Uri): File? {
+        val backup = AndroidFileCache.createCacheFile(this)
+
+        return try {
+            val input = checkNotNull(contentResolver.openInputStream(uri)) { "cannot read $uri" }
+            StreamUtil.copy(input, backup)
+
+            if (backup.length() > 0) {
+                backup
+            } else {
+                // a document that was just created has nothing worth keeping
+                backup.delete()
+
+                null
+            }
+        } catch (e: Throwable) {
+            // unreadable target: no worse than before, the save just cannot be rolled back
+            crashManager.log(e, uri)
+            backup.delete()
+
+            null
+        }
+    }
+
+    /** Puts [backup] back into [uri]. False if the old content could not be restored. */
+    private fun restore(uri: Uri, backup: File?): Boolean {
+        if (backup == null) {
+            return false
+        }
+
+        return try {
+            writeTo(uri, backup)
+
+            true
+        } catch (e: Throwable) {
+            crashManager.log(e, uri)
+
+            false
         }
     }
 

--- a/app/src/main/java/app/opendocument/droid/background/LoaderService.kt
+++ b/app/src/main/java/app/opendocument/droid/background/LoaderService.kt
@@ -261,11 +261,13 @@ class LoaderService : Service(), FileLoader.FileLoaderListener {
         }
     }
 
-    /** Copies [source] over [uri], truncating whatever was there. */
-    private fun writeTo(uri: Uri, source: File) {
+    /** Copies [source] over [uri]. False if the provider would not truncate first. */
+    private fun writeTo(uri: Uri, source: File): Boolean {
         // "wt" and not the default "w": not every provider truncates for "w", which leaves the
         // tail of a longer previous document sitting behind the new content. for a zip container
         // like odt or docx that trailing garbage is what makes the file stop opening
+        var truncated = true
+
         val outputStream =
             try {
                 contentResolver.openOutputStream(uri, "wt")
@@ -273,10 +275,14 @@ class LoaderService : Service(), FileLoader.FileLoaderListener {
                 // a provider that rejects the mode outright - saving at all beats truncating
                 crashManager.log(e, uri)
 
+                truncated = false
+
                 contentResolver.openOutputStream(uri)
             }
 
         checkNotNull(outputStream) { "cannot write $uri" }.use { StreamUtil.copy(source, it) }
+
+        return truncated
     }
 
     /** What [uri] holds right now, so a half finished write can be rolled back. */
@@ -304,7 +310,11 @@ class LoaderService : Service(), FileLoader.FileLoaderListener {
         }
     }
 
-    /** Puts [backup] back into [uri]. False if the old content could not be restored. */
+    /**
+     * Puts [backup] back into [uri]. False if the old content could not be restored - including the
+     * case where it went in without truncating, which leaves the tail of the failed save behind it
+     * and is no more readable than what it replaced.
+     */
     private fun restore(uri: Uri, backup: File?): Boolean {
         if (backup == null) {
             return false
@@ -312,8 +322,6 @@ class LoaderService : Service(), FileLoader.FileLoaderListener {
 
         return try {
             writeTo(uri, backup)
-
-            true
         } catch (e: Throwable) {
             crashManager.log(e, uri)
 


### PR DESCRIPTION
`saveSync` opened the user's own document and copied into it in place. The window between "destination truncated" and "new content written" was one where any throw left them with a mangled file and a "save failed" toast.

One of the 1★ reviews in the console is exactly that: *"tried to save, and got an 'Internal Server Error' that destroyed the file. Good thing it was a copy."* Another: *"it's going to make you save a new document only to discover it saved none of your changes."*

## Four problems, in rising order of how often they bite

**1. Mode `"w"` is not required to truncate.** That's what `"wt"` is for. Saving a document *shorter* than the one already there left the tail of the old file behind the new content — and for a zip container like odt or docx, trailing bytes after the central directory are what make it stop opening. **This needs no failure at all to happen**, which makes it the likely everyday corruptor rather than the dramatic one.

A provider that rejects the mode outright falls back to `"w"`, so this cannot make saving fail anywhere it works today.

**2. `close()` was not in a `finally`.** Any throw during the copy leaked the descriptor and left flushing undefined. `StreamUtil.copy` explicitly documents *"Closes the input, never the output — the caller owns that one."* It's a `use` block now.

**3. The retranslated temp file was only deleted on success**, so a failed save leaked it. Now deleted in a `finally` — and only that one: the other branch hands back the cache file of the document that is still open, which must survive.

**4. Nothing was kept, so a half-written destination could not be undone.** The current content is now copied into the cache before the write and put back if the write throws. If the rollback itself fails, that copy is deliberately *left behind* rather than deleted — at that point it is the only copy of the user's document that exists.

## Also

`onSaveError` is posted to the main handler, which `onSaveSuccess` already was. The listener touches fragment state and calls `requireActivity()`, neither of which belongs on the loader's background thread. (`SnackbarHelper` defends itself with `runOnUiThread`, so this was not visibly crashing — it was just wrong.)

## On testing — worth being straight about

**None of this is meaningfully covered, and I could not find an honest way to cover it in this repo.**

- The truncation fix cannot be demonstrated here. The only content provider available to a test is the app's own `FileProvider`, and `FileProvider.modeToMode` maps `"w"` to `MODE_TRUNCATE` anyway — so a test would pass identically with and without the fix. The providers that *don't* truncate are third-party `DocumentsProvider`s (Drive, Proton, various file managers), which a test cannot stand up.
- The rollback path needs a write that fails *partway*. A destination that fails to open never gets truncated, so it exercises nothing; making a real provider stream throw mid-copy isn't arrangeable without introducing a seam over `ContentResolver`.
- Saving at all goes through `ACTION_CREATE_DOCUMENT`, a system picker, which is why the existing instrumented tests cover entering edit mode but stop before the save.

What I did verify: `spotlessCheck`, `assembleLiteDebug`, `assembleProDebug`, `lintProDebug`, `testProDebugUnitTest`, `testLiteDebugUnitTest` all pass. The rest is reviewed by reading. Happy to add the `ContentResolver` seam and unit-test the rollback with fakes if you'd rather have the coverage than the smaller diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)