### PR TITLE
Fix the bugs a full review turned up, and cut the comments back

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,13 +8,15 @@ updates:
       interval: weekly
     open-pull-requests-limit: 5
     groups:
-      androidx:
-        patterns:
-          - "androidx.*"
+      # first match in file order wins, so the narrower group has to come first
       test:
         patterns:
           - "androidx.test*"
+          - "androidx.test.espresso*"
           - "junit*"
+      androidx:
+        patterns:
+          - "androidx.*"
 
   - package-ecosystem: github-actions
     directory: "/"

--- a/.github/scripts/play-service-account-key.py
+++ b/.github/scripts/play-service-account-key.py
@@ -3,20 +3,13 @@
 # Reads the play console service account key out of the environment and writes a
 # normalised copy of it to the given path.
 #
-# fastlane only ever says "'...' doesn't seem to be a JSON file" about a key it
-# cannot parse, and it says it after the bundles are built, at the one step of
-# the release that cannot simply be re-run - play refuses a version code it has
-# already accepted. So the key is checked here instead, before the build, and
-# with an error that names what is actually wrong.
+# fastlane's own "doesn't seem to be a JSON file" comes at the upload, the one step
+# of a release that cannot be re-run - play refuses a code it has already accepted.
+# So the key is checked here, up front, and with an error that names the problem.
 #
-# The three ways a good key arrives broken are all repaired rather than reported:
-# base64 (which is how the keystore secret is stored, so it is an easy mistake to
-# make), a utf-8 BOM or whitespace picked up on the way through a clipboard, and
-# a private_key whose line breaks were unescaped by hand. Anything that is not a
-# service account key after that is an error.
-#
-# The key is passed in through the environment and never printed: what comes back
-# out is the file.
+# Base64 (how the keystore secret is stored, so an easy mistake), a BOM or clipboard
+# whitespace, and hand-unescaped private_key line breaks are all repaired rather than
+# reported. The key comes in through the environment and is never printed.
 
 import argparse
 import base64
@@ -29,8 +22,7 @@ REQUIRED_FIELDS = ("type", "client_email", "private_key")
 
 def fail(message):
     if os.environ.get("GITHUB_ACTIONS"):
-        # shown in the log the same way, and additionally as an annotation on the
-        # run itself rather than only somewhere in the middle of a step
+        # ::error:: also annotates the run itself
         print(f"::error::{message}")
     else:
         print(message, file=sys.stderr)

--- a/.github/scripts/reap-crashpad.sh
+++ b/.github/scripts/reap-crashpad.sh
@@ -2,16 +2,12 @@
 #
 # Kills the emulator's crash reporter once the emulator it belonged to is gone.
 #
-# crashpad_handler inherits the stdout of the step that started the emulator, and
-# a step cannot finish while anything still holds that pipe open. On api 26 and 29
-# the emulator regularly exits without taking it along - the green jobs end on
-# "Netsim Wifi ... is gone" with only adb and the gradle daemons left over, the
-# hung ones stop at "removeAll" and leave a crashpad_handler - and the runner then
-# sits there until the job times out. 45 minutes a go, several times over.
+# crashpad_handler inherits the emulator step's stdout, and a step cannot finish while
+# anything still holds that pipe open. On api 26 and 29 the emulator regularly exits
+# without taking it along, and the runner then sits there until the job times out.
 #
-# run-instrumented-tests.sh cleans up after itself, but the action can also fail
-# before it ever runs the script: an "input keyevent 82" killed during boot ends
-# the same way. This runs detached from any step, so it covers that too.
+# Detached from any step, because the action can fail before run-instrumented-tests.sh
+# (which cleans up after itself) ever runs - an "input keyevent 82" killed during boot.
 
 set -u
 

--- a/.github/scripts/resolve-version.py
+++ b/.github/scripts/resolve-version.py
@@ -1,22 +1,12 @@
 #!/usr/bin/env python3
 #
-# Works out which version a release run is building, and refuses the runs that
-# cannot sensibly build one.
+# Works out which version a release run is building, from the run's `version` input,
+# and refuses the runs that cannot sensibly build one. Only a dry run may go without
+# one, on gradle's unversioned fallback - uploading that means a code the store refuses.
 #
-# There is no version number in the repository: it comes in as the release run's
-# `version` input, and app/build.gradle turns it into a version name and a version
-# code (v4.8.0 -> 4.8.0 and 40800, two digits per part). An input rather than the
-# tag the run was pushed on, because a tag written before the upload names a commit
-# that may never ship - release.yml writes its tags afterwards.
-#
-# Only a dry run may go without one, on gradle's unversioned fallback: uploading
-# that would mean a version code the store refuses. OpenDocument.ios has the same
-# script and the same two arguments, differing only in the shape it accepts.
-#
-# The shape is checked here rather than left to gradle, which checks it again and
-# is the one that counts: a typo in a dispatched version should not cost the
-# gradle setup first. The version code is deliberately not computed here - one
-# derivation of it, in the build, is enough.
+# gradle checks the shape again and is the one that counts; checking it here as well
+# only saves a typo the six minutes of a build. The version code is left to gradle -
+# one derivation of it is enough. OpenDocument.ios has the same script.
 #
 # Prints the resolved version and writes it to GITHUB_OUTPUT as `version`, empty
 # when there is none. Run it by hand to see what a dispatch would build.

--- a/.github/scripts/verify-keystore.sh
+++ b/.github/scripts/verify-keystore.sh
@@ -26,8 +26,7 @@ lite_alias="reader"
 
 fail() {
     if [ -n "${GITHUB_ACTIONS:-}" ]; then
-        # shown in the log the same way, and additionally as an annotation on the
-        # run itself rather than only somewhere in the middle of a step
+        # ::error:: also annotates the run itself
         echo "::error::$1"
     else
         echo "$1" >&2
@@ -48,7 +47,7 @@ fi
 verify_key() {
     local alias="$1" password="${2:-$store_password}"
     if ! keytool -certreq -alias "$alias" -keystore "$keystore" \
-            -storepass "$store_password" -keypass "${password:-$store_password}" > /dev/null; then
+            -storepass "$store_password" -keypass "$password" > /dev/null; then
         fail "the $alias key cannot be used - check its key password secret"
     fi
     echo "usable: $alias"

--- a/.github/scripts/verify-signed.sh
+++ b/.github/scripts/verify-signed.sh
@@ -45,7 +45,7 @@ for aab in "${bundles[@]}"; do
     if ! listing=$(unzip -l "$aab" 2>&1); then
         fail "$aab cannot be read as a zip: $listing"
     fi
-    if ! grep -qE " META-INF/[^/]+\.(RSA|DSA)$" <<< "$listing"; then
+    if ! grep -qE " META-INF/[^/]+\.(RSA|DSA|EC)$" <<< "$listing"; then
         fail "$aab is not signed"
     fi
     echo "signed: $aab"

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -91,9 +91,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # api 26 is minSdk - the floor was previously untested, which is part of
-          # why an API 26+ only call could ship in a path only old devices took.
-          # (the old api 23 entry was disabled for issue #390 and is now moot)
+          # api 26 is minSdk: the floor was untested, which is how an API 26+ only
+          # call shipped in a path only old devices took
           - { arch: x86_64, api-level: 26 }
           - { arch: x86_64, api-level: 29 }
           - { arch: x86_64, api-level: 30 }
@@ -119,10 +118,8 @@ jobs:
         path: |
           ~/.android/avd/*
           ~/.android/adb*
-        # this caches the avd itself; the snapshot in it is no longer loaded, since the
-        # test step boots cold to keep the guest out of the thaw that kept killing the
-        # action's first adb command. the key still has to move whenever what is in here
-        # changes - v4 was the ram bump, which the snapshot used to pin
+        # the avd itself, not its snapshot - the test step boots cold. bump the suffix
+        # whenever what is in here changes; v4 was the ram bump
         key: avd-${{ matrix.api-level }}-v4
 
     - name: Enable KVM group perms
@@ -144,10 +141,8 @@ jobs:
         arch: ${{ matrix.arch }}
         target: google_apis
         force-avd-creation: false
-        # the images default to 1536MB, which left the guest so tight that the first adb
-        # command after a snapshot restore got killed while the system was still thawing
-        # ("input keyevent 82" exiting 137, api 26 mostly). the runner has 16GB, so the
-        # headroom is free
+        # the images default to 1536MB, tight enough that the action's first adb command
+        # got killed mid-boot ("input keyevent 82" exiting 137). the runner has 16GB
         ram-size: 4096M
         emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
         disable-animations: false
@@ -161,12 +156,9 @@ jobs:
         target: google_apis
         force-avd-creation: false
         ram-size: 4096M
-        # -no-snapshot-load: every api level boots cold. the action treats
-        # sys.boot_completed as "ready" and runs "input keyevent 82" straight after, which a
-        # restored snapshot is not ready for - api 26 had it SIGKILLed at 1536MB and again at
-        # 4096MB, api 29 got "No service published for: input" - and a guest that is still
-        # thawing cannot be waited for from out here. A cold boot has nothing to thaw and
-        # costs about a minute
+        # -no-snapshot-load: the action runs "input keyevent 82" as soon as
+        # sys.boot_completed is set, which a guest still thawing out of a snapshot fails
+        # (SIGKILL, or "No service published for: input"). a cold boot costs a minute
         emulator-options: -no-snapshot-save -no-snapshot-load -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
         disable-animations: true
         # one line on purpose: the action runs this input line by line, each in its
@@ -188,9 +180,7 @@ jobs:
       uses: actions/upload-artifact@v7
       with:
         name: test-logs-${{ matrix.api-level }}
-        path: |
-          app/build/outputs/logs/
-          app/build/test-results/
+        path: app/build/outputs/logs/
         if-no-files-found: warn
 
     - name: Upload emulator logs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,9 +83,6 @@ jobs:
         version: ${{ steps.version.outputs.version }}
       run: .github/scripts/changelog-section.py --version "$version" > /dev/null
 
-    - name: install ninja
-      run: sudo apt-get install -y ninja-build
-
     - name: setup java
       uses: actions/setup-java@v5.6.0
       with:
@@ -95,7 +92,9 @@ jobs:
     # up front: signing is the last thing the build does, so a bad password would
     # otherwise surface six minutes in
     - name: decode keystore
-      run: echo "${{ secrets.ODR_KEYSTORE_BASE64 }}" | base64 -d > "${RUNNER_TEMP}/google_play.keystore"
+      env:
+        keystore: ${{ secrets.ODR_KEYSTORE_BASE64 }}
+      run: printf '%s' "$keystore" | base64 -d > "${RUNNER_TEMP}/google_play.keystore"
 
     - name: verify keystore
       env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,11 +21,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `./gradlew lintProDebug` - Run Android lint checks (errors fail the build)
 - `./gradlew spotlessApply` - Apply formatting (google-java-format AOSP for java,
   ktfmt kotlinlang style for kotlin)
-- `./gradlew spotlessCheck` - Verify formatting; CI runs this first
+- `./gradlew spotlessCheck` - Verify formatting; run by its own `format.yml` workflow
 
 ### Deployment
-- `fastlane android deployPro` - Deploy Pro version to Google Play internal track
-- `fastlane android deployLite` - Deploy Lite version to Google Play internal track
+- `fastlane android deployPro version:v4.8.0` - Deploy Pro to the Play internal track. The
+  version is required: no number is checked in, and a lane handed none errors out rather
+  than building 0.0.0
+- `fastlane android deployLite version:v4.8.0` - The same for Lite
 
 ### Clean
 - `./gradlew clean` - Clean build artifacts
@@ -52,7 +54,8 @@ what it replaced, and the second round of tapping is always the expensive one.
 
 **Document Processing Pipeline:**
 - `CoreLoader` - Primary document processor using the native C++ ODR core library
-- `RawLoader` - The three files odrcore does not render for us: csv, svg and xml
+- `RawLoader` - The three the core does not get: csv (which it would render, but line by
+  line), plus svg and xml, which it has no file type for
 - `OnlineLoader` - Remote document fetcher
 - `MetadataLoader` - Document metadata extractor
 
@@ -187,7 +190,7 @@ Two declarations are left. The app's own choice of what to *claim*, named in
 `SupportedDocumentTypes` as `CLAIMED_FILE_TYPES` because the core knows nothing about it. And
 the `STRICT_CATCH` `activity-alias` in `AndroidManifest.xml`, which cannot be collapsed into
 the first because XML cannot read any of this. Its three intent-filters are *generated* from
-the same table (an intent-filter matches a mime type exactly, so all 40 spellings and 41
+the same table (an intent-filter matches a mime type exactly, so all 49 spellings and 41
 extensions are written out) and covered by a test rather than by discipline:
 `SupportedFormatsTest` (instrumented) walks every mime type of every `FileType` and asserts
 that `SupportedDocumentTypes` and the package manager give the same answer, so a format added
@@ -197,8 +200,8 @@ The tables live in `libodr_jni`, so anything that reads them needs a device. Tha
 `CoreLoaderTest`, `SupportedDocumentTypesTest`, `RawLoaderTest` and `OnlineLoaderTest` are
 instrumented tests and not JVM ones - none of them opens a file, they just cannot ask the
 table from a plain JVM. What the core decides *after* the file is in the cache is unchanged:
-`MetadataLoader` runs libmagic over the copy, and `CoreLoader.isDocumentEditable` asks the
-opened document.
+`MetadataLoader` runs `Odr.mimetype` over the copy, and `CoreLoader.isDocumentEditable` asks
+the opened document.
 
 One consequence of claiming every spelling: `MetadataLoader` puts whatever mime type it ended
 up with through `SupportedDocumentTypes.canonicalMimeType`, so the loaders behind it see one

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,20 +2,12 @@ plugins {
     alias(libs.plugins.android.application)
 }
 
-// Release signing credentials are supplied out of band - they used to be committed
-// in plain text right here. Set them either as gradle properties (in
-// ~/.gradle/gradle.properties, never in the repo) or as environment variables:
-//
-//   odr.keystore         / ODR_KEYSTORE          path to the keystore
-//   odr.keystorePassword / ODR_KEYSTORE_PASSWORD store password
-//   odr.keyPasswordPro   / ODR_KEY_PASSWORD_PRO  key password, defaults to the store one
-//   odr.keyPasswordLite  / ODR_KEY_PASSWORD_LITE key password, defaults to the store one
-//
-// When they are absent the release variants build unsigned instead of failing, so
-// contributors and CI can still build them.
-// empty counts as absent: a github actions secret that is not set still reaches the
-// build as an empty environment variable, and taking that at face value would use an
-// empty key password instead of falling back to the store one
+// Release signing credentials come from gradle properties or the environment; see the
+// README's "Release signing" section for the names. Absent, the release variants build
+// unsigned rather than failing.
+// empty counts as absent: an unset github actions secret still arrives as an empty
+// environment variable, which would otherwise be used as the key password instead of
+// falling back to the store one
 def signingSetting = { String property, String environmentVariable ->
     providers.gradleProperty(property)
             .orElse(providers.environmentVariable(environmentVariable))
@@ -27,15 +19,13 @@ def releaseKeyPasswordPro = signingSetting('odr.keyPasswordPro', 'ODR_KEY_PASSWO
 def releaseKeyPasswordLite = signingSetting('odr.keyPasswordLite', 'ODR_KEY_PASSWORD_LITE')
 def hasReleaseSigning = releaseKeystore.isPresent() && releaseKeystorePassword.isPresent()
 
-// The version is the tag, and lives nowhere in the tree. A number checked in on main
-// describes either a release that already went out or a guess at the next one, so it is
-// wrong almost all of the time, and versionCode and versionName had to be walked forward
-// together by hand. The release workflow passes the tag it was triggered by as
-// -Podr.version (ODR_VERSION works too, the way the signing settings above take either).
+// The version lives nowhere in the tree: it is the release run's `version` input, handed
+// over as -Podr.version (or ODR_VERSION), and the tags are written afterwards. A number
+// checked in on main would describe either a release that already went out or a guess at
+// the next one, walked forward by hand in two places.
 //
 // Everything else - a local build, a PR build, a dry run - is 0.0.0, which nothing reads:
-// no code in the app looks at its own version, and only what the release workflow builds
-// is ever uploaded anywhere.
+// no code looks at its own version, and only the release workflow uploads anything.
 def parseVersion = { String version ->
     // split rather than tokenize, which would swallow the empty part in '4..8'
     def parts = (version - ~/^v/).split('\\.', -1) as List
@@ -48,9 +38,8 @@ def parseVersion = { String version ->
                 "odr.version must look like 4.8.0 or v4.8.0, not '${version}'")
     }
     def numbers = parts*.toInteger()
-    // two digits per component: v4.8.0 is 40800. That is a one way step past the codes
-    // that used to be counted by hand (204 and below) - the play store accepts a higher
-    // code than the last one it saw and never a lower one.
+    // two digits per component: v4.8.0 is 40800, a one way step past the hand counted
+    // codes (204 and below), since play never accepts a lower code than it has seen
     if (numbers.any { it > 99 }) {
         // silently carrying would make 4.100.0 and 5.0.0 the same code, and a collision
         // is only discoverable once the store rejects the upload
@@ -73,18 +62,15 @@ def appVersion = requestedVersion.isPresent()
 
 android {
     defaultConfig {
-        // NOT the java package (see namespace below) but the app identity on google play
-        // and f-droid, and it can never change: play has no rename path, so a new
-        // applicationId is a new listing that existing installs never update to, losing
-        // the install base, ratings and the pro entitlements. store-facing rebranding
-        // goes through the listing title under fastlane/metadata instead.
+        // NOT the java package (see namespace below) but the identity on play and
+        // f-droid, which can never change: a new one is a new listing that existing
+        // installs never update to. Rebranding goes through the listing title instead.
         applicationId = "at.tomtasche.reader"
         minSdk = 26
         targetSdk = 36
 
-        // derived from the tag above, and set here rather than in AndroidManifest.xml:
-        // both spellings end up in the merged manifest, and this one wins, so keeping
-        // the attributes there too would only leave a second number to disagree with
+        // here rather than in AndroidManifest.xml: this one wins in the merged manifest,
+        // so a copy there could only ever disagree
         versionCode = appVersion.code
         versionName = appVersion.name
 
@@ -174,9 +160,8 @@ android {
         // AGP 9 makes resValue opt-in; the flavors use it for DISABLE_TRACKING
         resValues = true
     }
-    // the java/kotlin package, R and BuildConfig. deliberately different from
-    // applicationId above: this one is internal and free to rename, that one is not.
-    // testNamespace is left to default to namespace + ".test".
+    // the java/kotlin package, R and BuildConfig - internal and free to rename, unlike
+    // the applicationId above. testNamespace defaults to this + ".test".
     namespace = 'app.opendocument.droid'
     // ahead of targetSdk on purpose: compiling against newer APIs is independent of
     // opting in to their runtime behavior. androidx.core 1.19.0 requires 37.
@@ -184,10 +169,7 @@ android {
 }
 
 dependencies {
-    // odrcore's JNI bindings. The AAR carries both halves - the java classes and a
-    // libodr_jni.so per ABI, plus the libc++_shared.so it links - built and published
-    // together, so the pair cannot drift the way two separately versioned artifacts
-    // could. Nothing here has to be extracted or wired up at runtime any more.
+    // odrcore's JNI bindings, java and native in one AAR (see settings.gradle)
     implementation libs.odr.core.android
 
     implementation libs.play.services.ads

--- a/app/proguard-rules.txt
+++ b/app/proguard-rules.txt
@@ -1,27 +1,3 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
-
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
-
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
-
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
-
--keepnames class at.stefl.** { *; }
-
 # libodr_jni.so resolves these by name: FindClass for HtmlConfig, HtmlPage, HtmlResource
 # and the Html result holders, GetFieldID for every HtmlConfig field, and the native
 # methods are bound by signature. it also constructs the OdrException subclasses when
@@ -29,16 +5,11 @@
 # shows up in minified builds, at runtime, as a null field id or a NoSuchMethodError.
 -keep class app.opendocument.core.** { *; }
 
-# play-services-ads drags in androidx.work 2.7, whose WorkDatabase is a room database
-# built on room 2.2.5, and androidx.startup instantiates it on every cold start whether
-# the app uses WorkManager or not. room 2.2.5 ships '-keep class * extends
-# androidx.room.RoomDatabase' without a member spec, and r8 in full mode - the default
-# since AGP 8 - reads that as "keep the class, the members are fair game", so it drops
-# WorkDatabase_Impl's no-arg constructor. room then calls Class.newInstance() on it and
-# the process dies at startup with "Failed to create an instance of
-# androidx.work.impl.WorkDatabase". room only fixed its own rule in 2.7.0; this is that
-# rule, and it can go once work-runtime pulls room that far (work 2.11 does, 2.10 still
-# lands on room 2.6.1 with the broken one).
+# play-services-ads drags in androidx.work, whose WorkDatabase androidx.startup builds on
+# every cold start. room 2.2.5's own keep rule names no members, and r8 in full mode reads
+# that as "the members are fair game" - it drops WorkDatabase_Impl's no-arg constructor and
+# startup dies on "Failed to create an instance of androidx.work.impl.WorkDatabase". room
+# fixed the rule in 2.7.0, so this can go once work-runtime pulls room that far (2.11 does).
 -keep class * extends androidx.room.RoomDatabase { <init>(); }
 
 -keepattributes *Annotation*

--- a/app/src/androidTest/java/app/opendocument/droid/background/CoreLoaderTest.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/background/CoreLoaderTest.kt
@@ -9,13 +9,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
- * What the core is expected to render. odrcore v6 keeps reference html output for every format
- * asserted here, so these are the types a load is expected to succeed for.
+ * What the core is expected to render: odrcore v6 keeps reference html output for every format
+ * asserted here.
  *
- * Instrumented rather than a JVM test since odrcore 6.1: [SupportedDocumentTypes] reads the core's
- * own format table now instead of keeping a list of mime prefixes, and that table lives in
- * `libodr_jni`. Nothing here opens a file - the loader only asks the table - but a device is what
- * has the library.
+ * Instrumented because [SupportedDocumentTypes] reads the core's format table, which lives in
+ * `libodr_jni`.
  */
 @SmallTest
 @RunWith(AndroidJUnit4::class)
@@ -128,8 +126,8 @@ class CoreLoaderTest {
 
     /**
      * The binary excel package: an ooxml container whose parts are not spreadsheetml, so there is
-     * no decoder for it. Claimed until odrcore 6.1 gave it a file type of its own, because the mime
-     * type starts like every other excel one and the app matched excel by prefix.
+     * no decoder for it. Its mime type starts like every other excel one, which is what the old
+     * prefix match got wrong.
      */
     @Test
     fun theBinaryExcelWorkbookIsNotClaimed() {

--- a/app/src/androidTest/java/app/opendocument/droid/background/RawLoaderTest.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/background/RawLoaderTest.kt
@@ -2,11 +2,9 @@ package app.opendocument.droid.background
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
-import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.BeforeClass
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -103,16 +101,5 @@ class RawLoaderTest {
         assertFalse(isSupported("text/vcard"))
         assertFalse(isSupported("text/rtf"))
         assertFalse(isSupported(null))
-    }
-
-    companion object {
-
-        // @JvmStatic because junit requires @BeforeClass to be static
-        @JvmStatic
-        @BeforeClass
-        fun prepare() {
-            // the csv mime types come from a table in libodr_jni
-            CoreLoader.initializeCore(InstrumentationRegistry.getInstrumentation().targetContext)
-        }
     }
 }

--- a/app/src/androidTest/java/app/opendocument/droid/background/SupportedDocumentTypesTest.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/background/SupportedDocumentTypesTest.kt
@@ -8,14 +8,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
- * What the app offers itself for, by example.
+ * What the app offers itself for, by example: the cases odrcore's table cannot express, which
+ * `SupportedFormatsTest` walks in full.
  *
- * `SupportedFormatsTest` walks odrcore's whole table and holds the manifest against it; this one
- * spells out the cases the table cannot express - that a known extension beats an unhelpful mime
- * type, that a format the core merely recognises is not offered for, and that nothing at all is
- * still nothing.
- *
- * Instrumented rather than a JVM test since odrcore 6.1, which is where the lists come from now.
+ * Instrumented because the lists come from `libodr_jni`.
  */
 @SmallTest
 @RunWith(AndroidJUnit4::class)

--- a/app/src/androidTest/java/app/opendocument/droid/test/CoreTest.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/CoreTest.kt
@@ -12,11 +12,8 @@ import app.opendocument.droid.nonfree.AnalyticsManager
 import app.opendocument.droid.nonfree.CrashManager
 import java.io.File
 import java.io.FileOutputStream
-import java.io.InputStream
-import org.junit.After
 import org.junit.AfterClass
 import org.junit.Assert
-import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -25,79 +22,15 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class CoreTest {
 
-    // nullable like the java fields were: a failure while extracting must not turn into an
-    // "uninitialized" error from the cleanup that follows it
-    private var testFile: File? = null
-    private var passwordTestFile: File? = null
-    private var spreadsheetTestFile: File? = null
-    private var docxTestFile: File? = null
-    private var pptxTestFile: File? = null
-    private var docTestFile: File? = null
-    private var pptTestFile: File? = null
-    private var xlsTestFile: File? = null
-
     private val coreLoader: CoreLoader
         get() = checkNotNull(sharedLoader) { "the core loader was not started" }
-
-    private fun requireFile(file: File?): File = checkNotNull(file) { "the test file is missing" }
-
-    @Before
-    fun extractTestFile() {
-        val appCtx = InstrumentationRegistry.getInstrumentation().targetContext
-        val assetManager = InstrumentationRegistry.getInstrumentation().context.assets
-
-        testFile = extract(assetManager.open("test.odt"), File(appCtx.cacheDir, "test.odt"))
-        passwordTestFile =
-            extract(
-                assetManager.open("password-test.odt"),
-                File(appCtx.cacheDir, "password-test.odt"),
-            )
-        spreadsheetTestFile =
-            extract(
-                assetManager.open("spreadsheet-test.ods"),
-                File(appCtx.cacheDir, "spreadsheet-test.ods"),
-            )
-        docxTestFile =
-            extract(
-                assetManager.open("style-various-1.docx"),
-                File(appCtx.cacheDir, "style-various-1.docx"),
-            )
-        pptxTestFile =
-            extract(
-                assetManager.open("style-various-1.pptx"),
-                File(appCtx.cacheDir, "style-various-1.pptx"),
-            )
-        docTestFile = extract(assetManager.open("11KB.doc"), File(appCtx.cacheDir, "11KB.doc"))
-        pptTestFile =
-            extract(
-                assetManager.open("style-various-1.ppt"),
-                File(appCtx.cacheDir, "style-various-1.ppt"),
-            )
-        xlsTestFile =
-            extract(
-                assetManager.open("file_example_XLS_10.xls"),
-                File(appCtx.cacheDir, "file_example_XLS_10.xls"),
-            )
-    }
-
-    @After
-    fun cleanupTestFile() {
-        testFile?.delete()
-        passwordTestFile?.delete()
-        spreadsheetTestFile?.delete()
-        docxTestFile?.delete()
-        pptxTestFile?.delete()
-        docTestFile?.delete()
-        pptTestFile?.delete()
-        xlsTestFile?.delete()
-    }
 
     @Test
     fun test() {
         val views =
             coreLoader.host(
                 prefix = "test",
-                inputPath = requireFile(testFile).absolutePath,
+                inputPath = testFile.absolutePath,
                 cachePath = File(cacheDir(), "core_cache").path,
                 editable = true,
                 keepDocument = true,
@@ -118,7 +51,7 @@ class CoreTest {
         val views =
             coreLoader.host(
                 prefix = "docx-edit",
-                inputPath = requireFile(docxTestFile).absolutePath,
+                inputPath = docxTestFile.absolutePath,
                 cachePath = File(cacheDir(), "core_cache").path,
                 editable = true,
                 keepDocument = true,
@@ -142,7 +75,7 @@ class CoreTest {
         val views =
             coreLoader.host(
                 prefix = "pptx-test",
-                inputPath = requireFile(pptxTestFile).absolutePath,
+                inputPath = pptxTestFile.absolutePath,
                 cachePath = File(cacheDir(), "pptx_cache").path,
             )
         Assert.assertFalse("hosting the PPTX file should produce a view", views.isEmpty())
@@ -153,7 +86,7 @@ class CoreTest {
         val views =
             coreLoader.host(
                 prefix = "doc-test",
-                inputPath = requireFile(docTestFile).absolutePath,
+                inputPath = docTestFile.absolutePath,
                 cachePath = File(cacheDir(), "doc_cache").path,
             )
         Assert.assertFalse("hosting the DOC file should produce a view", views.isEmpty())
@@ -164,7 +97,7 @@ class CoreTest {
         val views =
             coreLoader.host(
                 prefix = "ppt-test",
-                inputPath = requireFile(pptTestFile).absolutePath,
+                inputPath = pptTestFile.absolutePath,
                 cachePath = File(cacheDir(), "ppt_cache").path,
             )
         Assert.assertFalse("hosting the PPT file should produce a view", views.isEmpty())
@@ -175,7 +108,7 @@ class CoreTest {
         val views =
             coreLoader.host(
                 prefix = "xls-test",
-                inputPath = requireFile(xlsTestFile).absolutePath,
+                inputPath = xlsTestFile.absolutePath,
                 cachePath = File(cacheDir(), "xls_cache").path,
             )
         Assert.assertFalse("hosting the XLS file should produce a view", views.isEmpty())
@@ -183,22 +116,20 @@ class CoreTest {
 
     /**
      * Which of the formats the core renders it can also write back again - the answer
-     * `DocumentFragment` puts the Edit button up by. Offering it for a document the core will not
-     * save only gets as far as a failed save, which is what happened to the legacy binary formats
-     * when they started going through the core.
+     * `DocumentFragment` puts the Edit button up by.
      */
     @Test
     fun testEditableFormats() {
-        assertEditable("odt-editable", requireFile(testFile), true)
-        assertEditable("docx-editable", requireFile(docxTestFile), true)
+        assertEditable("odt-editable", testFile, true)
+        assertEditable("docx-editable", docxTestFile, true)
 
         // the core declares these read only: the three legacy binary formats, ooxml presentations
         // and every spreadsheet - the last being issue #442, which the core has its own TODO for
-        assertEditable("doc-editable", requireFile(docTestFile), false)
-        assertEditable("ppt-editable", requireFile(pptTestFile), false)
-        assertEditable("xls-editable", requireFile(xlsTestFile), false)
-        assertEditable("pptx-editable", requireFile(pptxTestFile), false)
-        assertEditable("ods-editable", requireFile(spreadsheetTestFile), false)
+        assertEditable("doc-editable", docTestFile, false)
+        assertEditable("ppt-editable", pptTestFile, false)
+        assertEditable("xls-editable", xlsTestFile, false)
+        assertEditable("pptx-editable", pptxTestFile, false)
+        assertEditable("ods-editable", spreadsheetTestFile, false)
     }
 
     private fun assertEditable(prefix: String, file: File, expected: Boolean) {
@@ -222,7 +153,7 @@ class CoreTest {
         Assert.assertThrows(OdrException.FileEncrypted::class.java) {
             coreLoader.host(
                 prefix = "password-test-no-pw",
-                inputPath = requireFile(passwordTestFile).absolutePath,
+                inputPath = passwordTestFile.absolutePath,
                 cachePath = File(cacheDir(), "core_cache").path,
             )
         }
@@ -233,7 +164,7 @@ class CoreTest {
         Assert.assertThrows(OdrException::class.java) {
             coreLoader.host(
                 prefix = "password-test-wrong-pw",
-                inputPath = requireFile(passwordTestFile).absolutePath,
+                inputPath = passwordTestFile.absolutePath,
                 cachePath = File(cacheDir(), "core_cache").path,
                 password = "wrongpassword",
             )
@@ -245,7 +176,7 @@ class CoreTest {
         val views =
             coreLoader.host(
                 prefix = "password-test-correct-pw",
-                inputPath = requireFile(passwordTestFile).absolutePath,
+                inputPath = passwordTestFile.absolutePath,
                 cachePath = File(cacheDir(), "core_cache").path,
                 password = "passwort",
             )
@@ -257,14 +188,12 @@ class CoreTest {
         val views =
             coreLoader.host(
                 prefix = "spreadsheet-test",
-                inputPath = requireFile(spreadsheetTestFile).absolutePath,
+                inputPath = spreadsheetTestFile.absolutePath,
                 cachePath = File(cacheDir(), "spreadsheet_cache").path,
             )
 
-        // Verify we have exactly 3 sheets
         Assert.assertEquals("ODS file should contain 3 sheets", 3, views.size)
 
-        // Verify sheet names match the actual sheet names from the ODS file
         Assert.assertEquals("First sheet should be named 'hey'", "hey", views[0].name)
         Assert.assertEquals("Second sheet should be named 'ho'", "ho", views[1].name)
         Assert.assertEquals("Third sheet should be named 'Sheet3'", "Sheet3", views[2].name)
@@ -274,15 +203,46 @@ class CoreTest {
 
         private var sharedLoader: CoreLoader? = null
 
+        // extracted once for the whole class: nothing here writes to a fixture
+        private val extracted = mutableListOf<File>()
+
+        private lateinit var testFile: File
+        private lateinit var passwordTestFile: File
+        private lateinit var spreadsheetTestFile: File
+        private lateinit var docxTestFile: File
+        private lateinit var pptxTestFile: File
+        private lateinit var docTestFile: File
+        private lateinit var pptTestFile: File
+        private lateinit var xlsTestFile: File
+
         // @JvmStatic because junit requires @BeforeClass / @AfterClass to be static
+        @JvmStatic
+        @BeforeClass
+        fun extractTestFiles() {
+            testFile = extract("test.odt")
+            passwordTestFile = extract("password-test.odt")
+            spreadsheetTestFile = extract("spreadsheet-test.ods")
+            docxTestFile = extract("style-various-1.docx")
+            pptxTestFile = extract("style-various-1.pptx")
+            docTestFile = extract("11KB.doc")
+            pptTestFile = extract("style-various-1.ppt")
+            xlsTestFile = extract("file_example_XLS_10.xls")
+        }
+
+        @JvmStatic
+        @AfterClass
+        fun cleanupTestFiles() {
+            extracted.forEach { it.delete() }
+            extracted.clear()
+        }
+
         @JvmStatic
         @BeforeClass
         fun startServer() {
             val appCtx = InstrumentationRegistry.getInstrumentation().targetContext
 
-            // the loader owns the core lifecycle now, so the test drives a real one rather than a
-            // set of statics. nothing here goes through loadAsync, so both handlers can be the main
-            // looper and the listener is never called back
+            // nothing here goes through loadAsync, so both handlers can be the main looper and
+            // the listener is never called back
             val handler = Handler(Looper.getMainLooper())
             val loader = CoreLoader(appCtx)
             sharedLoader = loader
@@ -297,10 +257,6 @@ class CoreTest {
                 AnalyticsManager(),
                 CrashManager(),
             )
-
-            // no waiting for the server here: these tests call host() and edit() straight on
-            // the loader and never fetch a url, so whether the socket is listening yet does
-            // not come into it. it used to sleep a second for it anyway
         }
 
         @JvmStatic
@@ -313,8 +269,14 @@ class CoreTest {
         private fun cacheDir(): File =
             InstrumentationRegistry.getInstrumentation().targetContext.cacheDir
 
-        private fun extract(source: InputStream, target: File): File {
-            source.use { input -> FileOutputStream(target).use { output -> input.copyTo(output) } }
+        private fun extract(name: String): File {
+            val instrumentation = InstrumentationRegistry.getInstrumentation()
+            val target = File(instrumentation.targetContext.cacheDir, name)
+
+            instrumentation.context.assets.open(name).use { input ->
+                FileOutputStream(target).use { output -> input.copyTo(output) }
+            }
+            extracted += target
 
             return target
         }

--- a/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
@@ -9,7 +9,6 @@ import android.app.Instrumentation
 import android.content.Intent
 import android.net.Uri
 import android.os.SystemClock
-import android.util.Log
 import androidx.core.content.FileProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.IdlingRegistry
@@ -72,7 +71,6 @@ class MainActivityTests {
 
     @Before
     fun setUp() {
-        // Launch a fresh activity for each test
         val mainActivity = mainActivityActivityTestRule.launchActivity(null)
 
         val idlingResource = OpenFileIdling.idlingResource
@@ -84,15 +82,10 @@ class MainActivityTests {
         mainActivity.sendBroadcast(Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS))
 
         Intents.init()
-
-        // Log test setup for debugging
-        Log.d(TAG, "setUp() called for test: " + javaClass.name)
     }
 
     @After
     fun tearDown() {
-        Log.d(TAG, "tearDown() called")
-
         Intents.release()
 
         idlingResource?.let { IdlingRegistry.getInstance().unregister(it) }
@@ -104,11 +97,8 @@ class MainActivityTests {
             InstrumentationRegistry.getInstrumentation().runOnMainSync { resumed.finish() }
         }
 
-        // Finish and wait for activity to be destroyed
         if (mainActivityActivityTestRule.activity != null) {
             mainActivityActivityTestRule.finishActivity()
-
-            // Use Instrumentation to wait until activity is destroyed
             InstrumentationRegistry.getInstrumentation().waitForIdleSync()
         }
     }
@@ -119,8 +109,8 @@ class MainActivityTests {
 
         openDocumentThroughPicker()
 
-        // next onView will be blocked until the idling resource is idle, which now covers
-        // the load itself and not just the picker round trip.
+        // the click blocks on the idling resource, which covers the load itself - so finding
+        // the Edit item enabled is the assertion that the document opened
         clickEditWithOverflowFallback()
     }
 
@@ -130,38 +120,12 @@ class MainActivityTests {
 
         openDocumentThroughPicker()
 
-        // next onView will be blocked until the idling resource is idle, which now covers
-        // the load itself and not just the picker round trip.
         clickEditWithOverflowFallback()
-
-        // there used to be a 10s sleep here that asserted nothing, and it is why "testPDF
-        // crashed" was an api 34 bucket of its own: the app is killed whenever play services
-        // dies under it ("depends on provider ...FontsProvider in dying proc"), which the
-        // instrumentation reports as "Process crashed", and this test sat still the longest
-        // so it was usually the one holding the app when that happened
     }
 
     @Test
     fun testPasswordProtectedODT() {
         val testFile = requireTestFile("password-test.odt")
-
-        // Check if the file exists and is readable
-        Assert.assertTrue(
-            "Password test file does not exist: " + testFile.absolutePath,
-            testFile.exists(),
-        )
-        Assert.assertTrue(
-            "Password test file is not readable: " + testFile.absolutePath,
-            testFile.canRead(),
-        )
-
-        // Log file info for debugging CI issues
-        Log.d(TAG, "Password test file path: " + testFile.absolutePath)
-        Log.d(TAG, "Password test file size: " + testFile.length())
-        Log.d(TAG, "All test files: " + testFiles.keys)
-
-        // Double-check we're using the right file
-        Assert.assertEquals("password-test.odt file size mismatch", 12671L, testFile.length())
 
         respondToOpenDocumentWith(testFile)
 
@@ -171,7 +135,6 @@ class MainActivityTests {
         // stays busy until it is on screen - so this does not have to poll for it.
         onView(withText("This document is password-protected")).check(matches(isDisplayed()))
 
-        // Enter wrong password first
         onView(withClassName(equalTo("android.widget.EditText"))).perform(typeText("wrongpassword"))
 
         onView(withId(android.R.id.button1)).perform(click())
@@ -179,7 +142,6 @@ class MainActivityTests {
         // Should show password dialog again for wrong password
         onView(withText("This document is password-protected")).check(matches(isDisplayed()))
 
-        // Clear the text field and enter correct password
         onView(withClassName(equalTo("android.widget.EditText")))
             .perform(clearText(), typeText("passwort"))
 
@@ -193,11 +155,8 @@ class MainActivityTests {
     fun testCorruptODTIsNotOfferedForUpload() {
         val activity = mainActivityActivityTestRule.activity
 
-        // a zip that still names itself odf, with a content.xml cut in half. the core claims
-        // the format and fails on the file, and that answer is taken as final: uploading it
-        // would only run the same core on a server and fail a second time
-        //
-        // not loadDocument(), which waits for a fragment this path takes back down again
+        // the core claims the format and fails on the file, which is final - an upload runs the
+        // same core. not loadDocument(), which waits for a fragment this path takes back down
         val testFileUri = uriOf(requireTestFile("corrupt.odt"))
         InstrumentationRegistry.getInstrumentation().runOnMainSync { activity.loadUri(testFileUri) }
 
@@ -236,12 +195,8 @@ class MainActivityTests {
         val before = documentFragment.lastResult
         Assert.assertNotNull(before)
 
-        // the document state used to be kept alive by setRetainInstance(true) and now
-        // lives in a ViewModel, so a configuration change must not drop it or reload.
-        // rotating is not enough to check that: MainActivity handles orientation and
-        // screenSize itself, so it is only reconfigured, never torn down. recreate() is
-        // what a locale or font scale change does, and that is the path the ViewModel and
-        // the saved instance state have to survive.
+        // not rotation, which MainActivity handles itself: recreate() is what a locale or font
+        // scale change does, and that is the path the ViewModel and saved state must survive
         val recreated = recreate(activity)
         Assert.assertNotNull("activity gone after recreation", recreated)
         Assert.assertNotSame("activity was not recreated", activity, recreated)
@@ -309,6 +264,9 @@ class MainActivityTests {
                     )
                     .perform(click())
             }
+            // the perform is what the handler above catches for; without it onView is lazy
+            // and this helper silently does nothing
+            .perform(click())
     }
 
     private fun recreate(activity: MainActivity): MainActivity? {
@@ -395,10 +353,8 @@ class MainActivityTests {
     }
 
     /**
-     * Fails with what the page and the file on disk actually contained. testODTEditMode fails on
-     * api 26 without ever being slow - about a second or never - so the interesting question is
-     * which half of the round trip went missing: the reload with translatable=true not producing
-     * editable html, or the webview never showing the html that was produced.
+     * Fails with what the page and the file on disk actually contained, since the interesting half
+     * of an edit mode failure is which end of the round trip went missing.
      */
     private fun assertBecomesEditable(
         label: String,
@@ -426,12 +382,9 @@ class MainActivityTests {
         ) ?: "no result"
 
     /**
-     * What the loader published, fetched over http the way the webview fetches it.
-     *
-     * Documents are served by the core's own server rather than read off disk, so asking for the
-     * url is the question that matters: a document the test process cannot fetch either was never
-     * served, and one it can fetch was the webview's to lose. When the server had failed to bind
-     * its port, this said "Connection refused" - which is the whole answer.
+     * What the loader published, fetched over http the way the webview fetches it: a document the
+     * test process cannot fetch either was never served, and one it can fetch was the webview's to
+     * lose.
      */
     private fun describeLoadedDocument(fragment: DocumentFragment): String {
         val result = fragment.lastResult ?: return "no result"
@@ -509,20 +462,11 @@ class MainActivityTests {
     }
 
     companion object {
-        private const val TAG = "MainActivityTests"
-
-        // entering edit mode has to round-trip through the webview before the dom reports
-        // contenteditable, and on a cold CI emulator that regularly took longer than the 10s
-        // this used to wait for - the edit mode tests were the flakiest thing in the suite.
-        //
-        // it stays at 30s. the api 26 failures that looked like it needed more were the core
-        // server failing to bind its port, so the document was never served at all and no
-        // deadline would have helped - 60s failed exactly as 30s had. a run that works is
-        // done in about a second
+        // a cold CI emulator needs more than the 10s this used to wait. more than 30s does not
+        // help: what still failed at 60s was the core server failing to bind its port
         private const val EDIT_MODE_TIMEOUT_MS = 30000L
 
-        // insertion ordered, so the "All test files" log below reads in extraction order
-        private val testFiles = LinkedHashMap<String, File>()
+        private val testFiles = mutableMapOf<String, File>()
 
         // @JvmStatic because junit requires @BeforeClass / @AfterClass to be static
         @JvmStatic

--- a/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
@@ -120,7 +120,13 @@ class MainActivityTests {
 
         openDocumentThroughPicker()
 
-        clickEditWithOverflowFallback()
+        // the core does not write pdf back, so Edit is not what says this opened - Search is.
+        // this asserted on Edit until the click was live, which it never can be here
+        onView(allOf(withId(R.id.menu_search), withContentDescription("Search in document")))
+            .check(matches(isDisplayed()))
+
+        // menu_edit is showAsAction="always", so an offered one would be in the toolbar
+        onView(withId(R.id.menu_edit)).check(doesNotExist())
     }
 
     @Test

--- a/app/src/androidTest/java/app/opendocument/droid/test/SupportedFormatsTest.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/SupportedFormatsTest.kt
@@ -18,20 +18,12 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
- * Keeps the two remaining declarations of what the app opens in step with each other, so that
- * changing one and forgetting the other is a failing test rather than a bug report.
+ * Keeps the two remaining declarations of what the app opens in step: [SupportedDocumentTypes],
+ * which reads odrcore's format table, and the STRICT_CATCH `activity-alias` in AndroidManifest.xml,
+ * which is XML and cannot read it - but can be *asked*, which is what [resolvesToUs] does.
  *
- * [SupportedDocumentTypes] is one of them, and since odrcore 6.1 it is barely a declaration at
- * all - it reads the core's own format table. The other is the STRICT_CATCH `activity-alias` in
- * AndroidManifest.xml, which is XML and cannot read that table - but it can be *asked*: an
- * intent-filter is only worth anything if the package manager resolves a real intent through it,
- * which is what [resolvesToUs] does here.
- *
- * So neither side needs a list of formats of its own. The test walks every mime type spelling
- * odrcore accepts, [Odr.mimetypesByFileType] for each of [Odr.allFileTypes], and demands that the
- * app and the manifest give the same answer for all of them. That reaches the templates, the macro
- * enabled variants and the `x-vnd` spellings, which used to need a hand written list here because
- * the core only named one canonical mime type per format.
+ * So neither side needs a list of formats of its own: the test walks every mime type spelling
+ * odrcore accepts and demands the same answer from both.
  */
 @SmallTest
 @RunWith(AndroidJUnit4::class)
@@ -216,10 +208,6 @@ class SupportedFormatsTest {
         @BeforeClass
         fun prepare() {
             val context = InstrumentationRegistry.getInstrumentation().targetContext
-
-            // Odr's tables live in libodr_jni; nothing here opens a file, so the data paths that
-            // initializeCore also sets up are along for the ride rather than needed
-            CoreLoader.initializeCore(context)
 
             // STRICT_CATCH is what this test is about, and the component states survive a test run
             // - a previous one that flipped the switch would otherwise leave CATCH_ALL answering

--- a/app/src/debug/java/app/opendocument/droid/ui/OpenFileIdling.kt
+++ b/app/src/debug/java/app/opendocument/droid/ui/OpenFileIdling.kt
@@ -4,9 +4,8 @@ import androidx.test.espresso.IdlingResource
 import androidx.test.espresso.idling.CountingIdlingResource
 
 /**
- * Debug variant: a real espresso idling resource, so instrumented tests can wait for the document
- * picker round trip. The release variant of this class does nothing, which keeps espresso out of
- * the shipped apk.
+ * Debug variant: a real espresso idling resource, so instrumented tests can wait for a document to
+ * finish loading. The release variant does nothing, keeping espresso out of the shipped apk.
  */
 object OpenFileIdling {
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -63,14 +63,9 @@
             android:value="ca-app-pub-8161473686436957~9025061963" />
 
         <!--
-             every component name below deliberately keeps its historical
-             at.tomtasche.reader.* spelling even though the java package is now
-             app.opendocument.droid. component names are persisted by the OS: they are
-             what a launcher stores for a pinned homescreen icon, and what the system
-             records when the user picks "always open .odt with this app". renaming them
-             would silently drop those associations for every existing install. an
-             activity-alias name does not have to correspond to a real class, so the old
-             names live on as aliases pointing at the relocated activity.
+             every component name below keeps its historical at.tomtasche.reader.* spelling:
+             the OS persists component names for pinned launcher icons and for "always open
+             .odt with this app". See the package names section of CLAUDE.md.
         -->
         <activity
             android:name="app.opendocument.droid.ui.activity.MainActivity"
@@ -78,9 +73,8 @@
             android:exported="true" />
 
         <!--
-             the launcher entry, kept under the pre-rename name so pinned homescreen
-             icons keep resolving. the MAIN/LAUNCHER filter lives here and NOT on the
-             activity above, otherwise the app would show two launcher icons.
+             the launcher entry. the MAIN/LAUNCHER filter lives here and NOT on the activity
+             above, or the app would show two launcher icons.
         -->
         <activity-alias
             android:name="at.tomtasche.reader.ui.activity.MainActivity"
@@ -178,10 +172,6 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.odg" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.odg" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.odg" />
-                <data android:pathPattern=".*\\.odt" />
-                <data android:pathPattern=".*\\.ods" />
-                <data android:pathPattern=".*\\.odp" />
-                <data android:pathPattern=".*\\.odg" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -221,10 +211,6 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.odg" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.odg" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.odg" />
-                <data android:pathPattern=".*\\.odt" />
-                <data android:pathPattern=".*\\.ods" />
-                <data android:pathPattern=".*\\.odp" />
-                <data android:pathPattern=".*\\.odg" />
             </intent-filter>
         </activity-alias>
         <activity-alias
@@ -235,15 +221,12 @@
             android:targetActivity="app.opendocument.droid.ui.activity.MainActivity"
             tools:ignore="AppLinkUrlError">
             <!--
-                 STRICT_CATCH: what the app actually opens - opendocument, ooxml, the legacy
-                 binary doc/ppt/xls and pdf, plus text, images, zip and csv. All of it goes to
-                 the core except csv, which RawLoader keeps for its table viewer. The three
-                 filters below are generated from odrcore's own format table and must not be
-                 edited by hand alone; SupportedDocumentTypes reads that same table at runtime,
-                 and SupportedFormatsTest fails when the two stop agreeing.
+                 what the app actually opens. The three filters below are generated from
+                 odrcore's format table - SupportedDocumentTypes reads the same table at
+                 runtime, and SupportedFormatsTest fails when the two stop agreeing.
 
-                 Narrower than what the core can render on purpose: it also turns fonts, audio
-                 and video into a page, none of which belong in a document viewer's share sheet.
+                 Narrower than what the core renders on purpose: fonts, audio and video do not
+                 belong in a document viewer's share sheet.
             -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -252,11 +235,9 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <!--
-                     every mime type spelling odrcore accepts for a format it turns into
-                     html. an intent-filter matches a mime type exactly, so the templates, the
-                     macro enabled variants and the x-vnd spellings all have to be named -
-                     where the old prefix list took each family in one line, and got .xlsb
-                     wrong for it.
+                     every mime type spelling odrcore accepts. an intent-filter matches
+                     exactly, so the templates, the macro enabled variants and the x-vnd
+                     spellings all have to be named - a prefix list got .xlsb wrong.
                 -->
                 <data android:mimeType="application/vnd.oasis.opendocument.text" />
                 <data android:mimeType="application/x-vnd.oasis.opendocument.text" />
@@ -300,15 +281,13 @@
                 <data android:mimeType="application/x-pdf" />
                 <!--
                      the octet-stream a provider volunteers when it knows nothing better.
-                     claimed outright, because only the filename can answer for it - which is
-                     what the pathPattern filter below does.
+                     only the filename can answer for it - the pathPattern filter below.
                 -->
                 <data android:mimeType="application/octet-stream" />
                 <!--
-                     the non-document types worth opening a viewer for: text/plain rather than
-                     text/*, which would re-match the vcard contacts of #477, and image/*
-                     rather than the image formats odrcore names, because it has no file type
-                     for svg - which RawLoader still shows.
+                     text/plain rather than text/*, which would re-match the vcard contacts of
+                     #477; image/* rather than the formats odrcore names, because it has no
+                     file type for svg.
                 -->
                 <data android:mimeType="text/plain" />
                 <data android:mimeType="text/csv" />
@@ -329,11 +308,10 @@
                 <data android:scheme="file" />
                 <data android:host="*" />
                 <!--
-                     a file manager that sends ACTION_VIEW with no mime type at all leaves
-                     the name as the only thing to go on. one pattern per leading dot,
-                     because pathPattern has no way to say "ends with" before API 31, and one
-                     extension per line - the same extensions SupportedDocumentTypes gets
-                     from the core.
+                     ACTION_VIEW with no mime type leaves the name as the only thing to go
+                     on. one pattern per leading dot, because pathPattern has no "ends with"
+                     before API 31, over the extensions SupportedDocumentTypes gets from the
+                     core.
                 -->
                 <data android:pathPattern=".*\\.odt" />
                 <data android:pathPattern=".*\\..*\\.odt" />
@@ -633,13 +611,7 @@
                 <data android:scheme="content" />
                 <data android:scheme="file" />
                 <data android:host="*" />
-                <!--
-                     a file manager that sends ACTION_VIEW with no mime type at all leaves
-                     the name as the only thing to go on. one pattern per leading dot,
-                     because pathPattern has no way to say "ends with" before API 31, and one
-                     extension per line - the same extensions SupportedDocumentTypes gets
-                     from the core.
-                -->
+                <!-- the same extensions as the filter above, for a typed ACTION_VIEW -->
                 <data android:pathPattern=".*\\.odt" />
                 <data android:pathPattern=".*\\..*\\.odt" />
                 <data android:pathPattern=".*\\..*\\..*\\.odt" />

--- a/app/src/main/java/app/opendocument/droid/background/AndroidFileCache.kt
+++ b/app/src/main/java/app/opendocument/droid/background/AndroidFileCache.kt
@@ -26,8 +26,7 @@ object AndroidFileCache {
     }
 
     fun getCacheDirectory(cacheFile: File): File {
-        // !! rather than a graceful fallback: reaching the filesystem root means the file was
-        // never below a cache directory, which the java version blew up on just as loudly
+        // !!: reaching the filesystem root means the file was never below a cache directory
         val parentDirectory = cacheFile.parentFile!!
         if (!parentDirectory.name.startsWith(CACHE_DIRECTORY_PREFIX)) {
             return getCacheDirectory(parentDirectory)
@@ -66,6 +65,17 @@ object AndroidFileCache {
         cacheDirectory.mkdirs()
 
         return File(cacheDirectory, "cached-file.tmp")
+    }
+
+    /**
+     * Deletes [file] along with the directory [createCacheFile] made for it - [cleanup] keeps
+     * whichever sorts last, so an empty leftover would be kept in place of the open document.
+     */
+    fun deleteCacheFile(file: File) {
+        file.delete()
+
+        // delete() on a directory only succeeds while it is empty, which is the intent
+        file.parentFile?.takeIf { it.name.startsWith(CACHE_DIRECTORY_PREFIX) }?.delete()
     }
 
     fun cleanup(context: Context) {

--- a/app/src/main/java/app/opendocument/droid/background/CatchAllSetting.kt
+++ b/app/src/main/java/app/opendocument/droid/background/CatchAllSetting.kt
@@ -16,21 +16,16 @@ object CatchAllSetting {
 
     private const val PREF_CATCH_ALL_ENABLED = "catch_all_enabled"
 
-    // these keep the historical at.tomtasche.reader names on purpose: the component name is
-    // what the OS persists when a user picks "always open .odt with this app", and what
-    // setComponentEnabledSetting stores the toggle against. renaming them would drop those
-    // defaults for every existing install, so the manifest declares the aliases under the old
-    // names too.
+    // the historical at.tomtasche.reader names: the OS persists component names for "always open
+    // .odt with this app", so renaming them drops that for every existing install
     private const val CATCH_ALL_COMPONENT = "at.tomtasche.reader.ui.activity.MainActivity.CATCH_ALL"
     private const val STRICT_CATCH_COMPONENT =
         "at.tomtasche.reader.ui.activity.MainActivity.STRICT_CATCH"
 
     /**
-     * Puts the aliases back in the state the stored setting asks for.
-     *
-     * Has to run on every launch, not just when the landing screen is shown: users upgrading from a
-     * version that shipped different alias defaults are only corrected here, and the app is
-     * regularly started straight into a document by an external intent.
+     * Puts the aliases back in the state the stored setting asks for. On every launch, not just the
+     * landing screen: an upgrade from different alias defaults is only corrected here, and the app
+     * is regularly started straight into a document by an external intent.
      */
     fun applyOnLaunch(context: Context): Boolean {
         val enabled = isEnabled(context)
@@ -41,9 +36,7 @@ object CatchAllSetting {
     }
 
     fun isEnabled(context: Context): Boolean =
-        // catch-all is only active if the user explicitly opted in. new installs and existing
-        // users who never touched the switch default to STRICT_CATCH, so we no longer volunteer
-        // to open unrelated file types like contacts (issue #477).
+        // opt-in: the default is STRICT_CATCH, so the app does not volunteer for contacts (#477)
         preferences(context).getBoolean(PREF_CATCH_ALL_ENABLED, false)
 
     fun setEnabled(context: Context, enabled: Boolean) {
@@ -70,10 +63,9 @@ object CatchAllSetting {
     }
 
     /**
-     * The preferences android.preference.PreferenceManager used to hand out. That class is
-     * deprecated and its androidx replacement lives in a whole preference-ui library we do not
-     * otherwise need, so the default file is opened by name instead - keeping the existing
-     * catch-all setting of users who upgrade.
+     * The file android.preference.PreferenceManager used to hand out, opened by name so upgrading
+     * users keep their setting - its androidx replacement needs a preference-ui library we do not
+     * otherwise want.
      */
     private fun preferences(context: Context): SharedPreferences =
         context.getSharedPreferences(context.packageName + "_preferences", Context.MODE_PRIVATE)

--- a/app/src/main/java/app/opendocument/droid/background/CoreLoader.kt
+++ b/app/src/main/java/app/opendocument/droid/background/CoreLoader.kt
@@ -5,7 +5,6 @@ import android.net.Uri
 import android.os.Handler
 import android.system.Os
 import android.util.Log
-import app.opendocument.core.DecodePreference
 import app.opendocument.core.DecodedFile
 import app.opendocument.core.Document
 import app.opendocument.core.DocumentType
@@ -28,42 +27,20 @@ import java.io.IOException
 /**
  * Loads documents through odrcore and publishes them on a local http server.
  *
- * This talks to odrcore's own JNI bindings (`app.opendocument.core`, the java classes and the
- * matching `libodr_jni.so`, both out of the odr-core-android AAR). It used to go through
- * `CoreWrapper` and a hand-written JNI layer in `src/main/cpp/core_wrapper.cpp` that flattened
- * every failure into an integer error code; the core reports typed [OdrException]s instead, so the
- * codes and their mirror exception types are gone.
- *
- * The loader owns the process-wide core state: the one-time initialization, the single http server
- * and the currently open [Document] that [retranslate] edits.
+ * Owns the process wide core state: the one-time initialization, the single http server and the
+ * currently open [Document] that [retranslate] edits.
  */
-// the context is nullable like FileLoader's own field, which close() clears and the unit
-// tests never set - isSupported() is pure and does not need one
 class CoreLoader(context: Context?) : FileLoader(context, LoaderType.CORE) {
 
     private var document: Document? = null
     private var lastInputPath: String? = null
-    private var lastCachePath: String? = null
 
     /**
-     * Whether the document [host] last opened is one [edit] can do something with.
-     *
-     * This is the core's own answer, not a list of formats kept here: [host] only holds a document
-     * open when it reports itself editable and savable, so having one is the answer. The core says
-     * no to the legacy binary formats, to ooxml spreadsheets and presentations and to opendocument
-     * spreadsheets - the last of those being the same gap as issue #442, which the app used to
-     * check for by mime type on its own.
+     * Whether the document [host] last opened is one [edit] can do something with - the core's own
+     * answer, since [host] only keeps a document that reports itself editable and savable.
      */
     val isDocumentEditable: Boolean
         get() = document != null
-
-    // the shared server and the port it actually got, which is not always the preferred one.
-    // see bind() and startSharedServer()
-    private val server: HttpServer?
-        get() = sharedServer
-
-    private val serverPort: Int
-        get() = sharedServerPort
 
     override fun initialize(
         listener: FileLoaderListener,
@@ -72,9 +49,7 @@ class CoreLoader(context: Context?) : FileLoader(context, LoaderType.CORE) {
         analyticsManager: AnalyticsManager,
         crashManager: CrashManager,
     ) {
-        // loads the native library and points the core at a usable temporary directory. Kept out
-        // of the constructor so that constructing a CoreLoader stays side effect free -
-        // LoaderService calls initialize() right after new CoreLoader() anyway.
+        // loads the native library and points the core at a usable temporary directory
         initializeCore(context)
 
         startSharedServer(crashManager)
@@ -83,8 +58,8 @@ class CoreLoader(context: Context?) : FileLoader(context, LoaderType.CORE) {
     }
 
     /**
-     * Everything odrcore can turn into html, which since 6.2 is much more than documents - only csv
-     * is left out, for [RawLoader]'s table viewer. Wider than what the app offers itself for (see
+     * Everything odrcore can turn into html, which is much more than documents - only csv is left
+     * out, for [RawLoader]'s table viewer. Wider than what the app offers itself for (see
      * [SupportedDocumentTypes]): this decides how a failed load is reported, not the share sheet.
      */
     override fun isSupported(options: Options): Boolean =
@@ -119,7 +94,6 @@ class CoreLoader(context: Context?) : FileLoader(context, LoaderType.CORE) {
         val coreCacheDirectory = File(cacheDirectory, "core_cache")
 
         lastInputPath = cachedFile.path
-        lastCachePath = coreCacheDirectory.path
 
         val views =
             host(
@@ -155,13 +129,13 @@ class CoreLoader(context: Context?) : FileLoader(context, LoaderType.CORE) {
         paging: Boolean = false,
         keepDocument: Boolean = false,
     ): List<HostedView> {
-        val server = checkNotNull(server) { "core server is not running" }
+        val server = checkNotNull(sharedServer) { "core server is not running" }
 
         Log.i(TAG, "host file")
 
         server.clear()
 
-        var file = open(inputPath)
+        var file = Odr.open(inputPath)
 
         if (file.passwordEncrypted()) {
             if (password == null) {
@@ -175,21 +149,16 @@ class CoreLoader(context: Context?) : FileLoader(context, LoaderType.CORE) {
         if (keepDocument) {
             closeDocument()
 
-            // what the format could ever allow, which odrcore 6.1 answers without decoding
-            // anything. A document is only opened here when it might be kept, and opening one
-            // costs a second parse of the whole file (the TODO below) - so the formats that
-            // declare no editing, which is pdf and every spreadsheet and presentation the app
-            // renders, no longer pay for an answer that was always going to be no.
+            // an upper bound the core answers without decoding, so a format that declares no
+            // editing is not opened just to be told no
             val capabilities = file.capabilities()
 
             if (file.isDocumentFile && capabilities.edit && capabilities.save) {
                 // TODO this will cause a second load
                 val document = file.asDocumentFile().document()
 
-                // keep only what [edit] can do something with, and let the core be the one to say
-                // so - see [isDocumentEditable]. The declaration above is an upper bound; the
-                // document itself is the precise answer, and a read only one held open buys a
-                // second parse and nothing else.
+                // the document itself is the precise answer, and a read only one held open buys
+                // that second parse and nothing else
                 if (document.isEditable && document.isSavable) {
                     this.document = document
                 } else {
@@ -216,7 +185,7 @@ class CoreLoader(context: Context?) : FileLoader(context, LoaderType.CORE) {
             Log.i(TAG, "view name=" + view.name() + " path=" + view.path())
             HostedView(
                 view.name(),
-                "http://$SERVER_URL_HOST:$serverPort/file/$prefix/" + view.path(),
+                "http://$SERVER_URL_HOST:$sharedServerPort/file/$prefix/" + view.path(),
             )
         }
     }
@@ -247,10 +216,8 @@ class CoreLoader(context: Context?) : FileLoader(context, LoaderType.CORE) {
     fun edit(htmlDiff: String, outputPathPrefix: String): File {
         val document = checkNotNull(document) { "no editable document is open" }
 
-        // the file type's own extension, not [Odr.fileTypeToString], which is its *name*: the two
-        // read alike for most formats but are not the same table, and the name is not always
-        // something a file can be called (odrcore 6.1 spells the encrypted ooxml one
-        // "ooxml_encrypted")
+        // the file type's extension, not [Odr.fileTypeToString], which is its name - and a name
+        // like "ooxml_encrypted" is not something a file can be called
         val extension = Odr.fileExtensionByFileType(document.fileType())
         val outputFile = File("$outputPathPrefix.$extension")
 
@@ -263,13 +230,11 @@ class CoreLoader(context: Context?) : FileLoader(context, LoaderType.CORE) {
     }
 
     /**
-     * Drops what this loader published and leaves the server itself running - see
-     * [startSharedServer] for why it is never stopped.
+     * Drops what this loader published and leaves the server itself running - see [sharedServer]
+     * for why it is never stopped.
      */
-    override fun close() {
-        super.close()
-
-        server?.clear()
+    override fun onClose() {
+        sharedServer?.clear()
 
         closeDocument()
     }
@@ -288,24 +253,9 @@ class CoreLoader(context: Context?) : FileLoader(context, LoaderType.CORE) {
         /**
          * The one http server of the process, started on the first [initialize] and never stopped.
          *
-         * Never stopped, though no longer because stopping it was unsafe. Both of the ways odrcore
-         * let a server go used to drop the native server while the thread that called
-         * [HttpServer.listen] was still inside it - `close()` as a use after free that surfaced as
-         * a SIGSEGV in `httplib::Server::listen_internal`, and `stop()` by closing the listening
-         * socket twice, the second time after its fd number had been handed to whatever opened a
-         * file next (which android's fdsan catches by aborting the process, "attempted to close
-         * file descriptor N, actually owned by ZipArchive"). That was
-         * opendocument-app/OpenDocument.core#631, and odrcore 6.1 fixed it: `stop()` now closes the
-         * socket and waits for the accept loop to leave before releasing anything, so nothing is
-         * serving by the time it returns.
-         *
-         * What is left is that there is nobody to stop it *for*. The server is process wide, so no
-         * single loader's teardown is the end of it, and [close] drops what it published with
-         * [HttpServer.clear] and leaves the socket listening. The process exit reclaims it, which
-         * is what was really doing the work all along; nothing here ever outlived its process.
-         *
-         * A second consequence is that the port is bound once rather than once per service
-         * lifetime, so [bind]'s fallback stops being reached by our own teardown.
+         * There is nobody to stop it for: the server is process wide, so no single loader's
+         * teardown is the end of it. [close] drops what it published with [HttpServer.clear] and
+         * leaves the socket listening; the process exit reclaims it.
          */
         private var sharedServer: HttpServer? = null
 
@@ -314,34 +264,20 @@ class CoreLoader(context: Context?) : FileLoader(context, LoaderType.CORE) {
         /**
          * Binds [server], preferring [PREFERRED_SERVER_PORT], and returns the port it got.
          *
-         * The preferred port is occupied more often than it looks. Both flavors hardcode it, so
-         * lite and pro collide whenever they run on one device - the instrumented tests do exactly
-         * that, one flavor after the other - and a port does not come free the moment its owner
-         * goes away: the sockets the webview opened linger in TIME_WAIT for a minute. That second
-         * half is what [HttpServer.Options.reuseAddress] covers, on by default since the core
-         * started setting SO_REUSEADDR rather than cpp-httplib's SO_REUSEPORT; a live server of the
-         * other flavor still holds the port for real, hence the fallback to any free one.
-         *
-         * A failed bind used to be invisible: the old `listen(host, port)` returned void either
-         * way, so an occupied port left the app with no server and nothing to show for it - every
-         * document then failed with ERR_CONNECTION_REFUSED behind chrome's own error page.
-         * [HttpServer.bind] throws instead, and reports back the port that a request has to be
-         * addressed to.
+         * The preferred port is hardcoded in both flavors, so lite and pro collide whenever they
+         * run on one device - the instrumented tests do exactly that. A failed bind used to be
+         * silent, leaving every document at ERR_CONNECTION_REFUSED.
          */
         private fun bind(server: HttpServer, crashManager: CrashManager): Int {
-            // a preference of ANY_PORT is a request for an arbitrary free port, which is what the
-            // fallback below asks for anyway - there is nothing to try first
-            if (PREFERRED_SERVER_PORT != ANY_PORT) {
-                try {
-                    return server.bind(SERVER_BIND_ADDRESS, PREFERRED_SERVER_PORT)
-                } catch (e: Throwable) {
-                    crashManager.log(
-                        IOException(
-                            "core server cannot bind $SERVER_BIND_ADDRESS:$PREFERRED_SERVER_PORT",
-                            e,
-                        )
+            try {
+                return server.bind(SERVER_BIND_ADDRESS, PREFERRED_SERVER_PORT)
+            } catch (e: Throwable) {
+                crashManager.log(
+                    IOException(
+                        "core server cannot bind $SERVER_BIND_ADDRESS:$PREFERRED_SERVER_PORT",
+                        e,
                     )
-                }
+                )
             }
 
             try {
@@ -350,11 +286,9 @@ class CoreLoader(context: Context?) : FileLoader(context, LoaderType.CORE) {
                 crashManager.log(IOException("core server cannot bind any port", e))
             }
 
-            // nothing is bound at this point, so [listen] will fail as well and this port only
-            // decides which url the documents that follow are refused at. It must not be
-            // ANY_PORT, which would address every one of them to :0.
-            return if (PREFERRED_SERVER_PORT != ANY_PORT) PREFERRED_SERVER_PORT
-            else FALLBACK_SERVER_PORT
+            // nothing is bound, so listen() fails too - this port only decides which url the
+            // documents that follow are refused at
+            return PREFERRED_SERVER_PORT
         }
 
         /** Starts [sharedServer] if this is the first loader to ask. */
@@ -399,39 +333,19 @@ class CoreLoader(context: Context?) : FileLoader(context, LoaderType.CORE) {
 
         /**
          * The port the server prefers. Only a preference: it is hardcoded and therefore shared with
-         * the other flavor, so it is not always free. Set it to [ANY_PORT] to always take whatever
-         * is going. See [bind].
+         * the other flavor, so it is not always free. See [bind].
          */
         const val PREFERRED_SERVER_PORT: Int = 29665
 
         /**
-         * The port the urls name when nothing could be bound at all and the preference is
-         * [ANY_PORT], which cannot be passed on - the resulting url would address :0. Only reached
-         * when the device has nothing free, where any choice is as good as the next.
-         */
-        private const val FALLBACK_SERVER_PORT: Int = 29665
-
-        /**
-         * Whether odrcore renders text documents with page margins. This used to be read from the
-         * "use_paging" remote config key, but that resolved to false for every user since firebase
-         * remote config was removed - the ConfigManager left behind is a stub without a backing
-         * store. Kept as an explicit constant so the shipped behavior is visible instead of hidden
-         * behind a lookup that cannot return a value.
+         * Whether odrcore renders text documents with page margins. Was the "use_paging" remote
+         * config key, which resolved to false for every user once that store went away.
          */
         private const val USE_PAGING = false
 
         private var coreInitialized = false
 
-        /**
-         * One-time process wide setup of the core: the temporary directory, and nothing else.
-         *
-         * There used to be data to unpack here - the renderer's css and js, and libmagic's
-         * database - out of `assets/core` and into [Context.getFilesDir], with
-         * `GlobalParams.setOdrCoreDataPath` and `setLibmagicDatabasePath` pointing the core at the
-         * result. odrcore 6.2 ended both: the css and js are written into the html it produces, and
-         * `Odr.mimetype` is core's own detection rather than libmagic. Both setters are inert now,
-         * so the extraction only cost startup time and apk size.
-         */
+        /** One-time process wide setup of the core: the temporary directory, and nothing else. */
         @Synchronized
         fun initializeCore(context: Context) {
             if (coreInitialized) {
@@ -439,27 +353,14 @@ class CoreLoader(context: Context?) : FileLoader(context, LoaderType.CORE) {
             }
 
             // core resolves its temporary directory through std::filesystem::temp_directory_path(),
-            // which falls back to /tmp - a path that does not exist on android. this replaces the
-            // tmpfile() interposition that used to live in src/main/cpp/tmpfile_hack.cpp: that only
-            // worked while the app linked the core into a library it compiled itself, and
-            // libodr_jni.so is a prebuilt now. has to happen before the first native call, because
-            // core caches the directory on first use.
+            // which falls back to /tmp - a path that does not exist on android. has to happen
+            // before the first native call, because core caches the directory on first use
             Os.setenv("TMPDIR", context.cacheDir.absolutePath, true)
 
             Log.i(TAG, "odrcore " + Odr.identify())
 
             coreInitialized = true
         }
-
-        /**
-         * Opens [path].
-         *
-         * This used to pass a [DecodePreference] naming core's own decoder engine, since the
-         * pdf2htmlEX and wvWare ones were compiled out of the android build and asking for them
-         * would only produce "unsupported decoder engine" failures. odrcore 6 dropped those
-         * backends and with them the whole engine dimension, so there is nothing left to choose.
-         */
-        private fun open(path: String): DecodedFile = Odr.open(path)
 
         /**
          * Spreadsheets show one tab per sheet; every other format only shows the full "document"

--- a/app/src/main/java/app/opendocument/droid/background/FileLoader.kt
+++ b/app/src/main/java/app/opendocument/droid/background/FileLoader.kt
@@ -22,9 +22,8 @@ import java.util.LinkedList
 abstract class FileLoader(context: Context?, protected val type: LoaderType) {
 
     /**
-     * Null in the unit tests, which only exercise [isSupported], and dropped again by [close].
-     * Everything on the loading path goes through [context] instead, which fails loudly rather than
-     * NPEing somewhere further down.
+     * Null in the unit tests, which only exercise [isSupported], and dropped again by [close]. The
+     * loading path goes through [context], which fails loudly rather than NPEing further down.
      */
     private var contextOrNull: Context? = context
 
@@ -40,10 +39,6 @@ abstract class FileLoader(context: Context?, protected val type: LoaderType) {
     protected lateinit var crashManager: CrashManager
 
     private var initialized = false
-
-    /** Whether a [loadAsync] is still running. */
-    var isLoading: Boolean = false
-        private set
 
     open fun initialize(
         listener: FileLoaderListener,
@@ -68,13 +63,7 @@ abstract class FileLoader(context: Context?, protected val type: LoaderType) {
             throw RuntimeException("not initialized")
         }
 
-        isLoading = true
-
-        backgroundHandler.post {
-            loadSync(options)
-
-            isLoading = false
-        }
+        backgroundHandler.post { loadSync(options) }
     }
 
     protected abstract fun loadSync(options: Options)
@@ -114,13 +103,18 @@ abstract class FileLoader(context: Context?, protected val type: LoaderType) {
         }
     }
 
-    open fun close() {
+    fun close() {
         backgroundHandler.post {
+            onClose()
+
             initialized = false
             listener = null
             contextOrNull = null
         }
     }
+
+    /** Loader specific teardown, on the background thread so it cannot race a load in flight. */
+    protected open fun onClose() {}
 
     enum class LoaderType {
         CORE,

--- a/app/src/main/java/app/opendocument/droid/background/LoaderService.kt
+++ b/app/src/main/java/app/opendocument/droid/background/LoaderService.kt
@@ -19,11 +19,11 @@ import java.io.File
 
 /**
  * Owns the four loaders and the background thread they run on, and decides what to try next when
- * one of them succeeds or fails: metadata first, then the core, and finally an upload the user has
- * to agree to.
+ * one of them succeeds or fails: metadata first, then raw or the core, and finally an upload the
+ * user has to agree to.
  *
  * [RawLoader] sits outside that chain rather than at the end of it: the core would succeed at a
- * csv, so it has to be asked first. Everything else the core cannot open goes to the upload offer.
+ * csv, so it has to be asked first.
  */
 class LoaderService : Service(), FileLoader.FileLoaderListener {
 
@@ -180,9 +180,8 @@ class LoaderService : Service(), FileLoader.FileLoaderListener {
             )
 
             if (coreLoader.isSupported(options)) {
-                // the core names this format and still said no, so the file is what is wrong.
-                // an upload would only run the same engine again - onUnsupported is below,
-                // for the formats the core never claimed
+                // the core names the format and still said no, so the file is what is wrong -
+                // an upload would only run the same engine again
                 withListener { it.onError(result, error) }
             } else {
                 withListener { it.onUnsupported(result) }
@@ -190,9 +189,8 @@ class LoaderService : Service(), FileLoader.FileLoaderListener {
 
             return
         } else if (result.loaderType == FileLoader.LoaderType.RAW) {
-            // the core has not had its turn yet and is a real fallback for all three. Not gated
-            // on isSupported, which says no to csv by design; if it fails too, the branch above
-            // reports that properly
+            // the core has not had its turn yet. not gated on isSupported, which says no to csv
+            // by design; if it fails too, the branch above reports that properly
             loadWithType(FileLoader.LoaderType.CORE, options)
 
             return
@@ -253,7 +251,9 @@ class LoaderService : Service(), FileLoader.FileLoaderListener {
             backup = backUp(outFile)
 
             try {
-                writeTo(outFile, fileToSave)
+                if (!writeTo(outFile, fileToSave)) {
+                    crashManager.log("saved without truncating: $outFile")
+                }
             } catch (e: Throwable) {
                 backupIsTheLastCopy = !restore(outFile, backup)
 
@@ -276,16 +276,15 @@ class LoaderService : Service(), FileLoader.FileLoaderListener {
             // if the rollback did not get the old content back in, this copy is all that is
             // left of it - leave it in the cache rather than finishing the job
             if (!backupIsTheLastCopy) {
-                backup?.delete()
+                backup?.let { AndroidFileCache.deleteCacheFile(it) }
             }
         }
     }
 
     /** Copies [source] over [uri]. False if the provider would not truncate first. */
     private fun writeTo(uri: Uri, source: File): Boolean {
-        // "wt" and not the default "w": not every provider truncates for "w", which leaves the
-        // tail of a longer previous document sitting behind the new content. for a zip container
-        // like odt or docx that trailing garbage is what makes the file stop opening
+        // "wt", not the default "w": not every provider truncates for "w", and the tail of a
+        // longer previous document left behind is what stops an odt or docx opening
         var truncated = true
 
         val outputStream =
@@ -317,23 +316,22 @@ class LoaderService : Service(), FileLoader.FileLoaderListener {
                 backup
             } else {
                 // a document that was just created has nothing worth keeping
-                backup.delete()
+                AndroidFileCache.deleteCacheFile(backup)
 
                 null
             }
         } catch (e: Throwable) {
             // unreadable target: no worse than before, the save just cannot be rolled back
             crashManager.log(e, uri)
-            backup.delete()
+            AndroidFileCache.deleteCacheFile(backup)
 
             null
         }
     }
 
     /**
-     * Puts [backup] back into [uri]. False if the old content could not be restored - including the
-     * case where it went in without truncating, which leaves the tail of the failed save behind it
-     * and is no more readable than what it replaced.
+     * Puts [backup] back into [uri]. False if the old content could not be restored, including a
+     * write that did not truncate and so left the tail of the failed save behind it.
      */
     private fun restore(uri: Uri, backup: File?): Boolean {
         if (backup == null) {
@@ -365,7 +363,8 @@ class LoaderService : Service(), FileLoader.FileLoaderListener {
         rawLoader.close()
         onlineLoader.close()
 
-        backgroundThread.quit()
+        // quitSafely, not quit: close() posts each loader's teardown, which quit() would drop
+        backgroundThread.quitSafely()
 
         super.onDestroy()
     }

--- a/app/src/main/java/app/opendocument/droid/background/LoaderServiceQueue.kt
+++ b/app/src/main/java/app/opendocument/droid/background/LoaderServiceQueue.kt
@@ -13,8 +13,8 @@ class LoaderServiceQueue {
     private var boundService: LoaderService? = null
 
     /**
-     * The bound service, or null while the connection is still pending. Setting it replays
-     * everything queued up so far; the queue is deliberately kept, matching the previous behaviour.
+     * The bound service, or null while the connection is pending or after it dropped. Setting it
+     * replays what queued up in the meantime.
      */
     var service: LoaderService?
         @Synchronized get() = boundService
@@ -26,7 +26,12 @@ class LoaderServiceQueue {
                 return
             }
 
-            for (entry in queue) {
+            // drained, not kept: a reconnect would otherwise replay every load this activity has
+            // ever queued, reopening documents the user has moved on from
+            val pending = queue.toList()
+            queue.clear()
+
+            for (entry in pending) {
                 entry.onService(value)
             }
         }
@@ -42,7 +47,6 @@ class LoaderServiceQueue {
         queue.add(entry)
     }
 
-    /** fun interface, so the callers can queue a lambda instead of an anonymous object. */
     fun interface QueueEntry {
         fun onService(service: LoaderService)
     }

--- a/app/src/main/java/app/opendocument/droid/background/MetadataLoader.kt
+++ b/app/src/main/java/app/opendocument/droid/background/MetadataLoader.kt
@@ -28,7 +28,6 @@ class MetadataLoader(context: Context?) : FileLoader(context, LoaderType.METADAT
         try {
             var uri = checkNotNull(options.originalUri) { "nothing to load" }
 
-            // cleanup uri
             val uriString = uri.toString()
             if (uriString.startsWith("/./")) {
                 uri = Uri.parse(uriString.substring(2))
@@ -36,22 +35,17 @@ class MetadataLoader(context: Context?) : FileLoader(context, LoaderType.METADAT
 
             AndroidFileCache.cleanup(context)
 
-            // detecting the filename early so we can use it in the catch-block if something goes
-            // wrong
             var filename: String? = null
             try {
                 // https://stackoverflow.com/a/38304115/198996
-                val fileCursor = context.contentResolver.query(uri, null, null, null, null)
-                if (fileCursor != null && fileCursor.moveToFirst()) {
-                    val nameIndex = fileCursor.getColumnIndexOrThrow(OpenableColumns.DISPLAY_NAME)
-                    filename = fileCursor.getString(nameIndex)
-                    fileCursor.close()
+                context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+                    if (cursor.moveToFirst()) {
+                        val nameIndex = cursor.getColumnIndexOrThrow(OpenableColumns.DISPLAY_NAME)
+                        filename = cursor.getString(nameIndex)
+                    }
                 }
             } catch (e: Exception) {
-                // "URI does not contain a valid access token." or
-                // "Couldn't read row 0, col -1 from CursorWindow. Make sure the Cursor is
-                // initialized correctly before accessing data from it."
-
+                // providers throw here for a missing access token or a missing DISPLAY_NAME column
                 crashManager.log(e)
             }
 
@@ -112,9 +106,7 @@ class MetadataLoader(context: Context?) : FileLoader(context, LoaderType.METADAT
                 }
             }
 
-            // whatever spelling this came out as, go on with the core's own from here: a provider
-            // is free to volunteer application/x-zip-compressed or application/csv, and the app
-            // claims those now, but the loaders behind us go by one mime type per format
+            // one spelling per format from here on: a provider may volunteer application/csv
             mimetype = SupportedDocumentTypes.canonicalMimeType(mimetype)
 
             val resolution = MimeTypeResolver.resolve(mimetype, extension, MIME_TYPE_LOOKUP)
@@ -135,8 +127,7 @@ class MetadataLoader(context: Context?) : FileLoader(context, LoaderType.METADAT
                 try {
                     val evicted = RecentDocumentsUtil.addRecentDocument(context, filename, uri)
                     if (evicted.isNotEmpty()) {
-                        // hand the uri permissions of the documents that just fell off the end
-                        // of the list back, so we stay well below the per package grant limit
+                        // stay well below the per package grant limit
                         PersistedUriPermissions.prune(context)
                     }
                 } catch (e: IOException) {

--- a/app/src/main/java/app/opendocument/droid/background/OnlineLoader.kt
+++ b/app/src/main/java/app/opendocument/droid/background/OnlineLoader.kt
@@ -18,21 +18,8 @@ class OnlineLoader(context: Context?) : FileLoader(context, LoaderType.ONLINE) {
     override fun isSupported(options: Options): Boolean {
         val fileType = options.fileType ?: return false
 
-        for (mime in MIME_WHITELIST) {
-            if (!fileType.startsWith(mime)) {
-                continue
-            }
-
-            for (blackMime in MIME_BLACKLIST) {
-                if (fileType.startsWith(blackMime)) {
-                    return false
-                }
-            }
-
-            return true
-        }
-
-        return false
+        return MIME_WHITELIST.any { fileType.startsWith(it) } &&
+            MIME_BLACKLIST.none { fileType.startsWith(it) }
     }
 
     override fun loadSync(options: Options) {
@@ -52,12 +39,11 @@ class OnlineLoader(context: Context?) : FileLoader(context, LoaderType.ONLINE) {
     }
 
     /**
-     * Whether use.opendocument.app can convert this type itself. Everything else is uploaded and
-     * handed to a third party viewer instead.
+     * Whether use.opendocument.app converts this itself; everything else is uploaded and handed to
+     * a third party viewer.
      *
      * The last term asks whether the core *files* this as a document, not whether it renders one:
-     * the converter runs libreoffice, so an `.xlsb` is worth sending it. It used to ask
-     * [CoreLoader.isSupported], which stopped meaning that when the core loader took on media.
+     * the converter runs libreoffice, so an `.xlsb` is worth sending it.
      */
     fun isConvertible(options: Options): Boolean {
         val fileType = options.fileType
@@ -88,30 +74,36 @@ class OnlineLoader(context: Context?) : FileLoader(context, LoaderType.ONLINE) {
         connection.setRequestProperty("Content-Type", "multipart/form-data; boundary=$boundary")
         connection.instanceFollowRedirects = false
 
-        connection.outputStream.use { output ->
-            PrintWriter(OutputStreamWriter(output, StreamUtil.ENCODING), true).use { writer ->
-                writer.append("--$boundary").append(crlf)
-                writer.append(disposition).append(crlf)
-                writer.append(crlf).flush()
-                StreamUtil.copy(binaryFile, output)
-                output.flush()
-                writer.append(crlf).flush()
+        try {
+            connection.outputStream.use { output ->
+                PrintWriter(OutputStreamWriter(output, StreamUtil.ENCODING), true).use { writer ->
+                    writer.append("--$boundary").append(crlf)
+                    writer.append(disposition).append(crlf)
+                    writer.append(crlf).flush()
+                    StreamUtil.copy(binaryFile, output)
+                    output.flush()
+                    writer.append(crlf).flush()
 
-                writer.append("--$boundary--").append(crlf).flush()
+                    writer.append("--$boundary--").append(crlf).flush()
+                }
             }
-        }
 
-        // a converted document is answered with a redirect to it, so a response without a Location
-        // is the server refusing the file - concatenating the missing header would build a
-        // "...appnull" url that only fails later, inside the webview
-        val responseCode = connection.responseCode
-        val redirectUrl = connection.getHeaderField("Location")
-        if (redirectUrl.isNullOrEmpty()) {
-            val error = readError(connection)
-            throw IOException("server couldn't handle request: $responseCode $error")
-        }
+            // a converted document is answered with a redirect to it, so a response without a
+            // Location is the server refusing the file - concatenating the missing header would
+            // build a "...appnull" url that only fails later, inside the webview
+            val responseCode = connection.responseCode
+            val redirectUrl = connection.getHeaderField("Location")
+            if (redirectUrl.isNullOrEmpty()) {
+                val error = readError(connection)
+                throw IOException("server couldn't handle request: $responseCode $error")
+            }
 
-        return Uri.parse(basePath + redirectUrl)
+            return Uri.parse(basePath + redirectUrl)
+        } finally {
+            // the success path never reads the body, so the socket would sit in the keep-alive
+            // pool with an unconsumed response until it timed out
+            connection.disconnect()
+        }
     }
 
     private fun doTransferUpload(options: Options): Uri {
@@ -145,9 +137,7 @@ class OnlineLoader(context: Context?) : FileLoader(context, LoaderType.ONLINE) {
     }
 
     private fun buildViewerUri(options: Options, downloadUrl: String): Uri {
-        // ODF does not seem to be supported by google docs viewer, but pdf is the one thing the
-        // microsoft viewer will not take - and the core opens both, so what it supports no longer
-        // tells the two apart on its own
+        // google's viewer will not take odf, microsoft's will not take pdf
         val isPdf = options.fileType?.startsWith("application/pdf") == true
 
         // the office viewer wants an office document; an image or an mp3 is google's problem
@@ -183,6 +173,9 @@ class OnlineLoader(context: Context?) : FileLoader(context, LoaderType.ONLINE) {
 
         // https://help.joomlatools.com/article/169-google-viewer
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types
+        //
+        // matched as prefixes, so the four families at the top already cover every "text/..." and
+        // "image/..." spelling of the formats below them
         private val MIME_WHITELIST =
             arrayOf(
                 "text/",
@@ -192,26 +185,16 @@ class OnlineLoader(context: Context?) : FileLoader(context, LoaderType.ONLINE) {
                 // markup
                 "application/json",
                 "application/xml",
-                "text/css",
                 "application/css-stylesheet",
                 "application/xhtml",
                 "application/x-httpd-php",
-                "text/php",
                 "application/php",
                 "application/x-php",
                 "application/x-javascript",
-                "text/javascript",
-                "text/x-java-source",
-                "text/java",
-                "text/x-java",
                 "application/ms-java",
                 // rtf
                 "application/rtf",
-                "text/rtf",
                 // psd: https://filext.com/file-extension/PSD
-                "image/photoshop",
-                "image/x-photoshop",
-                "image/psd",
                 "application/photoshop",
                 "application/psd",
                 "zz-application/zz-winassoc-psd",
@@ -220,8 +203,6 @@ class OnlineLoader(context: Context?) : FileLoader(context, LoaderType.ONLINE) {
                 "application/x-pdf",
                 "application/acrobat",
                 "applications/vnd.pdf",
-                "text/pdf",
-                "text/x-pdf",
                 // odf: https://filext.com/file-extension/ODT
                 "application/vnd.oasis.opendocument",
                 "application/x-vnd.oasis.opendocument",
@@ -242,7 +223,6 @@ class OnlineLoader(context: Context?) : FileLoader(context, LoaderType.ONLINE) {
                 "application/msexcel",
                 "application/x-msexcel",
                 "application/x-ms-excel",
-                "application/vnd.ms-excel",
                 "application/x-excel",
                 "application/x-dos_ms_excel",
                 "application/xls",
@@ -261,23 +241,16 @@ class OnlineLoader(context: Context?) : FileLoader(context, LoaderType.ONLINE) {
                 "application/postscript",
                 "application/eps",
                 "application/x-eps",
-                "image/eps",
-                "image/x-eps",
                 // autocad: https://filext.com/file-extension/DXF
                 "application/dxf",
                 "application/x-autocad",
                 "application/x-dxf",
                 "drawing/x-dxf",
-                "image/vnd.dxf",
-                "image/x-autocad",
-                "image/x-dxf",
                 "zz-application/zz-winassoc-dxf",
                 // zip: https://filext.com/file-extension/ZIP
                 "application/zip",
                 "application/x-zip",
-                "application/x-zip-compressed",
                 "application/x-compress",
-                "application/x-compressed",
                 "multipart/x-zip",
                 // WPD
                 "application/vnd.wordperfect",

--- a/app/src/main/java/app/opendocument/droid/background/PersistedUriPermissions.kt
+++ b/app/src/main/java/app/opendocument/droid/background/PersistedUriPermissions.kt
@@ -19,14 +19,10 @@ object PersistedUriPermissions {
     /**
      * The grants taken during this process that the recent list does not name yet.
      *
-     * Taking a grant and writing down what needs it are not one step: a document only reaches the
-     * list once [MetadataLoader] has read it, which is long after [takeRead] ran - `loadUri` merely
-     * queues the load. A [prune] in that window would enumerate the fresh grant, find nothing
-     * referring to it and hand it straight back, leaving the entry that is about to be written
-     * unreadable on the next launch - the very failure releasing on close used to cause.
-     *
-     * Empty on a fresh process, so a grant whose document never made it onto the list is reclaimed
-     * on the next launch rather than leaking for good.
+     * A document only reaches the list once [MetadataLoader] has read it, long after [takeRead]
+     * ran; a [prune] in that window would find nothing referring to the fresh grant and hand it
+     * straight back. Empty on a fresh process, so a grant whose document never made the list is
+     * reclaimed on the next launch rather than leaking for good.
      */
     private val pendingGrants = HashSet<String>()
 
@@ -37,10 +33,9 @@ object PersistedUriPermissions {
      *   persistable permissions at all, and for uris that did not arrive on an intent of ours.
      */
     fun takeRead(context: Context, uri: Uri): Boolean {
-        // marked before the grant exists rather than after, so there is no instant in which a
-        // concurrent prune could enumerate it while nothing speaks for it. a uri that turns out not
-        // to be persistable is left in the set: we are reading it either way, and if an earlier
-        // session did persist it, that grant is exactly the one to hold on to
+        // marked before the grant exists, so a concurrent prune never sees it unspoken for. one
+        // that turns out not to be persistable stays in the set: an earlier session may have
+        // persisted it, and that grant is exactly the one to hold on to
         markPending(uri.toString())
 
         return try {
@@ -76,16 +71,13 @@ object PersistedUriPermissions {
     /**
      * Releases every persisted grant nothing refers to any more.
      *
-     * Reconciling against the stored lists rather than releasing on eviction keeps this idempotent:
-     * a grant that is covered twice is not released twice, and grants leaked by earlier versions
-     * get mopped up on the next launch.
-     *
-     * Does file and binder work, so it must not run on the main thread.
+     * Reconciling against the stored lists rather than releasing on eviction keeps this idempotent,
+     * so grants leaked by earlier versions get mopped up too. Does file and binder work, so it must
+     * not run on the main thread.
      */
     fun prune(context: Context) {
-        // the three reads are in this order on purpose. a grant taken while this runs is either
-        // missing from the snapshot, or still pending when the pending set is read - which happens
-        // after the list that would have settled it, so it cannot fall through both
+        // this order on purpose: a grant taken while this runs is either missing from the snapshot
+        // or still pending when the pending set is read, so it cannot fall through both
         val held = context.contentResolver.persistedUriPermissions
 
         val keep = HashSet<String>()

--- a/app/src/main/java/app/opendocument/droid/background/PrintingManager.kt
+++ b/app/src/main/java/app/opendocument/droid/background/PrintingManager.kt
@@ -20,16 +20,25 @@ class PrintingManager {
 
     private val backgroundHandler = Handler(backgroundThread.looper)
 
+    /**
+     * [onFinished] runs on the main thread once the job is over, whether it printed or not. The
+     * adapter is laid out and written by the print framework long after this returns, so anything
+     * the WebView had to be put into for printing can only be undone from there.
+     */
     @Suppress("DEPRECATION")
-    fun print(activity: MainActivity, webView: WebView) {
-        print(activity, webView.createPrintDocumentAdapter())
+    fun print(activity: MainActivity, webView: WebView, onFinished: () -> Unit) {
+        print(activity, webView.createPrintDocumentAdapter(), onFinished)
     }
 
     fun print(activity: MainActivity, pdfFile: File) {
-        print(activity, PdfDocumentAdapter(activity, JOB_NAME, pdfFile))
+        print(activity, PdfDocumentAdapter(activity, JOB_NAME, pdfFile)) {}
     }
 
-    private fun print(activity: MainActivity, printAdapter: PrintDocumentAdapter) {
+    private fun print(
+        activity: MainActivity,
+        printAdapter: PrintDocumentAdapter,
+        onFinished: () -> Unit,
+    ) {
         val printManager = activity.getSystemService(Context.PRINT_SERVICE) as PrintManager
 
         val printJob = printManager.print(JOB_NAME, printAdapter, PrintAttributes.Builder().build())
@@ -37,11 +46,22 @@ class PrintingManager {
         val checkPrintJob =
             object : Runnable {
                 override fun run() {
-                    if (!printJob.isCompleted && !activity.isFinishing && !activity.isDestroyed) {
-                        SnackbarHelper.show(activity, R.string.crouton_printing, null, false, false)
-
-                        backgroundHandler.postDelayed(this, 1000)
+                    // nothing left to restore, and the webview it would touch may be gone
+                    if (activity.isFinishing || activity.isDestroyed) {
+                        return
                     }
+
+                    // cancelled and failed are ends too - waiting only for isCompleted polls
+                    // forever on the job the user dismissed
+                    if (printJob.isCompleted || printJob.isCancelled || printJob.isFailed) {
+                        activity.runOnUiThread(onFinished)
+
+                        return
+                    }
+
+                    SnackbarHelper.show(activity, R.string.crouton_printing, null, false, false)
+
+                    backgroundHandler.postDelayed(this, 1000)
                 }
             }
 

--- a/app/src/main/java/app/opendocument/droid/background/RawLoader.kt
+++ b/app/src/main/java/app/opendocument/droid/background/RawLoader.kt
@@ -7,14 +7,10 @@ import android.util.Base64OutputStream
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
-import java.io.OutputStream
 
 /**
- * The three files odrcore does not render for us: csv, whose table viewer beats the core's line by
- * line text; svg and xml, which the core has no file type for.
- *
- * It used to cover text, images, audio, video and zip too, each with a viewer out of `assets/`.
- * odrcore 6.2 renders all of those, so [CoreLoader] took them over.
+ * The three files [CoreLoader] does not get: csv, whose table viewer beats the core's line by line
+ * text, plus svg and xml, which the core has no file type for.
  *
  * [SupportedDocumentTypes.isRenderedByRaw] decides, and [LoaderService] asks it before the core.
  */
@@ -60,7 +56,11 @@ class RawLoader(context: Context?) : FileLoader(context, LoaderType.RAW) {
                 FileOutputStream(htmlFile).use { outputStream ->
                     StreamUtil.copy(context.assets.open("text-prefix.html"), outputStream)
 
-                    writeBase64(cacheFile, cacheDirectory, outputStream)
+                    // NO_CLOSE: closing the encoder has to write its trailing characters
+                    // without closing the html file underneath it
+                    Base64OutputStream(outputStream, Base64.NO_WRAP or Base64.NO_CLOSE).use {
+                        StreamUtil.copy(FileInputStream(cacheFile), it)
+                    }
 
                     StreamUtil.copy(context.assets.open("text-suffix.html"), outputStream)
                 }
@@ -74,8 +74,9 @@ class RawLoader(context: Context?) : FileLoader(context, LoaderType.RAW) {
                         .appendQueryParameter("ext", extension)
                         .build()
             } else {
-                // xml and whatever else got here: handed to the WebView under its own name
-                val renamedFile = File(cacheDirectory, "temp.$fileExtension")
+                // xml, the only case left: the WebView goes by the name, and a shared file
+                // typed application/xml need not have an extension of its own
+                val renamedFile = File(cacheDirectory, "temp.${fileExtension ?: "xml"}")
                 StreamUtil.copy(cacheFile, renamedFile)
 
                 finalUri = Uri.fromFile(renamedFile)
@@ -95,14 +96,4 @@ class RawLoader(context: Context?) : FileLoader(context, LoaderType.RAW) {
      */
     private fun nameExtension(options: Options): String? =
         MimeTypeResolver.parseExtension(options.filename)
-
-    private fun writeBase64(cacheFile: File, cacheDirectory: File, outputStream: OutputStream) {
-        // need to store it in a separate file first because BaseStream writes characters on close
-        val baseFile = File(cacheDirectory, "tmp")
-        Base64OutputStream(FileOutputStream(baseFile), Base64.NO_WRAP).use { baseOutputStream ->
-            StreamUtil.copy(FileInputStream(cacheFile), baseOutputStream)
-        }
-
-        StreamUtil.copy(FileInputStream(baseFile), outputStream)
-    }
 }

--- a/app/src/main/java/app/opendocument/droid/background/RecentDocumentList.kt
+++ b/app/src/main/java/app/opendocument/droid/background/RecentDocumentList.kt
@@ -14,19 +14,7 @@ object RecentDocumentList {
      */
     const val MAX_ENTRIES: Int = 32
 
-    class Entry(val filename: String, val uri: String, val lastOpenedAt: Long) {
-
-        override fun equals(other: Any?): Boolean =
-            other is Entry &&
-                other.filename == filename &&
-                other.uri == uri &&
-                other.lastOpenedAt == lastOpenedAt
-
-        override fun hashCode(): Int =
-            filename.hashCode() * 31 * 31 + uri.hashCode() * 31 + lastOpenedAt.hashCode()
-
-        override fun toString(): String = "Entry($filename, $uri, $lastOpenedAt)"
-    }
+    data class Entry(val filename: String, val uri: String, val lastOpenedAt: Long)
 
     /**
      * The list after an [add], plus whatever fell off the end of it. The evicted entries are handed

--- a/app/src/main/java/app/opendocument/droid/background/RecentDocumentsUtil.kt
+++ b/app/src/main/java/app/opendocument/droid/background/RecentDocumentsUtil.kt
@@ -104,8 +104,7 @@ object RecentDocumentsUtil {
             )
         }
 
-        // the file stays in the append order older versions wrote it in, so that upgrading does
-        // not need a migration - the list is only turned around here, on the way out
+        // kept in the append order older versions wrote, so upgrading needs no migration
         entries.reverse()
 
         return entries

--- a/app/src/main/java/app/opendocument/droid/background/SupportedDocumentTypes.kt
+++ b/app/src/main/java/app/opendocument/droid/background/SupportedDocumentTypes.kt
@@ -5,34 +5,24 @@ import app.opendocument.core.FileType
 import app.opendocument.core.Odr
 
 /**
- * What the app claims to open and which loader gets it, read out of odrcore instead of kept here.
+ * What the app claims to open and which loader gets it, derived from odrcore's format table rather
+ * than kept here - so the app cannot claim a format the core does not have, or miss one it does.
  *
- * This used to be three hand written lists - mime prefixes for the core, mime prefixes for
- * [RawLoader] and an extension fallback - because odrcore only knew one canonical mime type and one
- * extension per format, and none of the spellings a content provider actually hands out. odrcore
- * 6.1 publishes its whole format table instead ([Odr.allFileTypes], [Odr.mimetypesByFileType],
- * [Odr.fileExtensionsByFileType] and [Odr.capabilitiesByFileType]), so the lists are derived now
- * and the app cannot claim a format the core does not have, or miss one it does.
+ * Two separate questions: what the app offers itself for ([CLAIMED_FILE_TYPES], mirrored by the
+ * STRICT_CATCH `activity-alias`) and what [CoreLoader] renders once it has a file
+ * ([CORE_FILE_TYPES]). The second is wider on purpose - the app does not offer for an mp3, but it
+ * plays one handed to it. `SupportedFormatsTest` holds the manifest, which cannot read any of this,
+ * against the first.
  *
- * Two questions live here, and they are not the same one: what the app offers itself for
- * ([CLAIMED_FILE_TYPES], mirrored by the STRICT_CATCH `activity-alias`) and what [CoreLoader]
- * renders once it has a file ([CORE_FILE_TYPES]). The second is wider on purpose - the app does not
- * offer for an mp3, but it plays one handed to it.
- *
- * The other declaration left is that manifest alias, which is XML and cannot read any of this.
- * `SupportedFormatsTest` walks the core's table and asks the package manager whether the manifest
- * still agrees, so the two cannot drift silently.
- *
- * These are still a guess, not the real answer: a folder listing only has a name and whatever mime
- * type the provider volunteered, and it has to go on appearances. What the core *decides* is
- * everything after the file is in the cache - [MetadataLoader] runs its libmagic over the copy, and
- * [CoreLoader.isDocumentEditable] asks the opened document itself.
+ * All of it is a guess from a name and whatever mime type a provider volunteered. What decides once
+ * the file is in the cache is [MetadataLoader], which asks `Odr.mimetype` about the copy, and
+ * [CoreLoader.isDocumentEditable], which asks the opened document.
  */
 object SupportedDocumentTypes {
 
     /**
-     * What [CoreLoader] renders: everything odrcore can turn into html, minus [RAW_FILE_TYPES].
-     * Since 6.2 that is far more than documents - images, archives, fonts and media included.
+     * What [CoreLoader] renders: everything odrcore turns into html, minus [RAW_FILE_TYPES]. Far
+     * more than documents - images, archives, fonts and media included.
      */
     private val CORE_FILE_TYPES: List<FileType> by lazy {
         Odr.allFileTypes().filter {
@@ -41,8 +31,8 @@ object SupportedDocumentTypes {
     }
 
     /**
-     * What [RawLoader] keeps although the core would take it too: only csv, which odrcore renders
-     * line by line where `text-prefix.html` builds a table. An app decision, so not derived.
+     * Kept for [RawLoader] although the core would take it too: csv, whose table beats the core's
+     * line by line text. An app decision, so not derived.
      */
     private val RAW_FILE_TYPES = listOf(FileType.COMMA_SEPARATED_VALUES)
 
@@ -64,10 +54,10 @@ object SupportedDocumentTypes {
     }
 
     /**
-     * Images, as a prefix rather than a set of file types: odrcore names all of them since 6.2
-     * except svg, which the wildcard is what claims. The manifest declares `image` likewise.
+     * Images, as a prefix rather than a set of file types: odrcore names all of them except svg,
+     * which the wildcard is what claims. The manifest declares `image` likewise.
      */
-    private val RAW_MIME_PREFIXES = listOf("image/")
+    private val CLAIMED_MIME_PREFIXES = listOf("image/")
 
     /** Every spelling of [RAW_FILE_TYPES], for [isCsv]. */
     private val RAW_MIME_TYPES: Set<String> by lazy { mimeTypesOf(RAW_FILE_TYPES) }
@@ -76,16 +66,15 @@ object SupportedDocumentTypes {
     private val XML_MIME_TYPES = setOf("application/xml", "text/xml")
 
     /** Every mime type spelling odrcore accepts for a format [CoreLoader] renders. */
-    val CORE_MIME_TYPES: Set<String> by lazy { mimeTypesOf(CORE_FILE_TYPES) }
+    private val CORE_MIME_TYPES: Set<String> by lazy { mimeTypesOf(CORE_FILE_TYPES) }
 
     /** The same for everything the app offers itself for. */
     val MIME_TYPES: Set<String> by lazy { mimeTypesOf(CLAIMED_FILE_TYPES) }
 
     /**
-     * The extensions to fall back on, because providers regularly volunteer nothing better than
-     * `application/octet-stream` - and because a file manager that sends `ACTION_VIEW` with no mime
-     * type at all leaves the name as the only thing anyone can go on. That second case is what the
-     * `pathPattern` filters in AndroidManifest.xml cover, and they have to list exactly this set.
+     * The extension fallback, for the `application/octet-stream` providers regularly volunteer and
+     * for an `ACTION_VIEW` with no mime type at all. The `pathPattern` filters in
+     * AndroidManifest.xml cover that second case and have to list exactly this set.
      */
     val EXTENSIONS: Set<String> by lazy {
         CLAIMED_FILE_TYPES.flatMap { Odr.fileExtensionsByFileType(it) }
@@ -94,14 +83,9 @@ object SupportedDocumentTypes {
     }
 
     /**
-     * The spelling of [mimeType] the rest of the app goes by: odrcore's canonical one whenever the
-     * core recognizes what a provider handed us, and the original otherwise.
-     *
-     * Reading the core's table means the app claims every spelling in it - `application/csv`,
-     * `application/x-zip-compressed`, `multipart/x-zip` - and not just the one it names first.
-     * Collapsing them here keeps one spelling per format flowing downstream.
-     *
-     * Anything the core does not name - svg, xml - passes through untouched.
+     * odrcore's canonical spelling of [mimeType], so one spelling per format flows downstream - the
+     * app claims every spelling in the core's table, `application/csv` and `multipart/x-zip`
+     * included. Anything the core does not name - svg, xml - passes through untouched.
      */
     fun canonicalMimeType(mimeType: String?): String? {
         if (mimeType == null) {
@@ -121,12 +105,11 @@ object SupportedDocumentTypes {
         mimeType != null && mimeType.lowercase() in CORE_MIME_TYPES
 
     /**
-     * Whether [RawLoader] takes this instead. Asked *before* [isRenderedByCore], because the core
-     * would render a csv itself and RawLoader would never get its turn.
+     * Whether [RawLoader] takes this instead. Asked *before* [isRenderedByCore], or the core would
+     * render a csv itself and RawLoader would never get its turn.
      *
-     * [extension] is needed because [MetadataLoader] identifies by content first, and an svg or an
-     * xml *is* text - `Odr.mimetype` says `text/plain` and the provider's `image/svg+xml` never
-     * arrives. The name only gets a say where the detection has none - see [nameSays].
+     * [extension] because an svg or an xml *is* text to the detection: `Odr.mimetype` says
+     * `text/plain` and the provider's `image/svg+xml` never arrives. See [nameSays].
      */
     fun isRenderedByRaw(mimeType: String?, extension: String? = null): Boolean =
         isCsv(mimeType, extension) || isSvg(mimeType, extension) || isXml(mimeType, extension)
@@ -146,7 +129,7 @@ object SupportedDocumentTypes {
     /**
      * Whether the file is called `.expected` *and* the detection left room for the name to know
      * better - plain text, or nothing recognized. The bytes win otherwise: a `report.csv` holding
-     * an odt would go to the table viewer, succeed, and leave no fallback.
+     * an odt is an odt.
      */
     private fun nameSays(mimeType: String?, extension: String?, expected: String): Boolean {
         if (extension?.lowercase() != expected) {
@@ -160,8 +143,7 @@ object SupportedDocumentTypes {
 
     /**
      * Whether the core files this as a document rather than text, an image, an archive, a font or
-     * media. What [OnlineLoader] and [DocumentFragment] used to get from [CoreLoader.isSupported],
-     * back when the core loader only claimed documents.
+     * media.
      */
     fun isDocument(mimeType: String?): Boolean {
         if (mimeType == null) {
@@ -189,7 +171,7 @@ object SupportedDocumentTypes {
 
         val normalized = mimeType.lowercase()
 
-        return normalized in MIME_TYPES || RAW_MIME_PREFIXES.any { normalized.startsWith(it) }
+        return normalized in MIME_TYPES || CLAIMED_MIME_PREFIXES.any { normalized.startsWith(it) }
     }
 
     private fun mimeTypesOf(fileTypes: List<FileType>): Set<String> =

--- a/app/src/main/java/app/opendocument/droid/nonfree/AdManager.kt
+++ b/app/src/main/java/app/opendocument/droid/nonfree/AdManager.kt
@@ -19,22 +19,18 @@ class AdManager {
 
     private lateinit var activity: Activity
     private lateinit var crashManager: CrashManager
-    private lateinit var analyticsManager: AnalyticsManager
     private lateinit var adContainer: LinearLayout
     private var adView: AdView? = null
 
-    fun initialize(
-        activity: Activity,
-        analyticsManager: AnalyticsManager,
-        crashManager: CrashManager,
-    ) {
+    fun initialize(activity: Activity, crashManager: CrashManager) {
+        // before the guard: removeAds() and destroyAds() reach these even with ads disabled,
+        // which billing does whenever the user has already paid
+        this.activity = activity
+        this.crashManager = crashManager
+
         if (!enabled) {
             return
         }
-
-        this.activity = activity
-        this.crashManager = crashManager
-        this.analyticsManager = analyticsManager
 
         try {
             MobileAds.initialize(activity)
@@ -63,6 +59,9 @@ class AdManager {
             return
         }
 
+        // a configuration change builds a fresh banner, and only the field's current occupant
+        // is ever destroyed - so the one being replaced has to go now
+        this.adView?.destroy()
         this.adView = adView
 
         adContainer.removeAllViews()
@@ -82,7 +81,7 @@ class AdManager {
     }
 
     fun showGoogleAds() {
-        if (!enabled) {
+        if (!enabled || isActivityGone()) {
             return
         }
 
@@ -93,12 +92,20 @@ class AdManager {
             activity,
             params,
             {
+                // both callbacks come back off the network, seconds later and with the
+                // activity captured, so the one they were meant for may be gone by then
+                if (isActivityGone()) {
+                    return@requestConsentInfoUpdate
+                }
+
                 UserMessagingPlatform.loadAndShowConsentFormIfRequired(activity) { loadAndShowError
                     ->
+                    if (isActivityGone()) {
+                        return@loadAndShowConsentFormIfRequired
+                    }
+
                     if (loadAndShowError != null || !consentInformation.canRequestAds()) {
-                        // without this the banner just silently stays hidden,
-                        // and the ump sdk only logs an unspecific "Error
-                        // making request."
+                        // the ump sdk only logs an unspecific "Error making request."
                         crashManager.log(
                             "consent form failed: " +
                                 describe(loadAndShowError) +
@@ -115,14 +122,20 @@ class AdManager {
                 }
             },
             { requestConsentError ->
-                // fires for the mundane offline case too - a device that was asleep
-                // times out against fundingchoicesmessages.google.com
+                if (isActivityGone()) {
+                    return@requestConsentInfoUpdate
+                }
+
+                // fires for the mundane offline case too, not just a real failure
                 crashManager.log("consent info update failed: " + describe(requestConsentError))
 
                 hideGoogleAds()
             },
         )
     }
+
+    private fun isActivityGone(): Boolean =
+        !::activity.isInitialized || activity.isFinishing || activity.isDestroyed
 
     // https://developers.google.com/admob/android/banner/adaptive
     // the anchored adaptive size is deprecated in favour of the inline one, which sizes the
@@ -153,15 +166,13 @@ class AdManager {
 
     fun destroyAds() {
         try {
-            // keeps throwing exceptions for some users:
-            // Caused by: java.lang.NullPointerException
-            // android.webkit.WebViewClassic.requestFocus(WebViewClassic.java:9898)
-            // android.webkit.WebView.requestFocus(WebView.java:2133)
-            // android.view.ViewGroup.onRequestFocusInDescendants(ViewGroup.java:2384)
+            // has thrown out of the ad sdk's own focus handling for some users
             adView?.destroy()
         } catch (e: Exception) {
             crashManager.log(e)
         }
+
+        adView = null
     }
 
     private companion object {

--- a/app/src/main/java/app/opendocument/droid/nonfree/AnalyticsManager.kt
+++ b/app/src/main/java/app/opendocument/droid/nonfree/AnalyticsManager.kt
@@ -12,9 +12,7 @@ class AnalyticsManager {
 
     private var enabled = false
 
-    fun initialize(context: Context) {
-        // nothing to set up while reporting is local only
-    }
+    fun initialize(context: Context) {}
 
     fun setEnabled(enabled: Boolean) {
         this.enabled = enabled
@@ -31,9 +29,7 @@ class AnalyticsManager {
             return
         }
 
-        // keys only: callers pass document uris as values, and those have no business in
-        // logcat. an analytics backend wired in here would get the values, a device log
-        // does not
+        // keys only: callers pass document uris as values, which have no business in logcat
         Log.i(
             TAG,
             buildString {

--- a/app/src/main/java/app/opendocument/droid/nonfree/BillingManager.kt
+++ b/app/src/main/java/app/opendocument/droid/nonfree/BillingManager.kt
@@ -11,7 +11,7 @@ class BillingManager {
     private var adManager: AdManager? = null
     private var billingPreferences: BillingPreferences? = null
 
-    fun initialize(context: Context, analyticsManager: AnalyticsManager, adManager: AdManager) {
+    fun initialize(context: Context, adManager: AdManager) {
         this.adManager = adManager
 
         val preferences = BillingPreferences(context)
@@ -44,6 +44,4 @@ class BillingManager {
     fun setEnabled(enabled: Boolean) {
         this.enabled = enabled
     }
-
-    fun isEnabled(): Boolean = enabled
 }

--- a/app/src/main/java/app/opendocument/droid/nonfree/InAppReview.kt
+++ b/app/src/main/java/app/opendocument/droid/nonfree/InAppReview.kt
@@ -4,18 +4,13 @@ import android.app.Activity
 import com.google.android.play.core.review.ReviewManagerFactory
 
 /**
- * The play in-app review sheet.
- *
- * Play decides from an undocumented per-user quota whether the sheet appears at all, and the
- * completion listener fires the same way either way. The analytics events below are the only
- * visibility there is.
+ * The play in-app review sheet. Whether it appears at all is Play's own per-user quota, and the
+ * completion listener fires either way - the analytics events are the only visibility there is.
  */
 object InAppReview {
 
-    /**
-     * Opens before the first ask - a fresh install has nothing to say yet, and asking costs stars.
-     */
-    const val MINIMUM_OPENS: Int = 3
+    /** Opens before the first ask: a fresh install has nothing to say, and asking costs stars. */
+    private const val MINIMUM_OPENS: Int = 3
 
     fun requestIfEarned(activity: Activity, analyticsManager: AnalyticsManager, opens: Int) {
         if (opens < MINIMUM_OPENS) {
@@ -25,7 +20,7 @@ object InAppReview {
         request(activity, analyticsManager)
     }
 
-    fun request(activity: Activity, analyticsManager: AnalyticsManager) {
+    private fun request(activity: Activity, analyticsManager: AnalyticsManager) {
         analyticsManager.report("in_app_review_eligible")
 
         val manager = ReviewManagerFactory.create(activity)

--- a/app/src/main/java/app/opendocument/droid/ui/EditActionModeCallback.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/EditActionModeCallback.kt
@@ -31,7 +31,6 @@ class EditActionModeCallback(
     }
 
     override fun onPrepareActionMode(mode: ActionMode, menu: Menu): Boolean {
-        // reload document with translation enabled
         documentFragment.reloadUri(true)
 
         imm.toggleSoftInputFromWindow(

--- a/app/src/main/java/app/opendocument/droid/ui/FindActionModeCallback.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/FindActionModeCallback.kt
@@ -17,8 +17,6 @@
 package app.opendocument.droid.ui
 
 import android.content.Context
-import android.graphics.Point
-import android.graphics.Rect
 import android.text.Editable
 import android.text.Selection
 import android.text.Spannable
@@ -46,20 +44,12 @@ class FindActionModeCallback(context: Context) :
     private var webView: WebView? = null
     private var matchesFound = false
     private var numberOfMatches = 0
-    private var activeMatchIndex = 0
     private var actionMode: ActionMode? = null
-
-    private val globalVisibleRect = Rect()
-    private val globalVisibleOffset = Point()
 
     init {
         editText.setOnClickListener(this)
         setText("")
         matches = customView.findViewById(R.id.matches)
-    }
-
-    fun finish() {
-        actionMode?.finish()
     }
 
     /**
@@ -145,14 +135,17 @@ class FindActionModeCallback(context: Context) :
         }
     }
 
-    fun updateMatchCount(matchIndex: Int, matchCount: Int, isEmptyFind: Boolean) {
-        if (!isEmptyFind) {
-            numberOfMatches = matchCount
-            activeMatchIndex = matchIndex
-        } else {
-            matches.visibility = View.GONE
+    private fun updateMatchCount(matchIndex: Int, matchCount: Int, isEmptyFind: Boolean) {
+        if (isEmptyFind) {
             numberOfMatches = 0
+            matches.visibility = View.GONE
+
+            return
         }
+
+        numberOfMatches = matchCount
+        matches.text = "${matchIndex + 1}/$matchCount"
+        matches.visibility = View.VISIBLE
     }
 
     // OnClickListener implementation
@@ -164,11 +157,8 @@ class FindActionModeCallback(context: Context) :
     // ActionMode.Callback implementation
 
     override fun onCreateActionMode(mode: ActionMode, menu: Menu): Boolean {
-        // the AOSP original this class is derived from bailed out here when
-        // mode.isUiFocusable() was false, to avoid an unusable find field inside a
-        // dialog. That method is @RestrictTo(LIBRARY_GROUP_PREFIX) on the appcompat
-        // ActionMode, so it is not ours to call. We only ever start this action mode
-        // from MainActivity via startSupportActionMode(), never from a dialog.
+        // the AOSP original bailed out here on !mode.isUiFocusable(), which appcompat marks
+        // @RestrictTo. we never start this from a dialog.
 
         mode.customView = customView
         mode.menuInflater.inflate(R.menu.webview_find, menu)
@@ -184,9 +174,13 @@ class FindActionModeCallback(context: Context) :
 
     override fun onDestroyActionMode(mode: ActionMode) {
         actionMode = null
-        val webView = requireWebView("onDestroyActionMode")
-        webView.setFindListener(null)
-        input.hideSoftInputFromWindow(webView.windowToken, 0)
+
+        // tolerant, unlike the paths that need a page to search: the mode is started before
+        // setWebView and dismissing it must not throw out of the framework's own callback
+        webView?.let {
+            it.setFindListener(null)
+            input.hideSoftInputFromWindow(it.windowToken, 0)
+        }
     }
 
     override fun onPrepareActionMode(mode: ActionMode, menu: Menu): Boolean {
@@ -219,24 +213,5 @@ class FindActionModeCallback(context: Context) :
 
     override fun afterTextChanged(s: Editable?) {
         // Does nothing.  Needed to implement TextWatcher.
-    }
-
-    fun getActionModeGlobalBottom(): Int {
-        if (actionMode == null) {
-            return 0
-        }
-        val view = customView.parent as? View ?: customView
-        view.getGlobalVisibleRect(globalVisibleRect, globalVisibleOffset)
-        return globalVisibleRect.bottom
-    }
-
-    class NoAction : ActionMode.Callback {
-        override fun onCreateActionMode(mode: ActionMode, menu: Menu): Boolean = false
-
-        override fun onPrepareActionMode(mode: ActionMode, menu: Menu): Boolean = false
-
-        override fun onActionItemClicked(mode: ActionMode, item: MenuItem): Boolean = false
-
-        override fun onDestroyActionMode(mode: ActionMode) {}
     }
 }

--- a/app/src/main/java/app/opendocument/droid/ui/TtsActionModeCallback.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/TtsActionModeCallback.kt
@@ -17,9 +17,8 @@ import app.opendocument.droid.ui.widget.PageView
  * at [lastParagraphIndex] back through [ParagraphListener], and every finished utterance asks for
  * the next one.
  */
-// the utterance callback and the parameter map are the deprecated TextToSpeech API. Their
-// replacements (UtteranceProgressListener, the Bundle overload) need the utterance to be queued
-// with an id, which is a behaviour change rather than a rename - left for its own change.
+// the replacements for the deprecated utterance callback and parameter map need the utterance
+// queued with an id, which is a behaviour change rather than a rename
 @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
 class TtsActionModeCallback(private val context: Context, private val pageView: PageView) :
     ActionMode.Callback, OnInitListener, ParagraphListener, OnUtteranceCompletedListener {

--- a/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
@@ -5,8 +5,6 @@ import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
 import android.text.InputType
 import android.text.SpannableString
 import android.text.Spanned
@@ -51,8 +49,6 @@ import java.io.IOException
 
 class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider {
 
-    private lateinit var mainHandler: Handler
-
     private lateinit var analyticsManager: AnalyticsManager
 
     lateinit var crashManager: CrashManager
@@ -67,21 +63,16 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
 
     private var menu: Menu? = null
 
-    private var resultOnStart: FileLoader.Result? = null
-    private var errorOnStart: Throwable? = null
+    /** A loader callback that arrived while the activity was stopped, replayed by [onStart]. */
+    private var replayOnStart: (() -> Unit)? = null
 
-    /** Set by [loadUri], consumed by the load it belongs to. See [loadUri]. */
     private var freshOpenPending = false
 
     private lateinit var tabLayout: TabLayout
 
     private lateinit var serviceQueue: LoaderServiceQueue
 
-    /**
-     * Survives configuration changes, so a rotation neither reloads the document nor loses unsaved
-     * edits. This used to be setRetainInstance(true), which kept the whole fragment - views
-     * included - alive instead.
-     */
+    /** Survives a configuration change, so the document and any unsaved edits outlive it. */
     class DocumentViewModel : ViewModel() {
         var lastResult: FileLoader.Result? = null
         var currentHtmlDiff: String? = null
@@ -93,21 +84,11 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
 
         var lastSelectedTab: Int = -1
 
-        // whether a load is outstanding as far as OpenFileIdling is concerned. MainActivity
-        // only keeps espresso busy for the document picker round trip, which ends the moment
-        // the picker returns a uri - long before a loader callback has put anything on screen.
-        // one token per fragment is enough: a load started while another is in flight replaces
-        // it, and the surviving callback releases the single token.
-        //
-        // it lives here rather than in the fragment so a configuration change does not lose it:
-        // the recreated fragment reattaches itself as the service listener and keeps this view
-        // model, so the callback that ends the load still finds a token to release.
+        // one espresso token per fragment: a load started while another is in flight replaces it,
+        // and it lives in the view model so a configuration change does not lose it
         private var loadIsIdling = false
 
-        /**
-         * Marks the app busy for espresso until one of the loader callbacks has run. No-op in
-         * release builds, where [OpenFileIdling] does nothing.
-         */
+        /** Keeps espresso busy until a loader callback has run. */
         fun beginLoadIdling() {
             if (!loadIsIdling) {
                 loadIsIdling = true
@@ -116,7 +97,6 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
             }
         }
 
-        /** Counterpart of [beginLoadIdling]. Called once the load put its result on screen. */
         fun endLoadIdling() {
             if (loadIsIdling) {
                 loadIsIdling = false
@@ -125,9 +105,7 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
             }
         }
 
-        // the fragment is gone for good, so a load still in flight will never call back.
-        // releasing the token here keeps the idling resource - a singleton - from staying
-        // busy into the next instrumented test
+        // no callback is coming, and the idling resource is a singleton the next test inherits
         override fun onCleared() {
             endLoadIdling()
         }
@@ -167,7 +145,7 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
 
             pageView.setDocumentFragment(this)
         } catch (t: Throwable) {
-            // can't call crashlytics yet at this point (onViewCreated not called)
+            // crashManager is not set yet: onViewCreated has not run
 
             val errorString =
                 "Please install \"Android System WebView\" and restart the app afterwards."
@@ -191,8 +169,6 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
 
         pageContainer = view.findViewById(R.id.page_container)
         tabLayout = view.findViewById(R.id.document_tabs)
-
-        mainHandler = Handler(Looper.getMainLooper())
 
         val mainActivity = requireActivity() as MainActivity
         analyticsManager = mainActivity.analyticsManager
@@ -223,17 +199,13 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
         state.lastResult?.let { lastResult ->
             crashManager.log("restoring lastResult")
 
-            prepareLoad(lastResult.loaderType, false)
             restoreTabs(lastResult)
         }
 
         pageView?.restoreState(savedInstanceState)
     }
 
-    /**
-     * Rebuilds the tab strip after the view was recreated. The tabs live in the fragment view, so
-     * unlike the document itself they do not survive a rotation on their own.
-     */
+    /** Rebuilds the tab strip: the tabs live in the view, which the view model does not hold. */
     private fun restoreTabs(result: FileLoader.Result) {
         if (result.partTitles.size <= 1) {
             return
@@ -288,27 +260,14 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
     override fun onStart() {
         super.onStart()
 
-        val resultOnStart = this.resultOnStart ?: return
-        val errorOnStart = this.errorOnStart
+        val replay = replayOnStart ?: return
+        replayOnStart = null
 
-        if (errorOnStart == null) {
-            onLoadSuccess(resultOnStart)
-        } else {
-            onError(resultOnStart, errorOnStart)
-        }
-
-        this.resultOnStart = null
-        this.errorOnStart = null
-    }
-
-    private fun prepareLoad(loaderType: FileLoader.LoaderType, showProgress: Boolean) {
-        if (showProgress) {
-            showProgress(loaderType == FileLoader.LoaderType.ONLINE)
-        }
+        replay()
     }
 
     private fun loadWithType(loaderType: FileLoader.LoaderType, options: FileLoader.Options) {
-        prepareLoad(loaderType, true)
+        showProgress(loaderType == FileLoader.LoaderType.ONLINE)
 
         state.beginLoadIdling()
 
@@ -355,8 +314,8 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
             callback.run()
         }
 
-        // note that a full save runs the callback a second time once the diff arrives; kept
-        // as it is, because changing when the save target is picked is a behaviour change
+        // a full save runs the callback twice, so a second requestSave() would open the
+        // create-document picker twice - masked only by odr.generateDiff() existing in edit mode
         pageView?.requestHtml { htmlDiff ->
             state.currentHtmlDiff = htmlDiff
 
@@ -377,15 +336,14 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
             return
         }
 
-        // read inside the entry, not before it: the queue replays this once the service is
-        // bound, and the java version looked the result up at that point too
+        // read inside the entry: the queue replays this once the service is bound
         serviceQueue.addToQueue { service ->
             service.saveAsync(requireLastResult(), outFile, state.currentHtmlDiff)
         }
     }
 
     private fun unload() {
-        toggleDocumentMenu(false)
+        toggleDocumentMenu(false, false)
 
         resetTabs()
     }
@@ -398,10 +356,6 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
         }
 
         state.lastSelectedTab = -1
-    }
-
-    private fun toggleDocumentMenu(enabled: Boolean) {
-        toggleDocumentMenu(enabled, enabled)
     }
 
     private fun toggleDocumentMenu(enabled: Boolean, editEnabled: Boolean) {
@@ -436,7 +390,14 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
         pageView?.toggleDarkMode(fileType?.startsWith("application/pdf") != true)
     }
 
-    private fun isActivityReadyForResult(result: FileLoader.Result): Boolean {
+    /**
+     * Whether [result] can be acted on now. If not, [replay] is what [onStart] runs instead - it
+     * has to be the caller's own callback, or a failure comes back as a success.
+     */
+    private fun isActivityReadyForResult(
+        result: FileLoader.Result,
+        replay: () -> Unit,
+    ): Boolean {
         val lastRequestedUri = state.lastRequestedUri
         if (lastRequestedUri != null && lastRequestedUri != result.options.originalUri) {
             crashManager.log("dropping result of abandoned load: " + result.options.originalUri)
@@ -445,7 +406,7 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
         }
 
         if (activity == null || isStateSaved) {
-            resultOnStart = result
+            replayOnStart = replay
 
             return false
         }
@@ -453,14 +414,13 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
         // needs to be saved for errors too for features like "Open With" to work
         state.lastResult = result
 
-        resultOnStart = null
-        errorOnStart = null
+        replayOnStart = null
 
         return true
     }
 
     override fun onLoadSuccess(result: FileLoader.Result) {
-        if (!isActivityReadyForResult(result)) {
+        if (!isActivityReadyForResult(result) { onLoadSuccess(result) }) {
             return
         }
 
@@ -484,9 +444,7 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
             loadData(result.partUris[0].toString())
         }
 
-        // the escape hatch for a file we show rather than read: an image, an archive listing, a
-        // player. This used to be "the raw loader ran", which meant the same until the core
-        // took those over
+        // the escape hatch for a file we show rather than read: an image, an archive listing
         if (
             !SupportedDocumentTypes.isDocument(options.fileType) ||
                 result.loaderType == FileLoader.LoaderType.ONLINE
@@ -512,7 +470,7 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
     }
 
     override fun onError(result: FileLoader.Result, error: Throwable) {
-        if (!isActivityReadyForResult(result)) {
+        if (!isActivityReadyForResult(result) { onError(result, error) }) {
             return
         }
 
@@ -527,13 +485,10 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
                 offerReopen(activity, options, R.string.toast_error_find_file, true)
             error is OutOfMemoryError ->
                 offerReopen(activity, options, R.string.toast_error_out_of_memory, true)
-            // an upload that did not come back says nothing about the file - the network or
-            // the server is what failed, and the file was one we never claimed to open in the
-            // first place. keep the reopen offer, which is the useful thing left to do with it
+            // the network or the server failed, which says nothing about the file
             result.loaderType == FileLoader.LoaderType.ONLINE ->
                 offerReopen(activity, options, R.string.toast_error_upload_failed, true)
-            // MetadataLoader could not read the file, or the core names its format and still
-            // could not open it. Neither is worth an upload, so ask to hear about it instead
+            // unreadable, or named and still not openable - neither is worth an upload
             else -> {
                 // nothing is ever going to be shown for this file, so drop back to the
                 // landing screen and let the dialog come up over that
@@ -550,7 +505,7 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
     }
 
     override fun onEncrypted(result: FileLoader.Result) {
-        if (!isActivityReadyForResult(result)) {
+        if (!isActivityReadyForResult(result) { onEncrypted(result) }) {
             return
         }
 
@@ -587,7 +542,7 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
     }
 
     override fun onUnsupported(result: FileLoader.Result) {
-        if (!isActivityReadyForResult(result)) {
+        if (!isActivityReadyForResult(result) { onUnsupported(result) }) {
             return
         }
 
@@ -664,9 +619,7 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
     private fun offerContact(activity: Activity) {
         analyticsManager.report("contact_offer")
 
-        // its own content view rather than setMessage plus the builder's buttons - see
-        // dialog_broken_file.xml. every string comes off the activity, because closeDocument()
-        // has already detached this fragment and its own getString() would throw
+        // strings off the activity: closeDocument() already detached this fragment
         val view = activity.layoutInflater.inflate(R.layout.dialog_broken_file, null)
 
         val dialog =
@@ -885,7 +838,7 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
                 // so the previous tab is re-selected instead
                 if (lastResult.options.translatable && state.lastSelectedTab >= 0) {
                     // reselecting from inside onTabSelected() does not take effect
-                    mainHandler.postDelayed(
+                    tabLayout.postDelayed(
                         { tabLayout.getTabAt(state.lastSelectedTab)?.select() },
                         1,
                     )
@@ -929,12 +882,8 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
 
         serviceQueue.service?.setListener(null)
 
-        // the listener is gone, so a load still in flight will never call back - unless this
-        // is a configuration change, where the recreated fragment takes the listener (and the
-        // view model holding the token) over and still gets the callback. anywhere else,
-        // releasing here keeps the idling resource - a singleton - from staying busy into the
-        // next instrumented test. a fragment that goes away for good on top of that has its
-        // view model cleared, which releases as well
+        // no callback is coming, except on a configuration change - there the recreated
+        // fragment inherits both the listener and the view model
         if (!requireActivity().isChangingConfigurations) {
             state.endLoadIdling()
         }

--- a/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
@@ -298,6 +298,12 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
     }
 
     fun reloadUri(translatable: Boolean) {
+        // closeDocument() removes this fragment and only then finishes the edit mode, whose
+        // onDestroyActionMode reloads - a load queued here would have nothing left to land in
+        if (!isAdded) {
+            return
+        }
+
         val lastResult = checkNotNull(state.lastResult) { "nothing was loaded yet" }
         lastResult.options.translatable = translatable
 
@@ -343,7 +349,7 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
     }
 
     private fun unload() {
-        toggleDocumentMenu(false, false)
+        toggleDocumentMenu(false, false, false)
 
         resetTabs()
     }
@@ -358,7 +364,7 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
         state.lastSelectedTab = -1
     }
 
-    private fun toggleDocumentMenu(enabled: Boolean, editEnabled: Boolean) {
+    private fun toggleDocumentMenu(enabled: Boolean, editEnabled: Boolean, ttsEnabled: Boolean) {
         val menu = this.menu
         if (menu == null) {
             val activity = activity
@@ -368,22 +374,29 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener, MenuProvider 
             }
 
             // menu is not set when loadUri is called via onStart, retry later
-            pageView.post { toggleDocumentMenu(enabled, editEnabled) }
+            pageView.post { toggleDocumentMenu(enabled, editEnabled, ttsEnabled) }
 
             return
         }
 
         menu.findItem(R.id.menu_edit).isVisible = editEnabled
+        menu.findItem(R.id.menu_tts).isVisible = ttsEnabled
 
         menu.findItem(R.id.menu_search).isVisible = enabled
-        menu.findItem(R.id.menu_tts).isVisible = enabled
     }
 
     private fun prepareMenu(result: FileLoader.Result) {
         // whether editing is on offer is the core's answer, not a list of formats kept here: it
         // knows which of the documents it renders it can also write back, which is why neither the
-        // legacy binary formats nor the spreadsheets of issue #442 need naming
-        toggleDocumentMenu(true, result.isEditable)
+        // legacy binary formats nor the spreadsheets of issue #442 need naming.
+        //
+        // read aloud needs the javascript bridge, which PageView keeps off the third party viewers
+        // an ONLINE result loads - offering it there leaves it stuck at "reading" with no paragraph
+        toggleDocumentMenu(
+            enabled = true,
+            editEnabled = result.isEditable,
+            ttsEnabled = result.loaderType != FileLoader.LoaderType.ONLINE,
+        )
 
         // pdf is the one thing worth leaving alone: inverting a page of scanned paper helps nobody
         val fileType = result.options.fileType

--- a/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
@@ -560,14 +560,13 @@ class MainActivity : AppCompatActivity(), MenuProvider {
 
                 documentFragment?.pageView?.let { pageView ->
                     // printing a dark page wastes ink, but the setting has to come back
-                    // afterwards or the rest of the document is read in light mode
+                    // afterwards or the rest of the document is read in light mode. only once
+                    // the job is over: the print framework reads the page well after print()
                     val wasDark = pageView.isDarkEnabled
 
                     pageView.toggleDarkMode(false)
 
-                    printingManager.print(this, pageView)
-
-                    pageView.toggleDarkMode(wasDark)
+                    printingManager.print(this, pageView) { pageView.toggleDarkMode(wasDark) }
                 }
             }
 
@@ -665,9 +664,9 @@ class MainActivity : AppCompatActivity(), MenuProvider {
 
     // also called by DocumentFragment, so an error dialog comes up over the landing screen
     fun closeDocument() {
-        // an edit or tts mode would otherwise outlive the fragment it acts on
-        currentActionMode?.finish()
-
+        // the fragment goes first: finishing an edit mode reloads the document it acts on, and
+        // that load would put a progress dialog up over a fragment that is about to be removed.
+        // reloadUri() is a no-op once it is detached
         documentFragment?.let { fragment ->
             removeMenuProvider(fragment)
 
@@ -675,6 +674,9 @@ class MainActivity : AppCompatActivity(), MenuProvider {
 
             documentFragment = null
         }
+
+        // an edit or tts mode would otherwise outlive the document it acts on
+        currentActionMode?.finish()
 
         lastUri = null
 

--- a/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
@@ -22,6 +22,7 @@ import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.view.ActionMode as SupportActionMode
 import androidx.appcompat.widget.SwitchCompat
 import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
@@ -62,9 +63,8 @@ class MainActivity : AppCompatActivity(), MenuProvider {
 
     private var fullscreen = false
 
-    // With targetSdk 36 predictive back is enabled by default and neither KEYCODE_BACK
-    // nor onBackPressed() are delivered anymore, so back is intercepted via the
-    // OnBackPressedDispatcher instead.
+    // predictive back (default from targetSdk 36) delivers neither KEYCODE_BACK nor
+    // onBackPressed(), so back is intercepted through the dispatcher
     private val backCallback =
         object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
@@ -90,7 +90,9 @@ class MainActivity : AppCompatActivity(), MenuProvider {
         }
 
     private var ttsActionMode: TtsActionModeCallback? = null
-    private var editActionMode: EditActionModeCallback? = null
+
+    /** The action mode on screen, so [closeDocument] and [onDestroy] can take it down with them. */
+    private var currentActionMode: SupportActionMode? = null
 
     lateinit var crashManager: CrashManager
         private set
@@ -106,9 +108,7 @@ class MainActivity : AppCompatActivity(), MenuProvider {
     private var loadOnStart: Uri? = null
     private var lastSaveUri: Uri? = null
 
-    // documents opened from another app keep the default back behavior (returning
-    // to that app), while documents opened from within the app go back to the
-    // landing screen instead of closing the app
+    // back returns to the calling app for these, rather than to the landing screen
     private var documentOpenedExternally = false
 
     // set before we start an activity of our own, so coming back from it is not counted as
@@ -120,12 +120,22 @@ class MainActivity : AppCompatActivity(), MenuProvider {
 
     private var service: LoaderService? = null
 
+    /**
+     * Whether [bindService] was called. Not the same as holding a [service]: the binder arrives
+     * asynchronously, and an activity destroyed before it does still has to unbind.
+     */
+    private var isBound = false
+
     private val connection =
         object : ServiceConnection {
             override fun onServiceDisconnected(name: ComponentName?) {
                 service?.setListener(null)
 
                 service = null
+
+                // the queue holds its own reference, and handing work to a service whose
+                // background thread has quit drops it without telling anyone
+                loaderServiceQueue.service = null
             }
 
             override fun onServiceConnected(name: ComponentName?, binder: IBinder) {
@@ -168,9 +178,8 @@ class MainActivity : AppCompatActivity(), MenuProvider {
 
         setContentView(R.layout.main)
 
-        // Edge-to-edge is enforced from targetSdk 35 on: pad the root view so content
-        // stays clear of the system bars, display cutouts and the keyboard. On older
-        // devices the window does not extend under the bars and the insets are zero.
+        // edge-to-edge is enforced from targetSdk 35 on: pad the root so content stays clear
+        // of the system bars, cutouts and the keyboard
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main_root)) { view, windowInsets
             ->
             val insets =
@@ -189,6 +198,7 @@ class MainActivity : AppCompatActivity(), MenuProvider {
 
         loaderServiceQueue = LoaderServiceQueue()
         bindService(Intent(this, LoaderService::class.java), connection, BIND_AUTO_CREATE)
+        isBound = true
 
         handler = Handler(Looper.getMainLooper())
 
@@ -210,8 +220,8 @@ class MainActivity : AppCompatActivity(), MenuProvider {
 
         initializeCatchAllSwitch()
 
-        // reclaims the uri permissions of documents that have since dropped off the recently
-        // opened list. touches the filesystem and the permission binder, so not on the main thread
+        // reclaims the grants of documents that dropped off the recent list; hits the
+        // filesystem and the permission binder, so off the main thread
         Thread { PersistedUriPermissions.prune(applicationContext) }.start()
 
         crashManager.log("onCreate")
@@ -276,8 +286,8 @@ class MainActivity : AppCompatActivity(), MenuProvider {
 
         crashManager.log("onStart")
 
-        // here rather than in onCreate: tapping the launcher while the task is still alive
-        // resumes this activity instead of creating it, and those opens count too
+        // not in onCreate: a launcher tap onto a live task resumes rather than creates,
+        // and those opens count too
         if (documentFragment == null && loadOnStart == null) {
             if (leftForOwnActivity) {
                 leftForOwnActivity = false
@@ -300,8 +310,6 @@ class MainActivity : AppCompatActivity(), MenuProvider {
     }
 
     private fun initializeCatchAllSwitch() {
-        // retoggles the aliases for users upgrading from a version that shipped different
-        // defaults, and answers with what the stored setting says
         val isCatchAllEnabled = CatchAllSetting.applyOnLaunch(this)
 
         val catchAllSwitch = findViewById<SwitchCompat>(R.id.landing_catch_all)
@@ -349,7 +357,7 @@ class MainActivity : AppCompatActivity(), MenuProvider {
             leftForOwnActivity = true
             createDocumentLauncher.launch(intent)
         } catch (e: ActivityNotFoundException) {
-            // happens on a variety devices, e.g. Samsung Galaxy Tab4 7.0 with Android 4.4.2
+            // a device with nothing handling ACTION_CREATE_DOCUMENT - there is nowhere to save to
             crashManager.log(e)
         }
     }
@@ -377,11 +385,11 @@ class MainActivity : AppCompatActivity(), MenuProvider {
         adManager = AdManager()
         adManager.setEnabled(!IS_TESTING && useProprietaryLibraries)
         adManager.setAdContainer(adContainer)
-        adManager.initialize(this, analyticsManager, crashManager)
+        adManager.initialize(this, crashManager)
 
         billingManager = BillingManager()
         billingManager.setEnabled(useProprietaryLibraries)
-        billingManager.initialize(this, analyticsManager, adManager)
+        billingManager.initialize(this, adManager)
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -408,10 +416,8 @@ class MainActivity : AppCompatActivity(), MenuProvider {
         }
     }
 
-    // The play services availability dialog calls startActivityForResult() itself with a
-    // request code we hand it, so its result cannot be routed through an
-    // ActivityResultLauncher. Everything the app launches on its own goes through the
-    // launchers declared above.
+    // the play services availability dialog calls startActivityForResult() itself with a request
+    // code we hand it, so its result cannot come back through an ActivityResultLauncher
     @Deprecated("Deprecated in Java")
     @Suppress("DEPRECATION")
     override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
@@ -458,15 +464,10 @@ class MainActivity : AppCompatActivity(), MenuProvider {
             uri.toString(),
         )
 
-        // the grant has to outlive this call: loadUri only queues the load onto LoaderService,
-        // so MetadataLoader opens the stream long after we return. releasing it here - as this
-        // used to - also dropped the persisted grant, which left every uri in the recently
-        // opened list unreadable on the next launch. PersistedUriPermissions.prune() reclaims
-        // them instead, once nothing refers to them any more.
-        //
-        // takeRead fails for a document below a directory tree we were granted, because only a
-        // uri that arrived on one of our own intents can be persisted - isRetained covers those,
-        // so browsing to a document still records it as recent
+        // the grant has to outlive this call: the load is only queued, so the stream is opened
+        // long after we return. releasing it here also dropped the persisted grant, leaving the
+        // recent documents unreadable - prune() reclaims instead. isRetained covers a document
+        // below a granted tree, which cannot be persisted on its own
         val isPersistentUri =
             PersistedUriPermissions.takeRead(this, uri) ||
                 PersistedUriPermissions.isRetained(this, uri)
@@ -481,7 +482,7 @@ class MainActivity : AppCompatActivity(), MenuProvider {
             R.id.menu_search -> {
                 val findActionModeCallback = FindActionModeCallback(this)
                 documentFragment?.pageView?.let { findActionModeCallback.setWebView(it) }
-                startSupportActionMode(findActionModeCallback)
+                currentActionMode = startSupportActionMode(findActionModeCallback)
 
                 analyticsManager.report("menu_search")
                 analyticsManager.report(AnalyticsConstants.EVENT_SEARCH)
@@ -558,9 +559,15 @@ class MainActivity : AppCompatActivity(), MenuProvider {
                 analyticsManager.report("menu_print")
 
                 documentFragment?.pageView?.let { pageView ->
+                    // printing a dark page wastes ink, but the setting has to come back
+                    // afterwards or the rest of the document is read in light mode
+                    val wasDark = pageView.isDarkEnabled
+
                     pageView.toggleDarkMode(false)
 
                     printingManager.print(this, pageView)
+
+                    pageView.toggleDarkMode(wasDark)
                 }
             }
 
@@ -571,7 +578,7 @@ class MainActivity : AppCompatActivity(), MenuProvider {
                     val ttsActionMode = TtsActionModeCallback(this, pageView)
                     this.ttsActionMode = ttsActionMode
 
-                    startSupportActionMode(ttsActionMode)
+                    currentActionMode = startSupportActionMode(ttsActionMode)
                 }
             }
 
@@ -579,10 +586,8 @@ class MainActivity : AppCompatActivity(), MenuProvider {
                 analyticsManager.report("menu_edit")
 
                 documentFragment?.let { fragment ->
-                    val editActionMode = EditActionModeCallback(this, fragment)
-                    this.editActionMode = editActionMode
-
-                    startSupportActionMode(editActionMode)
+                    currentActionMode =
+                        startSupportActionMode(EditActionModeCallback(this, fragment))
                 }
             }
 
@@ -614,7 +619,7 @@ class MainActivity : AppCompatActivity(), MenuProvider {
     override fun onActionModeFinished(mode: ActionMode?) {
         super.onActionModeFinished(mode)
 
-        editActionMode = null
+        currentActionMode = null
         ttsActionMode = null
     }
 
@@ -634,8 +639,7 @@ class MainActivity : AppCompatActivity(), MenuProvider {
     private fun buyAdRemoval() {
         analyticsManager.report(AnalyticsConstants.EVENT_ADD_TO_CART)
 
-        // the play listing id is the applicationId, which stays at.tomtasche.reader.pro
-        // - it is not the java package and does not follow the namespace rename
+        // the play listing id is the applicationId, not the renamed java package
         startActivity(
             Intent(
                 Intent.ACTION_VIEW,
@@ -659,9 +663,11 @@ class MainActivity : AppCompatActivity(), MenuProvider {
         analyticsManager.report("fullscreen_end")
     }
 
-    // also called by DocumentFragment when a load failed for good, so the landing screen is
-    // what the error dialog comes up over rather than an empty document view
+    // also called by DocumentFragment, so an error dialog comes up over the landing screen
     fun closeDocument() {
+        // an edit or tts mode would otherwise outlive the fragment it acts on
+        currentActionMode?.finish()
+
         documentFragment?.let { fragment ->
             removeMenuProvider(fragment)
 
@@ -747,8 +753,13 @@ class MainActivity : AppCompatActivity(), MenuProvider {
     }
 
     override fun onDestroy() {
-        if (service != null) {
+        // appcompat does not finish it for us, and TtsActionModeCallback only shuts its
+        // engine down when the mode is destroyed
+        currentActionMode?.finish()
+
+        if (isBound) {
             unbindService(connection)
+            isBound = false
         }
 
         printingManager.close()
@@ -756,12 +767,7 @@ class MainActivity : AppCompatActivity(), MenuProvider {
         adManager.destroyAds()
 
         try {
-            // keeps throwing exceptions for some users:
-            // Caused by: java.lang.NullPointerException
-            // android.webkit.WebViewClassic.requestFocus(WebViewClassic.java:9898)
-            // android.webkit.WebView.requestFocus(WebView.java:2133)
-            // ViewGroup.onRequestFocusInDescendants(ViewGroup.java:2384)
-
+            // has thrown out of the WebView's focus handling for some users
             super.onDestroy()
         } catch (e: Exception) {
             crashManager.log(e)

--- a/app/src/main/java/app/opendocument/droid/ui/widget/PageView.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/widget/PageView.kt
@@ -44,15 +44,19 @@ constructor(context: Context, attributeSet: AttributeSet?) :
     private var htmlCallback: HtmlCallback? = null
 
     /**
-     * sometimes the page stays invisible after reporting progress 100:
-     * https://stackoverflow.com/q/48082474/198996
-     *
-     * this seems to happen if progress 100 is reported before finish is called. therefore we set a
-     * timer in finish that checks if commit was ever called and reload if not.
+     * Progress 100 reported before the page commits leaves it blank
+     * (https://stackoverflow.com/q/48082474/198996), so onPageFinished schedules a reload for
+     * whatever never committed.
      */
     private val buggyWebViewHandler = Handler(Looper.getMainLooper())
 
     private var wasCommitCalled = false
+
+    private var isBridgeAttached = false
+
+    /** What [toggleDarkMode] was last set to, so printing can turn it off and put it back. */
+    var isDarkEnabled = false
+        private set
 
     init {
         settings.builtInZoomControls = true
@@ -64,17 +68,9 @@ constructor(context: Context, attributeSet: AttributeSet?) :
         settings.useWideViewPort = true
         settings.allowFileAccess = true
 
-        // setWebContentsDebuggingEnabled(true)
-
-        addJavascriptInterface(this, "paragraphListener")
+        attachBridge(true)
 
         keepScreenOn = true
-        try {
-            val method = context.javaClass.getMethod("setSystemUiVisibility", Integer::class.java)
-            method.invoke(context, 1)
-        } catch (e: Exception) {
-            // the context is not an activity that would hide the system ui
-        }
 
         webViewClient =
             object : WebViewClient() {
@@ -98,9 +94,7 @@ constructor(context: Context, attributeSet: AttributeSet?) :
                     wasCommitCalled = true
                 }
 
-                // a document that fails to load leaves chrome's own error page on screen and
-                // said nothing to anyone. that cost a full round of ci archaeology to work out
-                // from the outside, so the main frame failing is now reported
+                // a failed load otherwise leaves chrome's error page on screen and tells nobody
                 override fun onReceivedError(
                     view: WebView,
                     request: WebResourceRequest,
@@ -153,6 +147,8 @@ constructor(context: Context, attributeSet: AttributeSet?) :
 
     @Suppress("DEPRECATION") // setForceDarkAllowed and setForceDark are the pre-webkit-1.6 api
     fun toggleDarkMode(isDarkEnabled: Boolean) {
+        this.isDarkEnabled = isDarkEnabled
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             isForceDarkAllowed = isDarkEnabled
         }
@@ -171,7 +167,39 @@ constructor(context: Context, attributeSet: AttributeSet?) :
     override fun loadUrl(url: String) {
         wasCommitCalled = false
 
+        // sendFile writes into the cache and opens what it wrote, so the bridge must not reach
+        // the third party viewers an ONLINE result loads here. takes effect on the next load
+        if (!url.startsWith(JAVASCRIPT_SCHEME)) {
+            attachBridge(isOwnContent(url))
+        }
+
         super.loadUrl(url)
+    }
+
+    override fun destroy() {
+        // the reload is scheduled 2.5s out, and this also runs when a second document
+        // replaces the view - so it must not land on a WebView that is gone
+        buggyWebViewHandler.removeCallbacksAndMessages(null)
+
+        super.destroy()
+    }
+
+    /** Whether [url] is a document we produced: a cached file, or the core's own http server. */
+    private fun isOwnContent(url: String): Boolean =
+        url.startsWith("file://") || url.startsWith(LOCAL_SERVER_URL_PREFIX)
+
+    private fun attachBridge(attach: Boolean) {
+        if (attach == isBridgeAttached) {
+            return
+        }
+
+        if (attach) {
+            addJavascriptInterface(this, BRIDGE_NAME)
+        } else {
+            removeJavascriptInterface(BRIDGE_NAME)
+        }
+
+        isBridgeAttached = attach
     }
 
     fun setDocumentFragment(documentFragment: DocumentFragment) {
@@ -201,7 +229,7 @@ constructor(context: Context, attributeSet: AttributeSet?) :
     fun requestHtml(callback: HtmlCallback) {
         this.htmlCallback = callback
 
-        loadUrl("javascript:window.paragraphListener.sendHtml(odr.generateDiff());")
+        loadUrl("${JAVASCRIPT_SCHEME}window.$BRIDGE_NAME.sendHtml(odr.generateDiff());")
     }
 
     @JavascriptInterface
@@ -255,5 +283,15 @@ constructor(context: Context, attributeSet: AttributeSet?) :
     fun interface HtmlCallback {
 
         fun onHtml(htmlDiff: String)
+    }
+
+    private companion object {
+
+        const val BRIDGE_NAME = "paragraphListener"
+
+        const val JAVASCRIPT_SCHEME = "javascript:"
+
+        /** Where CoreLoader publishes a translated document. */
+        const val LOCAL_SERVER_URL_PREFIX = "http://localhost:"
     }
 }

--- a/app/src/main/java/app/opendocument/droid/ui/widget/ProgressDialogFragment.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/widget/ProgressDialogFragment.kt
@@ -9,10 +9,7 @@ import android.os.Bundle
 import androidx.fragment.app.DialogFragment
 import app.opendocument.droid.R
 
-/**
- * @JvmOverloads keeps the no-arg constructor the framework needs to re-create the fragment; a
- *   restored dialog reports itself as a load, same as before.
- */
+/** @JvmOverloads keeps the no-arg constructor the fragment framework re-creates this with. */
 @SuppressLint("ValidFragment")
 class ProgressDialogFragment @JvmOverloads constructor(private val isUpload: Boolean = false) :
     DialogFragment() {

--- a/app/src/main/java/app/opendocument/droid/ui/widget/RecentDocumentDialogFragment.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/widget/RecentDocumentDialogFragment.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import android.view.View
 import android.widget.AdapterView
 import android.widget.AdapterView.OnItemClickListener
-import android.widget.AdapterView.OnItemLongClickListener
 import android.widget.ArrayAdapter
 import android.widget.ListAdapter
 import android.widget.ListView
@@ -17,12 +16,10 @@ import app.opendocument.droid.R
 import app.opendocument.droid.background.RecentDocumentsUtil
 import app.opendocument.droid.ui.activity.MainActivity
 
-class RecentDocumentDialogFragment :
-    DialogFragment(), OnItemClickListener, OnItemLongClickListener {
+class RecentDocumentDialogFragment : DialogFragment(), OnItemClickListener {
 
-    // insertion ordered: the adapter is built from keys, so a HashMap here would
-    // throw away the order RecentDocumentsUtil hands the documents back in
-    private var items: MutableMap<String, String?> = LinkedHashMap()
+    // insertion ordered: the adapter is built from the keys, in the order they came back in
+    private val items: MutableMap<String, String?> = LinkedHashMap()
     private lateinit var adapter: ListAdapter
     private lateinit var listView: ListView
 
@@ -37,25 +34,12 @@ class RecentDocumentDialogFragment :
         listView = ListView(requireActivity())
         listView.emptyView = emptyView
         listView.onItemClickListener = this
-        listView.onItemLongClickListener = this
-
-        adapter =
-            ArrayAdapter(
-                requireActivity(),
-                android.R.layout.simple_list_item_1,
-                emptyArray<String>(),
-            )
-        listView.adapter = adapter
 
         builder.setView(listView)
 
         setCancelable(true)
 
-        items = LinkedHashMap()
-
         loadRecentDocuments()
-
-        listView.emptyView = emptyView
 
         return builder.create()
     }
@@ -67,7 +51,6 @@ class RecentDocumentDialogFragment :
         }
 
         if (items.isEmpty()) {
-            items = LinkedHashMap()
             items[getString(R.string.dialog_list_no_documents_found)] = null
         }
 
@@ -89,15 +72,6 @@ class RecentDocumentDialogFragment :
         dismiss()
 
         (requireActivity() as MainActivity).loadUri(Uri.parse(uri))
-    }
-
-    override fun onItemLongClick(
-        parent: AdapterView<*>?,
-        view: View?,
-        position: Int,
-        id: Long,
-    ): Boolean {
-        return false
     }
 
     companion object {

--- a/app/src/main/res/layout/page_view.xml
+++ b/app/src/main/res/layout/page_view.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Inflated into the page container of fragment_document every time a document is
-  loaded: the WebView is thrown away and recreated rather than reused, so no state
-  from the previous document can leak into the next one.
+  Re-inflated per document: the WebView is recreated rather than reused, so no state
+  leaks from one document into the next.
 -->
 <app.opendocument.droid.ui.widget.PageView
         xmlns:android="http://schemas.android.com/apk/res/android"

--- a/app/src/main/res/xml/cache_provider_paths.xml
+++ b/app/src/main/res/xml/cache_provider_paths.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
-    <!-- for nnf -->
+    <!-- the whole app directory, for uris handed to us from outside the cache -->
     <root-path
             name="root"
             path="." />
@@ -10,7 +10,7 @@
             name="cache"
             path="." />
 
-<!--    For instrumentation tests-->
+    <!-- for instrumentation tests -->
     <cache-path
             name="test-documents"
             path="test-documents" />

--- a/app/src/release/java/app/opendocument/droid/ui/OpenFileIdling.kt
+++ b/app/src/release/java/app/opendocument/droid/ui/OpenFileIdling.kt
@@ -1,9 +1,8 @@
 package app.opendocument.droid.ui
 
 /**
- * Release variant: does nothing. The debug variant backs these calls with an espresso
- * CountingIdlingResource; keeping the espresso dependency out of release builds is the whole point
- * of the split.
+ * Release variant: does nothing, which is what keeps espresso out of release builds. The debug
+ * variant backs these calls with a CountingIdlingResource.
  */
 object OpenFileIdling {
 

--- a/app/src/test/java/app/opendocument/droid/background/StreamUtilTest.kt
+++ b/app/src/test/java/app/opendocument/droid/background/StreamUtilTest.kt
@@ -28,7 +28,7 @@ class StreamUtilTest {
 
     @Test
     fun copyLargeStream() {
-        // larger than the internal 1024 byte buffer
+        // larger than copyTo's buffer
         val data = ByteArray(10000)
         for (i in data.indices) {
             data[i] = (i % 256).toByte()

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,7 @@ plugins {
     alias(libs.plugins.spotless)
 }
 
-// Formatting is google-java-format in its AOSP flavor: 4 space indents and a 100
-// column limit, which is what this codebase already broadly follows. Run
-// ./gradlew spotlessApply to fix, ./gradlew spotlessCheck to verify (CI does).
+// ./gradlew spotlessApply to fix, spotlessCheck to verify (CI does).
 spotless {
     java {
         target 'app/src/*/java/**/*.java'
@@ -29,7 +27,8 @@ spotless {
         // deliberately explicit: a '**/*.yml' style glob also matches generated
         // output under build/
         target '*.gradle', 'app/*.gradle', 'gradle/*.toml', '*.md', '.gitignore',
-                '.github/**/*.yml', 'crowdin.yml', '_config.yml', '*.sh'
+                '.github/**/*.yml', 'crowdin.yml', '_config.yml', '*.sh',
+                '.github/scripts/*', 'tools/**/*.sh', 'tools/**/*.py'
         targetExclude '**/build/**'
 
         trimTrailingWhitespace()

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,7 +22,7 @@ platform :android do
   end
 
   desc "Upload an already built Pro bundle. Used by the release workflow, which builds " \
-       "with gradle directly so that the native dependency cache is reused."
+       "both flavors with gradle directly, in one job."
   lane :uploadPro do |options|
     uploadBundle(flavor: "Pro", track: options[:track])
   end
@@ -37,10 +37,9 @@ platform :android do
   end
 
   private_lane :buildBundle do |options|
-    # there is no version number in the repository - it is the git tag, so a build
-    # started by hand has to say which one it is producing. Left out, gradle would fall
-    # back to 0.0.0, and the store would refuse that version code once the whole build
-    # and upload had already run
+    # there is no version number in the repository - the release run is handed one as an
+    # input, so a build started by hand has to say which one it is producing. Left out,
+    # gradle falls back to 0.0.0 and the store refuses that code after the build has run
     version = options[:version] || ENV["ODR_VERSION"]
     if version.to_s.empty?
       UI.user_error!("no version to build. pass one as version:v4.8.0, or set ODR_VERSION")
@@ -65,12 +64,8 @@ platform :android do
     upload_to_play_store(
       track: options[:track] || DEFAULT_TRACK,
       package_name: PACKAGE_NAMES.fetch(flavor),
-      # the release workflow keeps the key outside the checkout and points here
-      # at it. passing it rather than leaving it to the Appfile matters even
-      # then: supply verifies the Appfile's default whether or not that is the
-      # value being used, so an absent fastlane_google_play.json fails the run
-      # with "Invalid default value for json_key" no matter what SUPPLY_JSON_KEY
-      # says. an explicit value is the one thing that check skips
+      # explicit: supply validates the Appfile's default even when it is unused, so an
+      # absent file there fails the run whatever SUPPLY_JSON_KEY says
       json_key: ENV["ODR_PLAY_JSON_KEY"] ||
         CredentialsManager::AppfileConfig.try_fetch_value(:json_key_file),
       aab: "app/build/outputs/bundle/#{variant}Release/app-#{variant}-release.aab",

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,6 @@ android.useAndroidX=true
 android.nonTransitiveRClass=true
 android.nonFinalResIds=true
 
-# https://docs.gradle.org/current/userguide/configuration_cache.html - it was turned on to
-# run the per-ABI conanInstall tasks in parallel, and kept after those went away because a
-# configuration-cache hit skips the configuration phase outright.
+# https://docs.gradle.org/current/userguide/configuration_cache.html - a cache hit skips
+# the configuration phase outright.
 org.gradle.configuration-cache=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,8 +4,7 @@ spotless = "8.9.0"
 googleJavaFormat = "1.35.0"
 ktfmt = "0.64"
 
-# odrcore's JNI bindings, both halves in one AAR: the java classes and a
-# libodr_jni.so per ABI, built together and published from OpenDocument.core.
+# odrcore's JNI bindings, java and native in one AAR, published from OpenDocument.core
 odrCore = "6.2.0"
 
 androidxAnnotation = "1.10.0"

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,11 +6,9 @@ pluginManagement {
     }
 }
 
-// odr-core-android carries both halves of odrcore's JNI bindings - the java classes and
-// a libodr_jni.so per ABI, built together and published as one AAR - so the pair cannot
-// drift the way two separately versioned artifacts could. It comes from maven central
-// rather than github packages on purpose: github packages demands authentication even
-// for a public artifact, which no clean source builder such as f-droid can supply.
+// odr-core-android holds odrcore's java classes and libodr_jni.so in one AAR, so the two
+// halves cannot drift apart. From maven central rather than github packages, which wants
+// authentication even for a public artifact - f-droid and other clean builders have none.
 dependencyResolutionManagement {
     repositories {
         google()

--- a/tools/render-sweep/README.md
+++ b/tools/render-sweep/README.md
@@ -3,7 +3,7 @@
 Opens every document of a corpus on a connected device, one at a time, and screenshots
 what the app made of it.
 
-The instrumented tests open nine files. `OpenDocument.core`'s own input corpus has a couple
+The instrumented tests open ten files. `OpenDocument.core`'s own input corpus has a couple
 of hundred, across formats no test here touches, and the app now hands almost all of them to
 `CoreLoader` (see the supported-file-types section of `CLAUDE.md`). This walks that corpus so
 a format that renders blank, renders half, or takes the process down with it is something you
@@ -60,6 +60,7 @@ The `signal` column is a triage hint, not a verdict:
 | `encrypted` | the password dialog came up (expected for the encrypted fixtures) |
 | `unsupported` | the app put up its "try opening it in another app" snackbar |
 | `upload-offer` | the core declined it and the app offered to convert it online |
+| `broken-file` | the app claimed the format and then failed on the file — "Couldn't open this file" |
 | `still-rendering` | the screen was still changing when the shutter gave up — see below |
 | `launch-*` | `am start` itself did not report `ok` |
 
@@ -92,9 +93,9 @@ site, in more detail:
   `/sdcard/Android/data/<pkg>`, which comes back `EACCES` when shell owns the file. Piping
   into internal storage via `run-as` is the route that works, and it is why this needs the
   debug build rather than the store one.
-- **The intent carries no mime type.** That leaves `MetadataLoader`'s libmagic detection in
-  the path instead of taking a caller's word for the type, which is the half of the app worth
-  exercising.
+- **The intent carries no mime type.** That leaves the app's own detection (`Odr.mimetype`, run
+  by `MetadataLoader`) in the path instead of taking a caller's word for the type, which is the
+  half of the app worth exercising.
 - **`uiautomator dump` runs twice per document.** A WebView only builds its accessibility
   tree once something asks for one, so the first dump after a load has no text in it and the
   second has the document.

--- a/tools/render-sweep/render-sweep.sh
+++ b/tools/render-sweep/render-sweep.sh
@@ -119,32 +119,22 @@ while IFS= read -r rel <&3; do
   "$ADB" shell am force-stop "$PKG" >/dev/null 2>&1
   "$ADB" logcat -c -b all >/dev/null 2>&1
 
-  # The app declares only INTERNET, so it cannot read a file pushed anywhere on
-  # shared storage - even its own /sdcard/Android/data/<pkg> comes back EACCES
-  # when the file is owned by shell. Piping it into the app's internal storage
-  # through run-as (which the debug build allows) is the one route that works.
-  #
-  # It lands as doc.<ext> rather than under its own name so that names with
-  # spaces, '$' or '+' need no quoting here and no percent-encoding in the URI
-  # below. Only the extension carries information the app might use.
+  # The app declares only INTERNET, so a file pushed to shared storage is unreadable
+  # to it; run-as into its internal storage is the one route that works. It lands as
+  # doc.<ext> so names with spaces, '$' or '+' need no quoting or percent-encoding.
   "$ADB" shell run-as "$PKG" sh -c "rm -f files/sweep/doc.*" >/dev/null 2>&1
   "$ADB" shell "run-as $PKG sh -c 'cat > files/sweep/doc.$ext'" < "$src" >/dev/null 2>&1
 
-  # No -t: leaving the mime type off is what a real opener rarely does, but it
-  # puts MetadataLoader's libmagic detection in the path instead of taking the
-  # caller's word for it, which is the more interesting half of the app.
+  # No -t: leaving the mime type off puts the app's own detection (Odr.mimetype, via
+  # MetadataLoader) in the path instead of taking the caller's word for it.
   launch=$("$ADB" shell am start -W -a android.intent.action.VIEW \
       -d "file:///data/data/$PKG/files/sweep/doc.$ext" \
       -n "$PKG/$ALIAS_SUFFIX" 2>&1 | grep -E '^Status:' | head -1 | awk '{print $2}')
   [ -z "$launch" ] && launch=nostart
 
-  # Rendering is not something the app signals from outside, so this waits - and a
-  # fixed wait is not enough. A 5MB .doc was still showing "Loading..." at 11s and a
-  # 284KB .csv was still a blank white page at 6s; both render fine given a minute,
-  # so a fixed shutter reports slow documents as broken ones.
-  #
-  # Instead: shoot, wait, shoot again, and keep going until two frames agree in size
-  # to within 1% (the clock and battery icon change, so they are never byte-equal).
+  # A fixed shutter reports slow documents as broken ones: a 5MB .doc still showed
+  # "Loading..." at 11s and rendered fine given a minute. So shoot until two frames
+  # agree in size to within 1% (the clock ticks, so they are never byte-equal).
   wait=$(( 4 + bytes / 2000000 ))
   [ $wait -gt 12 ] && wait=12
   sleep $wait
@@ -197,6 +187,9 @@ while IFS= read -r rel <&3; do
   grep -q "This document is password-protected" "$OUT/ui/$idx.xml" && signal=encrypted
   grep -q "doesn't seem to be a supported file format" "$OUT/ui/$idx.xml" && signal=upload-offer
   grep -q "Unsupported file format" "$OUT/ui/$idx.xml" && signal=unsupported
+  # DocumentFragment's dialog for a format it claimed and then could not render, which is the
+  # failure this sweep exists to find - without this such a document is recorded as ok
+  grep -q "Couldn't open this file" "$OUT/ui/$idx.xml" && signal=broken-file
   [ "$launch" != "ok" ] && signal=launch-$launch
 
   # settled=no means the shutter gave up before the screen stopped changing, so a

--- a/tools/screen-tour/README.md
+++ b/tools/screen-tour/README.md
@@ -83,8 +83,9 @@ document the app reached a way no user can would defeat the point.
 
 **Nothing is seeded into the app's own storage.** Writing three entries into
 `recent_documents.json` would be quicker than opening three documents through a picker, and
-would produce a screenshot of a list the app then throws away: the uris carry no grant, and
-`LandingViewModel.reload()` drops what it cannot resolve.
+would produce a screenshot of a list the app cannot use: the uris carry no grant, so opening
+one of those rows fails. `RecentDocumentDialogFragment.loadRecentDocuments()` reads the list
+straight off disk and shows whatever is in it, grant or no grant.
 
 **Each step looks for several things.** The two designs put their actions in different
 places - a toolbar and a floating button - so `MORE_BUTTON`, `OPEN_BUTTON` and the rest are

--- a/tools/screen-tour/collage.py
+++ b/tools/screen-tour/collage.py
@@ -130,6 +130,9 @@ class Sheet:
 
 
 def shot_path(sets, name, shot):
+    if name not in sets:
+        sys.exit(f"no --set named {name} (story asks for it; got {', '.join(sets) or 'none'})")
+
     path = os.path.join(sets[name], f"{shot}.png")
     if not os.path.exists(path):
         sys.exit(f"no {shot}.png in the {name} set ({sets[name]})")
@@ -137,7 +140,16 @@ def shot_path(sets, name, shot):
     return path
 
 
-def cover(story, sets, dpi):
+def pages_for(story, sets):
+    """The story's pages, minus the ones naming a set this run was not given."""
+    return [
+        page
+        for page in story["pages"]
+        if all(column["set"] in sets for column in page["columns"])
+    ]
+
+
+def cover(story, pages, sets, dpi):
     sheet = Sheet(dpi)
     title = sheet.font("bold", 30)
     heading = sheet.font("bold", 12)
@@ -151,42 +163,45 @@ def cover(story, sets, dpi):
     sheet.rule(MARGIN, MARGIN + 122, PAGE_W - MARGIN * 2)
 
     # the contact sheet: every page that compares two sets, one column each
-    pairs = [page for page in story["pages"] if len(page["columns"]) == 2]
-    gap = 8
-    tile_w = (PAGE_W - MARGIN * 2 - gap * (len(pairs) - 1)) / len(pairs)
+    pairs = [page for page in pages if len(page["columns"]) == 2]
+    y = MARGIN + 172
 
-    sample = Image.open(shot_path(sets, pairs[0]["columns"][0]["set"], pairs[0]["shot"]))
-    tile_h = tile_w * sample.height / sample.width
+    if pairs:
+        gap = 8
+        tile_w = (PAGE_W - MARGIN * 2 - gap * (len(pairs) - 1)) / len(pairs)
 
-    rows = [pairs[0]["columns"][0]["set"], pairs[0]["columns"][1]["set"]]
-    y_top = MARGIN + 172
-    tops = [y_top, y_top + tile_h + 34]
+        sample = Image.open(shot_path(sets, pairs[0]["columns"][0]["set"], pairs[0]["shot"]))
+        tile_h = tile_w * sample.height / sample.width
 
-    for name, top in zip(rows, tops):
-        sheet.text(MARGIN, top - 16, name.upper(), heading, ACCENT)
+        rows = [pairs[0]["columns"][0]["set"], pairs[0]["columns"][1]["set"]]
+        tops = [y, y + tile_h + 34]
 
-    for index, page in enumerate(pairs):
-        x = MARGIN + index * (tile_w + gap)
         for name, top in zip(rows, tops):
-            image = Image.open(shot_path(sets, name, page["shot"]))
-            image = image.resize(
-                (sheet.px(tile_w), sheet.px(tile_h)), Image.LANCZOS
-            ).convert("RGB")
-            sheet.paste(image, x, top)
-            sheet.draw.rectangle(
-                (
-                    sheet.px(x),
-                    sheet.px(top),
-                    sheet.px(x + tile_w) - 1,
-                    sheet.px(top + tile_h) - 1,
-                ),
-                outline=(205, 205, 212),
-            )
+            sheet.text(MARGIN, top - 16, name.upper(), heading, ACCENT)
 
-        caption = page["title"].split("·", 1)[-1].strip()
-        sheet.paragraph(x, tops[1] + tile_h + 6, caption, tiny, MUTED, tile_w, 11)
+        for index, page in enumerate(pairs):
+            x = MARGIN + index * (tile_w + gap)
+            for name, top in zip(rows, tops):
+                image = Image.open(shot_path(sets, name, page["shot"]))
+                image = image.resize(
+                    (sheet.px(tile_w), sheet.px(tile_h)), Image.LANCZOS
+                ).convert("RGB")
+                sheet.paste(image, x, top)
+                sheet.draw.rectangle(
+                    (
+                        sheet.px(x),
+                        sheet.px(top),
+                        sheet.px(x + tile_w) - 1,
+                        sheet.px(top + tile_h) - 1,
+                    ),
+                    outline=(205, 205, 212),
+                )
 
-    y = tops[1] + tile_h + 52
+            caption = page["title"].split("·", 1)[-1].strip()
+            sheet.paragraph(x, tops[1] + tile_h + 6, caption, tiny, MUTED, tile_w, 11)
+
+        y = tops[1] + tile_h + 52
+
     y = sheet.paragraph(MARGIN, y, story["footer"], small, MUTED, PAGE_W - MARGIN * 2, 14)
 
     summary = story.get("summary")
@@ -309,8 +324,17 @@ def main():
     with open(args.story, encoding="utf-8") as handle:
         story = json.load(handle)
 
-    pages = [cover(story, sets, args.dpi)]
+    wanted = pages_for(story, sets)
+    if not wanted:
+        sys.exit(f"no page of {args.story} names only sets that were passed")
+
     for page in story["pages"]:
+        missing = [c["set"] for c in page["columns"] if c["set"] not in sets]
+        if missing:
+            print(f"skipping {page['shot']}: no --set for {', '.join(missing)}")
+
+    pages = [cover(story, wanted, sets, args.dpi)]
+    for page in wanted:
         builder = pair_page if len(page["columns"]) == 2 else solo_page
         pages.append(builder(page, sets, args.dpi))
 

--- a/tools/screen-tour/screen-tour.py
+++ b/tools/screen-tour/screen-tour.py
@@ -47,9 +47,15 @@ class Device:
         self.size = None
 
     def run(self, *args, **kwargs):
-        return subprocess.run(
-            self.adb + list(args), capture_output=True, text=True, **kwargs
-        ).stdout
+        done = subprocess.run(self.adb + list(args), capture_output=True, text=True, **kwargs)
+
+        # a failed install is the one outcome that invalidates the whole tour quietly: it
+        # photographs the build that was already on the device. shell is exempt, since a
+        # remote command failing is often the answer the caller asked for
+        if done.returncode != 0 and args[0] != "shell":
+            raise Tourfail(f"adb {args[0]} failed: {(done.stderr or done.stdout).strip()}")
+
+        return done.stdout
 
     def shell(self, *args):
         return self.run("shell", *args)
@@ -308,15 +314,10 @@ def launch(device, args, fresh):
     dismiss_consent(device)
 
 
-# The lite flavour asks for advertising consent before anything else. The dialog is
-# a web view that arrives whenever the ad sdk has finished starting up - a second or
-# ten after the landing screen is already drawn - so this cannot be a fixed wait: it
-# watches for either the dialog or a quiet screen, and photographing the app with a
-# consent sheet over it is exactly what a fixed wait gets you.
-#
-# Its buttons carry a description and no text, being web content, and a mistimed tap
-# lands on "Manage options" and opens the vendor list - so "Accept all", which is the
-# way out of that list, is one of the things looked for.
+# The lite flavour's consent dialog, which arrives whenever the ad sdk finishes starting
+# up - a second or ten after the landing screen is drawn, so this cannot be a fixed wait.
+# Its buttons are web content, and a mistimed tap lands on "Manage options" and opens the
+# vendor list - so "Accept all", the way out of that list, is looked for too.
 CONSENT_BUTTONS = [
     (r"^Accept all$", "text"),
     (r"^Accept all$", "content-desc"),
@@ -423,14 +424,14 @@ def main():
         print("no booted device on adb", file=sys.stderr)
         return 2
 
-    if args.install:
-        print(f"installing {args.install}", flush=True)
-        device.run("install", "-r", "-g", args.install)
-
-    push_documents(device, args)
-
-    print(f"touring {args.package} into {args.out}", flush=True)
     try:
+        if args.install:
+            print(f"installing {args.install}", flush=True)
+            device.run("install", "-r", "-g", args.install)
+
+        push_documents(device, args)
+
+        print(f"touring {args.package} into {args.out}", flush=True)
         tour(device, args, args.out)
     except Tourfail as failure:
         print(f"\nthe tour stopped: {failure}", file=sys.stderr)


### PR DESCRIPTION
A review pass over the whole repo. Roughly 460 lines lighter, and the comments in
Kotlin are down from 483 lines to 265.

## The four that actually bite

- **A failed load came back as a success.** `DocumentFragment.errorOnStart` was
  declared and cleared but never assigned, so every failure that arrived while the
  activity was stopped got replayed through `onLoadSuccess`. Background the app
  while a password-protected, corrupt or unsupported file is loading and you came
  back to a blank screen - no password prompt, no error, no upload offer - with a
  Play review prompt over it. Both fields are now one replay action.
- **`testODT` and `testPDF` asserted nothing.** `clickEditWithOverflowFallback()`
  built an `onView(...)` chain and never called `perform`, and Espresso's `onView`
  is lazy - so nothing was clicked and nothing ever synced on the idling resource.
  Verified on a device: `testODT` passed in 2.9s without touching Edit. These
  assertions run for the first time in this PR.
- **The js bridge stayed attached to the online viewers.** `addJavascriptInterface`
  ran in `init` and never came off, while `shouldOverrideUrlLoading` deliberately
  keeps the Google/Microsoft viewer pages in that same WebView. Those pages could
  call `sendFile()` to write a blob into our cache and have us open it. The bridge
  is now attached only for `file://` and the core's own server.
- **`render-sweep` scored broken files as `ok`**, because it had no signal for the
  "Couldn't open this file" dialog - now the main failure path.

## Leaks and lifecycle

`MetadataLoader` leaked a `CursorWindow` per provider with no `DISPLAY_NAME`.
`LoaderService.onDestroy` used `quit()`, throwing away the teardown each loader had
just posted, and `CoreLoader` cleared the server and closed the native document on
the main thread mid-load. `LoaderServiceQueue` never drained and kept a dead service
after a disconnect; `MainActivity` leaked its `ServiceConnection` when destroyed
before the binder arrived. `AdManager` leaked an `AdView` per rotation, ran UMP
callbacks against destroyed activities, and left `lateinit` fields unset on the path
billing takes. `RawLoader` wrote `temp.null` for extension-less XML and left a base64
copy of every CSV in the cache. Printing turned dark mode off permanently.

## Cleanup

Dead code out: `lastCachePath`, `isLoading`, `FALLBACK_SERVER_PORT` and the branch
that could never run, `open()`, the AOSP leftovers in `FindActionModeCallback` (whose
match counter was also permanently blank), ~18 whitelist entries shadowed by an
earlier prefix, and 8 duplicate `pathPattern` entries. `CoreTest` extracts its
fixtures 8 times per run instead of 88.

CI: `release.yml` interpolated the keystore secret into a `run:` line, 33 lines below
a comment saying not to; the `install ninja` step outlived the build that needed it;
the dependabot `test` group could never match anything; spotless was checking one
shell script out of six and no Python.

## Stale docs

`CLAUDE.md` said libmagic (it's `Odr.mimetype`), "40 spellings" (49), and that
`spotlessCheck` runs first in CI. `app/build.gradle` and the `Fastfile` said the
version is the git tag - the scheme `release.yml` exists to replace.
`screen-tour/README.md` pointed at a `LandingViewModel` that does not exist.

## Left alone, on purpose

`connectedCheck` still runs the suite for both flavors (10 emulator runs per PR)
though they differ only in two `DISABLE_TRACKING` reads, and `proguard-rules.txt`
keeps its unexplained `-keep public class * extends java.lang.Exception`. Both are
judgement calls worth making deliberately rather than in a review PR.

## Verification

`spotlessCheck`, both flavors compiling, `compileProDebugAndroidTestKotlin`,
`testProDebugUnitTest`, `lintProDebug`, plus YAML/shell/Python syntax - all green.
The instrumented suite needs an emulator and has not been run; it is worth running
here specifically, since its assertions are live for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)