### PR TITLE
Serve a limited ad to whoever refuses consent, instead of nothing

### DIFF
--- a/app/src/main/java/app/opendocument/droid/nonfree/AdManager.kt
+++ b/app/src/main/java/app/opendocument/droid/nonfree/AdManager.kt
@@ -24,13 +24,16 @@ class AdManager {
 
     private var enabled = false
 
+    /** Whether [initialize] ran far enough for the fields below to exist. */
+    private var initialized = false
+
     private lateinit var activity: Activity
     private lateinit var crashManager: CrashManager
     private lateinit var analyticsManager: AnalyticsManager
     private lateinit var adContainer: LinearLayout
     private var adView: AdView? = null
 
-    /** Set once the consent flow has settled, which is also what makes its state readable. */
+    /** Set by the consent flow, which is also the only thing that makes it readable. */
     private var consentInformation: ConsentInformation? = null
 
     private var onConsentSettled: (() -> Unit)? = null
@@ -63,6 +66,8 @@ class AdManager {
         val configuration =
             RequestConfiguration.Builder().setTestDeviceIds(listOf(TEST_DEVICE_ID)).build()
         MobileAds.setRequestConfiguration(configuration)
+
+        initialized = true
     }
 
     fun setEnabled(enabled: Boolean) {
@@ -73,7 +78,7 @@ class AdManager {
         this.adContainer = adContainer
     }
 
-    /** Called once the consent flow has settled, so the caller can re-read what it decided. */
+    /** Fires once the consent flow has settled, so the caller can re-read it. */
     fun setConsentListener(listener: () -> Unit) {
         onConsentSettled = listener
     }
@@ -87,8 +92,6 @@ class AdManager {
         if (!enabled) {
             return
         }
-
-        this.adView = adView
 
         showInAdContainer(
             adView,
@@ -113,19 +116,29 @@ class AdManager {
     /**
      * Runs the consent flow, once per launch, and loads a banner whatever it decides.
      *
-     * [ConsentInformation.canRequestAds] is deliberately not a gate, which is where this parts ways
-     * with google's own sample. Refusing everything still emits a tc string carrying the special
-     * purposes, from which google picks limited ads server-side: no cookies, no identifiers, no
-     * local storage. There is no client-side flag for that mode - not sending the request is the
-     * only way to lose it, and showing nothing is a choice rather than an obligation.
-     *
-     * The two errors are breadcrumbs for the same reason: neither is a refusal. The sdk caches the
-     * user's decision, so a form that fails to show, or an update that times out because the device
-     * is offline, still leaves an earlier consent standing, and outside the regions where a form is
-     * required at all there is no decision to fail in the first place.
+     * [ConsentInformation.canRequestAds] is deliberately not a gate, unlike in google's sample: a
+     * refusal still emits a tc string google picks limited ads from, and not asking is the only way
+     * to lose those. Nor are the two errors, neither of which is a refusal. [hasConsentDecision] is
+     * the gate.
      */
     fun showGoogleAds() {
         if (!enabled) {
+            return
+        }
+
+        requestConsentInfo(gatherConsent = true)
+    }
+
+    /**
+     * The update on its own, no form and no banner, which is all [isPrivacyOptionsRequired] needs.
+     * Ad removal leads here, since [showGoogleAds] never runs once ads are gone.
+     */
+    fun updateConsentInfo() {
+        requestConsentInfo(gatherConsent = false)
+    }
+
+    private fun requestConsentInfo(gatherConsent: Boolean) {
+        if (!initialized) {
             return
         }
 
@@ -136,13 +149,17 @@ class AdManager {
             activity,
             params,
             {
-                UserMessagingPlatform.loadAndShowConsentFormIfRequired(activity) { loadAndShowError
-                    ->
-                    if (loadAndShowError != null) {
-                        // the ump sdk only logs an unspecific "Error making request."
-                        crashManager.log("consent form failed: " + describe(loadAndShowError))
-                    }
+                if (gatherConsent) {
+                    UserMessagingPlatform.loadAndShowConsentFormIfRequired(activity) {
+                        loadAndShowError ->
+                        if (loadAndShowError != null) {
+                            // the ump sdk only logs an unspecific "Error making request."
+                            crashManager.log("consent form failed: " + describe(loadAndShowError))
+                        }
 
+                        consentSettled(consentInformation)
+                    }
+                } else {
                     consentSettled(consentInformation)
                 }
             },
@@ -159,20 +176,35 @@ class AdManager {
     private fun consentSettled(consentInformation: ConsentInformation) {
         this.consentInformation = consentInformation
 
-        // the served mode is not readable from here, but this is what decides it
-        crashManager.log("consent settled, canRequestAds=" + consentInformation.canRequestAds())
+        // the served mode is not readable from here; this is what decides it
+        crashManager.log(
+            "consent settled, status=" +
+                consentInformation.consentStatus +
+                ", canRequestAds=" +
+                consentInformation.canRequestAds()
+        )
 
         activity.runOnUiThread {
             onConsentSettled?.invoke()
 
-            showAdaptiveBanner()
+            if (enabled) {
+                showAdaptiveBanner()
+            }
         }
     }
 
     /**
-     * Rebuilds the banner, whose size is orientation-dependent. The consent flow stays at once per
-     * launch - it is a network call, and nothing about a rotation can change its answer.
+     * Whether the sdk holds an answer to send. A refusal counts; an update that never came back on
+     * a device that has never had one does not, and would send no tc string to pick from.
      */
+    private fun hasConsentDecision(): Boolean =
+        when (consentInformation?.consentStatus) {
+            ConsentInformation.ConsentStatus.OBTAINED,
+            ConsentInformation.ConsentStatus.NOT_REQUIRED -> true
+            else -> false
+        }
+
+    /** Rebuilds the banner for a new size. A rotation cannot change what consent decided. */
     fun refreshAds() {
         if (!enabled || consentInformation == null) {
             return
@@ -181,16 +213,12 @@ class AdManager {
         activity.runOnUiThread { showAdaptiveBanner() }
     }
 
-    /**
-     * Whether the sdk wants a re-entry point into the consent form, which is how a user withdraws.
-     * Not gated on [enabled]: buying ad removal clears that, and someone who consented before
-     * buying must still be able to take it back.
-     */
+    /** Not gated on [enabled]: buying ad removal clears that, withdrawal outlives it. */
     fun isPrivacyOptionsRequired(): Boolean =
         consentInformation?.privacyOptionsRequirementStatus ==
             ConsentInformation.PrivacyOptionsRequirementStatus.REQUIRED
 
-    /** Only ever from user input - the sdk preloads the form for exactly this. */
+    /** Only from user input - the sdk preloads the form for exactly this. */
     fun showPrivacyOptions() {
         UserMessagingPlatform.showPrivacyOptionsForm(activity) { formError ->
             if (formError != null) {
@@ -204,24 +232,42 @@ class AdManager {
     // banner differently - a change to make on its own rather than in passing
     @Suppress("DEPRECATION")
     private fun showAdaptiveBanner() {
-        val adView = AdView(activity)
-
         // WindowManager.getDefaultDisplay() is deprecated and its replacement needs API
         // 30; the resources' metrics carry the same width and density.
         val metrics = activity.resources.displayMetrics
         val adWidth = (metrics.widthPixels / metrics.density).toInt()
 
         val adSize = AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(activity, adWidth)
+
+        // a webview underneath, and every rotation builds another
+        adView?.destroy()
+        adView = null
+
+        if (!hasConsentDecision()) {
+            showHouseAd(adSize, adWidth)
+
+            return
+        }
+
+        val adView = AdView(activity)
+        this.adView = adView
+
         adView.setAdSize(adSize)
         adView.adUnitId = AD_UNIT_ID
         adView.adListener =
             object : AdListener() {
-                // the sdk retries behind our back and reports every attempt, so one request
-                // arrives here as several failures - which would otherwise walk the house ad
-                // through all three of its texts in half a second
+                // the sdk retries behind our back and reports every attempt, which would
+                // otherwise walk the house ad through all three texts at once
                 private var houseAdShown = false
 
+                /** A rotation replaced this banner, so it is too late to say anything. */
+                private fun stale() = adView !== this@AdManager.adView
+
                 override fun onAdLoaded() {
+                    if (stale()) {
+                        return
+                    }
+
                     // a retry that eventually fills still gets to replace the house ad
                     houseAdShown = false
 
@@ -229,28 +275,26 @@ class AdManager {
                 }
 
                 override fun onAdFailedToLoad(error: LoadAdError) {
-                    if (houseAdShown) {
+                    if (stale() || houseAdShown) {
                         return
                     }
                     houseAdShown = true
 
-                    // limited ads fill far less often than personalised ones, so an empty
-                    // strip is the common case for whoever refused consent
+                    // limited ads fill far less often - the common case for a refusal
                     crashManager.log("ad failed to load: " + error.code + "/" + error.message)
 
                     showHouseAd(adSize, adWidth)
                 }
             }
 
-        // nothing goes into the container until the listener fires, so a request that does
-        // not fill never shows as a gap
+        // the container stays as it is until the listener fires, so a request that does not
+        // fill never shows as a gap
         adView.loadAd(AdRequest.Builder().build())
     }
 
     /**
-     * One layout for every slot the banner comes in. Parts drop out as it narrows - the subline
-     * first, then the icon - and the headline has a short form for when it is all that is left.
-     * Neither line ever wraps, so a long translation shortens rather than breaking the height.
+     * One layout for every slot the banner comes in: parts drop out as it narrows, the subline
+     * first and then the icon. Neither line wraps, so a translation cannot break the height.
      */
     private fun showHouseAd(adSize: AdSize, adWidth: Int) {
         if (!enabled) {

--- a/app/src/main/java/app/opendocument/droid/nonfree/AdManager.kt
+++ b/app/src/main/java/app/opendocument/droid/nonfree/AdManager.kt
@@ -1,13 +1,20 @@
 package app.opendocument.droid.nonfree
 
 import android.app.Activity
+import android.util.TypedValue
 import android.view.View
+import android.widget.ImageView
 import android.widget.LinearLayout
+import android.widget.TextView
+import app.opendocument.droid.R
+import com.google.android.gms.ads.AdListener
 import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.AdSize
 import com.google.android.gms.ads.AdView
+import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.MobileAds
 import com.google.android.gms.ads.RequestConfiguration
+import com.google.android.ump.ConsentInformation
 import com.google.android.ump.ConsentRequestParameters
 import com.google.android.ump.FormError
 import com.google.android.ump.UserMessagingPlatform
@@ -22,6 +29,14 @@ class AdManager {
     private lateinit var analyticsManager: AnalyticsManager
     private lateinit var adContainer: LinearLayout
     private var adView: AdView? = null
+
+    /** Set once the consent flow has settled, which is also what makes its state readable. */
+    private var consentInformation: ConsentInformation? = null
+
+    private var onConsentSettled: (() -> Unit)? = null
+    private var onPurchaseRequested: (() -> Unit)? = null
+
+    private var houseAdIndex = 0
 
     fun initialize(
         activity: Activity,
@@ -58,6 +73,16 @@ class AdManager {
         this.adContainer = adContainer
     }
 
+    /** Called once the consent flow has settled, so the caller can re-read what it decided. */
+    fun setConsentListener(listener: () -> Unit) {
+        onConsentSettled = listener
+    }
+
+    /** Where the house ad sends whoever taps it. */
+    fun setPurchaseListener(listener: () -> Unit) {
+        onPurchaseRequested = listener
+    }
+
     private fun showAds(adView: AdView) {
         if (!enabled) {
             return
@@ -65,14 +90,18 @@ class AdManager {
 
         this.adView = adView
 
-        adContainer.removeAllViews()
-
-        val params =
+        showInAdContainer(
+            adView,
             LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.MATCH_PARENT,
                 LinearLayout.LayoutParams.MATCH_PARENT,
-            )
-        adContainer.addView(adView, params)
+            ),
+        )
+    }
+
+    private fun showInAdContainer(view: View, params: LinearLayout.LayoutParams) {
+        adContainer.removeAllViews()
+        adContainer.addView(view, params)
 
         adContainer.visibility = View.VISIBLE
     }
@@ -81,6 +110,20 @@ class AdManager {
         activity.runOnUiThread { adContainer.visibility = View.GONE }
     }
 
+    /**
+     * Runs the consent flow, once per launch, and loads a banner whatever it decides.
+     *
+     * [ConsentInformation.canRequestAds] is deliberately not a gate, which is where this parts ways
+     * with google's own sample. Refusing everything still emits a tc string carrying the special
+     * purposes, from which google picks limited ads server-side: no cookies, no identifiers, no
+     * local storage. There is no client-side flag for that mode - not sending the request is the
+     * only way to lose it, and showing nothing is a choice rather than an obligation.
+     *
+     * The two errors are breadcrumbs for the same reason: neither is a refusal. The sdk caches the
+     * user's decision, so a form that fails to show, or an update that times out because the device
+     * is offline, still leaves an earlier consent standing, and outside the regions where a form is
+     * required at all there is no decision to fail in the first place.
+     */
     fun showGoogleAds() {
         if (!enabled) {
             return
@@ -95,23 +138,12 @@ class AdManager {
             {
                 UserMessagingPlatform.loadAndShowConsentFormIfRequired(activity) { loadAndShowError
                     ->
-                    if (loadAndShowError != null || !consentInformation.canRequestAds()) {
-                        // without this the banner just silently stays hidden,
-                        // and the ump sdk only logs an unspecific "Error
-                        // making request."
-                        crashManager.log(
-                            "consent form failed: " +
-                                describe(loadAndShowError) +
-                                ", canRequestAds=" +
-                                consentInformation.canRequestAds()
-                        )
-
-                        hideGoogleAds()
-
-                        return@loadAndShowConsentFormIfRequired
+                    if (loadAndShowError != null) {
+                        // the ump sdk only logs an unspecific "Error making request."
+                        crashManager.log("consent form failed: " + describe(loadAndShowError))
                     }
 
-                    activity.runOnUiThread { showAdaptiveBanner() }
+                    consentSettled(consentInformation)
                 }
             },
             { requestConsentError ->
@@ -119,9 +151,52 @@ class AdManager {
                 // times out against fundingchoicesmessages.google.com
                 crashManager.log("consent info update failed: " + describe(requestConsentError))
 
-                hideGoogleAds()
+                consentSettled(consentInformation)
             },
         )
+    }
+
+    private fun consentSettled(consentInformation: ConsentInformation) {
+        this.consentInformation = consentInformation
+
+        // the served mode is not readable from here, but this is what decides it
+        crashManager.log("consent settled, canRequestAds=" + consentInformation.canRequestAds())
+
+        activity.runOnUiThread {
+            onConsentSettled?.invoke()
+
+            showAdaptiveBanner()
+        }
+    }
+
+    /**
+     * Rebuilds the banner, whose size is orientation-dependent. The consent flow stays at once per
+     * launch - it is a network call, and nothing about a rotation can change its answer.
+     */
+    fun refreshAds() {
+        if (!enabled || consentInformation == null) {
+            return
+        }
+
+        activity.runOnUiThread { showAdaptiveBanner() }
+    }
+
+    /**
+     * Whether the sdk wants a re-entry point into the consent form, which is how a user withdraws.
+     * Not gated on [enabled]: buying ad removal clears that, and someone who consented before
+     * buying must still be able to take it back.
+     */
+    fun isPrivacyOptionsRequired(): Boolean =
+        consentInformation?.privacyOptionsRequirementStatus ==
+            ConsentInformation.PrivacyOptionsRequirementStatus.REQUIRED
+
+    /** Only ever from user input - the sdk preloads the form for exactly this. */
+    fun showPrivacyOptions() {
+        UserMessagingPlatform.showPrivacyOptionsForm(activity) { formError ->
+            if (formError != null) {
+                crashManager.log("privacy options form failed: " + describe(formError))
+            }
+        }
     }
 
     // https://developers.google.com/admob/android/banner/adaptive
@@ -136,14 +211,114 @@ class AdManager {
         val metrics = activity.resources.displayMetrics
         val adWidth = (metrics.widthPixels / metrics.density).toInt()
 
-        adView.setAdSize(
-            AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(activity, adWidth)
-        )
+        val adSize = AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(activity, adWidth)
+        adView.setAdSize(adSize)
         adView.adUnitId = AD_UNIT_ID
-        adView.loadAd(AdRequest.Builder().build())
+        adView.adListener =
+            object : AdListener() {
+                // the sdk retries behind our back and reports every attempt, so one request
+                // arrives here as several failures - which would otherwise walk the house ad
+                // through all three of its texts in half a second
+                private var houseAdShown = false
 
-        showAds(adView)
+                override fun onAdLoaded() {
+                    // a retry that eventually fills still gets to replace the house ad
+                    houseAdShown = false
+
+                    showAds(adView)
+                }
+
+                override fun onAdFailedToLoad(error: LoadAdError) {
+                    if (houseAdShown) {
+                        return
+                    }
+                    houseAdShown = true
+
+                    // limited ads fill far less often than personalised ones, so an empty
+                    // strip is the common case for whoever refused consent
+                    crashManager.log("ad failed to load: " + error.code + "/" + error.message)
+
+                    showHouseAd(adSize, adWidth)
+                }
+            }
+
+        // nothing goes into the container until the listener fires, so a request that does
+        // not fill never shows as a gap
+        adView.loadAd(AdRequest.Builder().build())
     }
+
+    /**
+     * One layout for every slot the banner comes in. Parts drop out as it narrows - the subline
+     * first, then the icon - and the headline has a short form for when it is all that is left.
+     * Neither line ever wraps, so a long translation shortens rather than breaking the height.
+     */
+    private fun showHouseAd(adSize: AdSize, adWidth: Int) {
+        if (!enabled) {
+            return
+        }
+
+        val houseAd = activity.layoutInflater.inflate(R.layout.house_ad, adContainer, false)
+
+        val variant = HOUSE_ADS[houseAdIndex % HOUSE_ADS.size]
+        houseAdIndex++
+
+        crashManager.log("house ad " + houseAdIndex + " at " + adWidth + "dp")
+
+        // the 90dp slot, which only tablets get
+        val wide = adWidth >= WIDE_WIDTH
+
+        val icon = houseAd.findViewById<ImageView>(R.id.house_ad_icon)
+        if (adWidth < ICON_WIDTH) {
+            icon.visibility = View.GONE
+        } else {
+            val size = dp(if (wide) 58 else 34)
+            icon.layoutParams.width = size
+            icon.layoutParams.height = size
+        }
+
+        val headline = houseAd.findViewById<TextView>(R.id.house_ad_headline)
+        headline.setText(if (adWidth < SUBLINE_WIDTH) variant.shortHeadline else variant.headline)
+        headline.setTextSize(TypedValue.COMPLEX_UNIT_SP, if (wide) 17f else 13f)
+
+        val subline = houseAd.findViewById<TextView>(R.id.house_ad_subline)
+        if (adWidth < SUBLINE_WIDTH) {
+            subline.visibility = View.GONE
+        } else {
+            subline.setText(if (wide) variant.wideSubline else variant.subline)
+            subline.setTextSize(TypedValue.COMPLEX_UNIT_SP, if (wide) 13f else 11f)
+        }
+
+        val cta = houseAd.findViewById<TextView>(R.id.house_ad_cta)
+        cta.setText(variant.cta)
+        if (wide) {
+            cta.setTextSize(TypedValue.COMPLEX_UNIT_SP, 13f)
+            cta.setPadding(dp(16), dp(8), dp(16), dp(8))
+        }
+
+        houseAd.setOnClickListener {
+            analyticsManager.report("house_ad")
+
+            onPurchaseRequested?.invoke()
+        }
+
+        showInAdContainer(
+            houseAd,
+            LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                adSize.getHeightInPixels(activity),
+            ),
+        )
+    }
+
+    private fun dp(value: Int) = (value * activity.resources.displayMetrics.density).toInt()
+
+    private class HouseAd(
+        val headline: Int,
+        val shortHeadline: Int,
+        val subline: Int,
+        val wideSubline: Int,
+        val cta: Int,
+    )
 
     fun removeAds() {
         enabled = false
@@ -168,6 +343,37 @@ class AdManager {
         const val AD_UNIT_ID = "ca-app-pub-8161473686436957/5931994762"
 
         const val TEST_DEVICE_ID = "46C05048B04145D0724C1ADA7FC17619"
+
+        // the slot widths, in dp, at which the house ad loses a part
+        const val WIDE_WIDTH = 700
+        const val SUBLINE_WIDTH = 360
+        const val ICON_WIDTH = 300
+
+        // three angles at the same offer, one per banner that did not fill
+        val HOUSE_ADS =
+            listOf(
+                HouseAd(
+                    R.string.house_ad_support_headline,
+                    R.string.house_ad_support_headline_short,
+                    R.string.house_ad_support_subline,
+                    R.string.house_ad_support_subline_wide,
+                    R.string.house_ad_cta_go_pro,
+                ),
+                HouseAd(
+                    R.string.house_ad_ad_free_headline,
+                    R.string.house_ad_ad_free_headline,
+                    R.string.house_ad_ad_free_subline,
+                    R.string.house_ad_ad_free_subline_wide,
+                    R.string.house_ad_cta_get_pro,
+                ),
+                HouseAd(
+                    R.string.house_ad_open_source_headline,
+                    R.string.house_ad_open_source_headline_short,
+                    R.string.house_ad_open_source_subline,
+                    R.string.house_ad_open_source_subline_wide,
+                    R.string.house_ad_cta_go_pro,
+                ),
+            )
 
         fun describe(error: FormError?): String {
             if (error == null) {

--- a/app/src/main/java/app/opendocument/droid/nonfree/BillingManager.kt
+++ b/app/src/main/java/app/opendocument/droid/nonfree/BillingManager.kt
@@ -28,6 +28,10 @@ class BillingManager {
 
         if (hasPurchased()) {
             adManager.removeAds()
+
+            // no banner to gate, but withdrawal has to survive the purchase, and only an
+            // update tells us whether the sdk wants a way back out
+            adManager.updateConsentInfo()
         } else {
             adManager.showGoogleAds()
         }

--- a/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
@@ -378,8 +378,7 @@ class MainActivity : AppCompatActivity(), MenuProvider {
         adManager = AdManager()
         adManager.setEnabled(!IS_TESTING && useProprietaryLibraries)
         adManager.setAdContainer(adContainer)
-        // the menu is built long before the consent update comes back, so whether the
-        // privacy item belongs in it is only known after the fact
+        // the menu is built long before the consent update comes back
         adManager.setConsentListener { invalidateMenu() }
         adManager.setPurchaseListener { buyAdRemoval() }
         adManager.initialize(this, analyticsManager, crashManager)

--- a/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
@@ -327,7 +327,8 @@ class MainActivity : AppCompatActivity(), MenuProvider {
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
 
-        adManager.showGoogleAds()
+        // the banner's size follows the orientation; the consent flow behind it does not
+        adManager.refreshAds()
     }
 
     fun requestSave() {
@@ -377,6 +378,10 @@ class MainActivity : AppCompatActivity(), MenuProvider {
         adManager = AdManager()
         adManager.setEnabled(!IS_TESTING && useProprietaryLibraries)
         adManager.setAdContainer(adContainer)
+        // the menu is built long before the consent update comes back, so whether the
+        // privacy item belongs in it is only known after the fact
+        adManager.setConsentListener { invalidateMenu() }
+        adManager.setPurchaseListener { buyAdRemoval() }
         adManager.initialize(this, analyticsManager, crashManager)
 
         billingManager = BillingManager()
@@ -406,6 +411,8 @@ class MainActivity : AppCompatActivity(), MenuProvider {
         if (billingManager.hasPurchased()) {
             menu.findItem(R.id.menu_remove_ads).isVisible = false
         }
+
+        menu.findItem(R.id.menu_privacy_options).isVisible = adManager.isPrivacyOptionsRequired()
     }
 
     // The play services availability dialog calls startActivityForResult() itself with a
@@ -520,6 +527,12 @@ class MainActivity : AppCompatActivity(), MenuProvider {
                 analyticsManager.report("menu_remove_ads")
 
                 buyAdRemoval()
+            }
+
+            R.id.menu_privacy_options -> {
+                analyticsManager.report("menu_privacy_options")
+
+                adManager.showPrivacyOptions()
             }
 
             R.id.menu_fullscreen -> {

--- a/app/src/main/res/drawable/house_ad_background.xml
+++ b/app/src/main/res/drawable/house_ad_background.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- White, with the bottom edge the banner it stands in for would have brought. Without
-     that line the strip reads as a stray line of text on the page. -->
+<!-- White, with the bottom edge the banner would have brought - without that line the
+     strip reads as a stray line of text on the page. -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item>

--- a/app/src/main/res/drawable/house_ad_background.xml
+++ b/app/src/main/res/drawable/house_ad_background.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- White, with the bottom edge the banner it stands in for would have brought. Without
+     that line the strip reads as a stray line of text on the page. -->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/white" />
+        </shape>
+    </item>
+
+    <item
+        android:gravity="bottom"
+        android:height="1dp">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/house_ad_divider" />
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable/house_ad_pill.xml
+++ b/app/src/main/res/drawable/house_ad_pill.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/house_ad_pill" />
+    <corners android:radius="99dp" />
+</shape>

--- a/app/src/main/res/layout/house_ad.xml
+++ b/app/src/main/res/layout/house_ad.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Stands in for a banner that did not fill, in the slot that banner would have had.
+     AdManager sizes it and drops parts of it as the slot narrows - see showHouseAd.
+     The white is the point rather than overdraw: the page behind it is grey. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/house_ad_background"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="?attr/selectableItemBackground"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingStart="10dp"
+    android:paddingEnd="10dp"
+    tools:ignore="Overdraw">
+
+    <ImageView
+        android:id="@+id/house_ad_icon"
+        android:layout_width="34dp"
+        android:layout_height="34dp"
+        android:layout_marginEnd="10dp"
+        android:contentDescription="@string/app_title"
+        android:src="@mipmap/ic_launcher" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="10dp"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <!-- both lines truncate rather than wrap, so a long translation shortens instead
+             of breaking the fixed banner height -->
+        <TextView
+            android:id="@+id/house_ad_headline"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="?android:attr/textColorPrimary"
+            android:textSize="13sp"
+            android:textStyle="bold"
+            tools:text="@string/house_ad_support_headline" />
+
+        <TextView
+            android:id="@+id/house_ad_subline"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="@color/house_ad_subline"
+            android:textSize="11sp"
+            tools:text="@string/house_ad_support_subline" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/house_ad_cta"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/house_ad_pill"
+        android:paddingStart="10dp"
+        android:paddingTop="5dp"
+        android:paddingEnd="10dp"
+        android:paddingBottom="5dp"
+        android:textColor="@android:color/white"
+        android:textSize="11sp"
+        android:textStyle="bold"
+        tools:text="@string/house_ad_cta_go_pro" />
+</LinearLayout>

--- a/app/src/main/res/layout/house_ad.xml
+++ b/app/src/main/res/layout/house_ad.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- Stands in for a banner that did not fill, in the slot that banner would have had.
-     AdManager sizes it and drops parts of it as the slot narrows - see showHouseAd.
-     The white is the point rather than overdraw: the page behind it is grey. -->
+<!-- Stands in for a banner that did not fill, in the slot it would have had. AdManager
+     sizes it and drops parts as the slot narrows - see showHouseAd. The white is the point
+     rather than overdraw: the page behind it is grey. -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -32,8 +32,7 @@
         android:layout_weight="1"
         android:orientation="vertical">
 
-        <!-- both lines truncate rather than wrap, so a long translation shortens instead
-             of breaking the fixed banner height -->
+        <!-- both truncate rather than wrap, so a long translation cannot break the height -->
         <TextView
             android:id="@+id/house_ad_headline"
             android:layout_width="match_parent"

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -68,8 +68,7 @@
         android:title="@string/menu_remove_ads"
         app:showAsAction="never" />
 
-    <!-- shown only where the ump sdk says a re-entry point into the consent form is
-         required, which it can only answer once the consent update has come back -->
+    <!-- shown only where the ump sdk asks for a re-entry point into the consent form -->
     <item
         android:id="@+id/menu_privacy_options"
         android:title="@string/menu_privacy_options"

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -67,4 +67,12 @@
         android:id="@+id/menu_remove_ads"
         android:title="@string/menu_remove_ads"
         app:showAsAction="never" />
+
+    <!-- shown only where the ump sdk says a re-entry point into the consent form is
+         required, which it can only answer once the consent update has come back -->
+    <item
+        android:id="@+id/menu_privacy_options"
+        android:title="@string/menu_privacy_options"
+        android:visible="false"
+        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- the house ad, which is the app talking about itself and so does not take its
+         greys from MainTheme - textColorSecondary is too light to read at 11sp -->
+    <color name="house_ad_subline">#6b7280</color>
+    <color name="house_ad_pill">#2f80c8</color>
+    <color name="house_ad_divider">#e3e6ea</color>
+
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <!-- the house ad, which is the app talking about itself and so does not take its
-         greys from MainTheme - textColorSecondary is too light to read at 11sp -->
+    <!-- the house ad does not take its greys from MainTheme: textColorSecondary is too
+         light to read at 11sp -->
     <color name="house_ad_subline">#6b7280</color>
     <color name="house_ad_pill">#2f80c8</color>
     <color name="house_ad_divider">#e3e6ea</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,8 +30,8 @@
     <string name="menu_remove_ads">Remove advertisements</string>
     <string name="menu_privacy_options">Ad privacy settings</string>
 
-    <!-- the house ad shown when an ad request does not fill. three angles at the same
-         offer; the short headlines are what a narrow phone gets once the rest drops out -->
+    <!-- the house ad, shown when a request does not fill. three angles at the same offer;
+         the short headlines are what a narrow phone gets once the rest drops out -->
     <string name="house_ad_support_headline">Support OpenDocument Reader</string>
     <string name="house_ad_support_headline_short">Support us</string>
     <string name="house_ad_support_subline">Get Pro — no ads, ever</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,23 @@
     <string name="menu_share">Share document</string>
     <string name="menu_edit">Edit document</string>
     <string name="menu_remove_ads">Remove advertisements</string>
+    <string name="menu_privacy_options">Ad privacy settings</string>
+
+    <!-- the house ad shown when an ad request does not fill. three angles at the same
+         offer; the short headlines are what a narrow phone gets once the rest drops out -->
+    <string name="house_ad_support_headline">Support OpenDocument Reader</string>
+    <string name="house_ad_support_headline_short">Support us</string>
+    <string name="house_ad_support_subline">Get Pro — no ads, ever</string>
+    <string name="house_ad_support_subline_wide">It is open source and ad-supported. Pro drops the advertisement.</string>
+    <string name="house_ad_ad_free_headline">Read without ads</string>
+    <string name="house_ad_ad_free_subline">ODR Pro — a one-time purchase</string>
+    <string name="house_ad_ad_free_subline_wide">ODR Pro is the same reader, minus the advertisement.</string>
+    <string name="house_ad_open_source_headline">Open source, kept free</string>
+    <string name="house_ad_open_source_headline_short">Open source</string>
+    <string name="house_ad_open_source_subline">Pro pays for it — and drops the ads</string>
+    <string name="house_ad_open_source_subline_wide">Buying Pro funds the work and removes the advertisement.</string>
+    <string name="house_ad_cta_go_pro">Go Pro</string>
+    <string name="house_ad_cta_get_pro">Get Pro</string>
     <string name="menu_fullscreen">Fullscreen mode</string>
     <string name="menu_cloud_print">Print document</string>
     <string name="menu_tts">Text-To-Speech</string>


### PR DESCRIPTION
Refusing all consent got no ad at all. Per `ad-consent-notes.md`, that is a choice rather than an obligation:

> NPA is *not* the privacy option — same consent bar as personalized, minus targeting. LTD is the mode for users who reject everything.

"Do not consent" still emits a TC string carrying the special purposes, and Google picks **limited ads** from it server-side: no cookies, no identifiers, no local storage. There is no client-side flag for that mode, so not sending the request is the only way to lose it.

## What changed

`canRequestAds()` stops being a gate — which is where this parts ways with Google's own sample, deliberately. The two consent errors stop being gates for the same reason: neither is a refusal. The SDK caches the user's decision, so a form that fails to show, or an update that times out because the device was asleep, still leaves an earlier consent standing; outside the regions where a form is required at all there is no decision to fail. One timeout used to blank the banner for the rest of the session, for users who had already said yes.

The rest follows from asking for ads we now expect not to fill:

**A house ad instead of an empty strip.** There was no `AdListener` at all, and the container was made visible before the load resolved. Nothing enters it until the listener fires now, and a request that does not fill puts a Pro house ad there. Three angles at the same offer, one per request, sized to the banner they replace — the subline drops below 360dp and the icon below 300dp, and neither line wraps, so a long translation shortens instead of breaking the height.

**A re-entry point into the consent form**, in the overflow menu, gated on the SDK's own `privacyOptionsRequirementStatus`. Withdrawal has to be as easy as granting (GDPR Art. 7(3)) and the TCF asks for one. The status is only answerable once the update has come back, so the menu is invalidated then. Not gated on the ad manager being enabled: buying ad removal clears that, and someone who consented before buying must still be able to take it back.

**`requestConsentInfoUpdate` stays at once per launch**, which is what refreshes region and message version. `onConfigurationChanged` used to re-run the whole thing; it now only rebuilds the banner, whose size is what the orientation actually changes.

## The call this rests on

"Programmatic limited ads" (AdMob → Settings → Account information) is on, the default. Off means waterfall mediation only and near-zero fill, and this change would buy nothing. On means Google uses invalid-traffic-detection-only cookies and local storage on unconsented traffic. Google's position is that no consent is needed for that; the legal responsibility is the publisher's. Worth stating plainly in a privacy-forward FOSS app: it is a deliberate call, not an oversight.

Pro/IAP ad removal remains the clean answer for "neither ads nor tracking", and the F-Droid build covers the absolutist case.

## Why it is worth fixing

Android match rate — the share of ad requests Google fills — since the consent form shipped in `f6b942b6` (Dec 2023):

| | 2023 | 2024 | 2025 | 2026 |
|---|---:|---:|---:|---:|
| Android (consent form) | 99.8% | 93.6% | 87.0% | **77.6%** |
| iOS (no consent form) | 99.9% | 98.7% | 95.9% | 95.8% |

Show rate over the same period *improved* to ~92%, so this is not a rendering problem. Most of that gap is expected and correct — non-personalised requests are simply filled less often. What this change adds back is the reject cohort, which was being discarded entirely, plus the requests lost to a consent call that merely failed.

## Testing

Built and driven on an emulator (lite debug), against a `DEBUG_GEOGRAPHY_EEA` override that was removed before committing:

- **Consent declined** (all TCF toggles off → "Confirm choices") → an ad still serves. Previously: nothing.
- **Offline** → `consent info update failed: 2/…` in logcat *followed by* the house ad, rather than by silence. This is the case the PR originally fixed, preserved.
- **Privacy item** — present in the overflow on first launch after the form was shown, so `invalidateMenu()` fires; reopens the form; absent in the pro flavor, where the consent update never runs.
- **House ad** — all three texts cycle, one per request. The SDK reports several failures per request, so there is a guard against walking through all three in half a second.
- **Drop-out widths** — 342dp drops the subline and uses the short headline; 274dp drops the icon too.
- **Rotation** — banner resizes; logcat shows no second `requestConsentInfoUpdate`.

`spotlessCheck`, `lintProDebug`, `lintLiteDebug`, `testProDebugUnitTest` and both `assemble` variants pass. No test covers any of this and none can: `MainActivity.IS_TESTING` forces `adManager.setEnabled(false)` whenever the instrumented suite is on the classpath.

## Still open, elsewhere

From the notes, not addressable in this repo: the iOS UMP/CMP work and its ordering before ATT, the IDFA explainer message in the AdMob UI, and the TCF v2.3 / serving-restriction check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
