### PR TITLE
Refuse a two-part version here too, not six minutes in

### DIFF
--- a/.github/scripts/resolve-version.py
+++ b/.github/scripts/resolve-version.py
@@ -33,9 +33,11 @@ import os
 import re
 import sys
 
-# what app/build.gradle accepts: an optional v, one to three parts, each below
-# 100 so that two digits per part stays unambiguous
-VERSION = re.compile(r"^v?[0-9]{1,2}(\.[0-9]{1,2}){0,2}$")
+# what app/build.gradle accepts: an optional v, all three parts, each below 100 so
+# that two digits per part stays unambiguous. Two-part versions were once padded
+# with a zero, which let one build be tagged under two names; the build refuses
+# them now, and this has to refuse the same ones or it stops being a check
+VERSION = re.compile(r"^v?[0-9]{1,2}(\.[0-9]{1,2}){2}$")
 
 
 def fail(message):
@@ -70,7 +72,8 @@ def resolve(tag, given, uploads, log=print):
 
     if not VERSION.match(version):
         raise ValueError(
-            f"'{version}' is not a version: expected something like v4.8.0, each part below 100"
+            f"'{version}' is not a version: expected something like v4.8.0 - all "
+            "three parts, each below 100"
         )
     log(f"building {version}")
     return version


### PR DESCRIPTION
`app/build.gradle` stopped padding a missing third part in #565, so `v4.7` is a build error now. `.github/scripts/resolve-version.py` exists to catch a bad version *before* the six minutes of gradle setup — and it still accepted one to three parts, so the one shape that newly cannot build was the one shape it waved through.

```
before                          after
v4.7   -> 'v4.7'                v4.7   -> REJECTED
v4     -> 'v4'                  v4     -> REJECTED
v4.8.0 -> 'v4.8.0'              v4.8.0 -> 'v4.8.0'
```

`{0,2}` becomes `{2}`, and the error message says which rule was broken.

Not hypothetical: a `v4.7` tag reached origin on the 3rd, the day after 4.13.0 went out, and started a full release run of a week-old commit that had to be cancelled by hand. This would have ended it at the resolve step.

The pre-`v4.8.0` tags are two-part and can therefore no longer be re-run through the release workflow. That is already true of the build itself, which is where it is enforced; this only moves the failure earlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)