### PR TITLE
Drop the -pro suffix from the pro flavor's version name

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -110,9 +110,6 @@ android {
         }
 
         pro {
-            // the suffix on the applicationId is what separates the two listings, so the
-            // version name stays plain - it is only ever read by a human, in the store and
-            // in the system settings
             applicationIdSuffix = ".pro"
 
             if (hasReleaseSigning) {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -110,8 +110,10 @@ android {
         }
 
         pro {
+            // the suffix on the applicationId is what separates the two listings, so the
+            // version name stays plain - it is only ever read by a human, in the store and
+            // in the system settings
             applicationIdSuffix = ".pro"
-            versionNameSuffix = "-pro"
 
             if (hasReleaseSigning) {
                 signingConfig = signingConfigs.releasePro


### PR DESCRIPTION
`versionNameSuffix = "-pro"` did no work, so it is gone. `applicationIdSuffix = ".pro"` stays - that one is the identity on Play and F-Droid.

Nothing reads the version name: no code in the tree looks at its own version, and the release pipeline derives tags and the changelog section from the run's `version` input rather than from the built artifact. The suffix only ever reached a human, as "4.8.0-pro" in the store listing and in the system settings, where the two flavors are already separate listings under separate applicationIds.

Play compares version *codes*, so existing pro installs are unaffected - the next release just reads "4.9.0" instead of "4.9.0-pro".

Verified on a `assembleProDebug -Podr.version=v4.8.0` build:

```
package: name='at.tomtasche.reader.pro' versionCode='40800' versionName='4.8.0'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)