### PR TITLE
Name the flavor flag after what it switches, and stop gating logging on play services

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,7 @@ lists rather than forking it. Reach for it before `adb shell input tap`.
 
 ## Build
 
-Three flavors. `DISABLE_TRACKING`, a resource bool read by the `nonfree/` managers,
-switches the behaviour off; what a flavor *links* matters more:
+Three flavors, and what separates them is what they *link*:
 
 | | ads + consent sdk | play in-app review | goes to |
 |---|---|---|---|
@@ -56,6 +55,14 @@ and `src/review`, with a no-op of the same shape in `src/noAds` and `src/noRevie
 `app/build.gradle` names two of the four per flavor. The rest of `nonfree/` imports
 nothing proprietary and stays in `src/main`. A method added to one copy has to be added
 to the other, which `assembleDebug` catches - it builds all three.
+
+Code that has to *ask* reads `Features`, never the flavor name: `Features.withAds` is the
+one question anything asks today, and `LINKS_ADS` behind it sits in `src/ads` and
+`src/noAds` next to the classes it stands for, so the flag cannot end up in a build whose
+code says otherwise. Do not add a `BuildConfig.FLAVOR` comparison back - it was what made
+`BillingManager` miss foss - and do not name a flag after a behaviour it only implies. The
+resource bool `DISABLE_TRACKING` was both mistakes at once: there is no tracking to
+disable, `AnalyticsManager` and `CrashManager` write to logcat and nowhere else.
 
 foss carries `applicationIdSuffix .foss` so a sideload sits beside a play install;
 f-droid strips it, since its listing is `at.tomtasche.reader` and that can never change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,11 @@ code says otherwise. Do not add a `BuildConfig.FLAVOR` comparison back - it was 
 resource bool `DISABLE_TRACKING` was both mistakes at once: there is no tracking to
 disable, `AnalyticsManager` and `CrashManager` write to logcat and nowhere else.
 
+Those two take no switch at all, which is why `LoaderService` just constructs them. Ads
+and billing are what `MainActivity.initializeManagers` gates, on `Features.withAds` *and*
+`PlayServices` - the device half of the answer, and the reason that method can run twice,
+once more after google's own dialog comes back.
+
 foss carries `applicationIdSuffix .foss` so a sideload sits beside a play install;
 f-droid strips it, since its listing is `at.tomtasche.reader` and that can never change.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -105,8 +105,6 @@ android {
             if (hasReleaseSigning) {
                 signingConfig = signingConfigs.releaseLite
             }
-
-            resValue("bool", "DISABLE_TRACKING", "false")
         }
 
         pro {
@@ -115,8 +113,6 @@ android {
             if (hasReleaseSigning) {
                 signingConfig = signingConfigs.releasePro
             }
-
-            resValue("bool", "DISABLE_TRACKING", "true")
         }
 
         // pro without the play in-app review sheet, so it links nothing proprietary:
@@ -127,14 +123,13 @@ android {
             if (hasReleaseSigning) {
                 signingConfig = signingConfigs.releaseLite
             }
-
-            resValue("bool", "DISABLE_TRACKING", "true")
         }
     }
 
     // The nonfree/ classes that call a play library, or a no-op of the same shape - two
-    // pairs, because the flavors disagree on both halves. kotlin.srcDirs and not
-    // java.srcDirs: a directory added to the latter reaches javac only.
+    // pairs, because the flavors disagree on both halves. What a flavor links is a flag in
+    // these directories too, read through Features, rather than a second list here.
+    // kotlin.srcDirs and not java.srcDirs: a directory added to the latter reaches javac only.
     sourceSets {
         getByName('lite') { kotlin.srcDirs += ['src/ads/java', 'src/review/java'] }
         getByName('pro') { kotlin.srcDirs += ['src/noAds/java', 'src/review/java'] }
@@ -177,8 +172,6 @@ android {
     }
     buildFeatures {
         buildConfig = true
-        // AGP 9 makes resValue opt-in; the flavors use it for DISABLE_TRACKING
-        resValues = true
     }
     // the java/kotlin package, R and BuildConfig - internal and free to rename, unlike
     // the applicationId above. testNamespace defaults to this + ".test".

--- a/app/src/ads/java/app/opendocument/droid/nonfree/Linked.kt
+++ b/app/src/ads/java/app/opendocument/droid/nonfree/Linked.kt
@@ -1,0 +1,4 @@
+package app.opendocument.droid.nonfree
+
+/** Read through [Features]. */
+internal const val LINKS_ADS = true

--- a/app/src/ads/java/app/opendocument/droid/nonfree/PlayServices.kt
+++ b/app/src/ads/java/app/opendocument/droid/nonfree/PlayServices.kt
@@ -1,19 +1,14 @@
 package app.opendocument.droid.nonfree
 
 import android.app.Activity
-import android.content.Context
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 
-/** Whether the device has the play services everything else in this package talks to. */
+/** Whether the device has the play services the ad and consent sdks talk to. */
 object PlayServices {
 
-    fun isAvailable(context: Context): Boolean =
-        GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context) ==
-            ConnectionResult.SUCCESS
-
     /**
-     * As [isAvailable], and on a no shows google's own dialog. It reports back through
+     * Whether they are there, and on a no shows google's own dialog. It reports back through
      * [Activity.onActivityResult] under [requestCode], calling `startActivityForResult` itself.
      */
     fun isAvailableOrOffersFix(activity: Activity, requestCode: Int): Boolean {

--- a/app/src/main/java/app/opendocument/droid/background/LoaderService.kt
+++ b/app/src/main/java/app/opendocument/droid/background/LoaderService.kt
@@ -8,10 +8,10 @@ import android.os.Handler
 import android.os.HandlerThread
 import android.os.IBinder
 import android.os.Looper
-import app.opendocument.droid.R
 import app.opendocument.droid.nonfree.AnalyticsConstants
 import app.opendocument.droid.nonfree.AnalyticsManager
 import app.opendocument.droid.nonfree.CrashManager
+import app.opendocument.droid.nonfree.Features
 import app.opendocument.droid.nonfree.PlayServices
 import app.opendocument.droid.ui.activity.DocumentFragment
 import java.io.File
@@ -81,7 +81,7 @@ class LoaderService : Service(), FileLoader.FileLoaderListener {
 
     // copied from MainActivity, consider how to deduplicate
     private fun initializeProprietaryLibraries() {
-        var useProprietaryLibraries = !resources.getBoolean(R.bool.DISABLE_TRACKING)
+        var useProprietaryLibraries = Features.withAds
 
         if (useProprietaryLibraries) {
             useProprietaryLibraries = PlayServices.isAvailable(this)

--- a/app/src/main/java/app/opendocument/droid/background/LoaderService.kt
+++ b/app/src/main/java/app/opendocument/droid/background/LoaderService.kt
@@ -11,8 +11,6 @@ import android.os.Looper
 import app.opendocument.droid.nonfree.AnalyticsConstants
 import app.opendocument.droid.nonfree.AnalyticsManager
 import app.opendocument.droid.nonfree.CrashManager
-import app.opendocument.droid.nonfree.Features
-import app.opendocument.droid.nonfree.PlayServices
 import app.opendocument.droid.ui.activity.DocumentFragment
 import java.io.File
 
@@ -52,7 +50,11 @@ class LoaderService : Service(), FileLoader.FileLoaderListener {
 
         backgroundHandler = Handler(backgroundThread.looper)
 
-        initializeProprietaryLibraries()
+        crashManager = CrashManager()
+        crashManager.initialize()
+
+        analyticsManager = AnalyticsManager()
+        analyticsManager.initialize(this)
 
         metadataLoader = MetadataLoader(this)
         metadataLoader.initialize(
@@ -77,23 +79,6 @@ class LoaderService : Service(), FileLoader.FileLoaderListener {
             analyticsManager,
             crashManager,
         )
-    }
-
-    // copied from MainActivity, consider how to deduplicate
-    private fun initializeProprietaryLibraries() {
-        var useProprietaryLibraries = Features.withAds
-
-        if (useProprietaryLibraries) {
-            useProprietaryLibraries = PlayServices.isAvailable(this)
-        }
-
-        crashManager = CrashManager()
-        crashManager.setEnabled(useProprietaryLibraries)
-        crashManager.initialize()
-
-        analyticsManager = AnalyticsManager()
-        analyticsManager.setEnabled(useProprietaryLibraries)
-        analyticsManager.initialize(this)
     }
 
     override fun onBind(intent: Intent?): IBinder = LoaderBinder()

--- a/app/src/main/java/app/opendocument/droid/nonfree/AnalyticsManager.kt
+++ b/app/src/main/java/app/opendocument/droid/nonfree/AnalyticsManager.kt
@@ -10,13 +10,7 @@ import android.util.Log
  */
 class AnalyticsManager {
 
-    private var enabled = false
-
     fun initialize(context: Context) {}
-
-    fun setEnabled(enabled: Boolean) {
-        this.enabled = enabled
-    }
 
     fun report(
         event: String,
@@ -25,10 +19,6 @@ class AnalyticsManager {
         key2: String? = null,
         value2: Any? = null,
     ) {
-        if (!enabled) {
-            return
-        }
-
         // keys only: callers pass document uris as values, which have no business in logcat
         Log.i(
             TAG,
@@ -41,10 +31,6 @@ class AnalyticsManager {
     }
 
     fun setCurrentScreen(activity: Activity, name: String) {
-        if (!enabled) {
-            return
-        }
-
         Log.i(TAG, "screen $name (${activity.javaClass.simpleName})")
     }
 

--- a/app/src/main/java/app/opendocument/droid/nonfree/BillingManager.kt
+++ b/app/src/main/java/app/opendocument/droid/nonfree/BillingManager.kt
@@ -1,7 +1,6 @@
 package app.opendocument.droid.nonfree
 
 import android.content.Context
-import app.opendocument.droid.R
 import app.opendocument.droid.background.BillingPreferences
 
 class BillingManager {
@@ -18,7 +17,7 @@ class BillingManager {
         billingPreferences = preferences
 
         // pro and foss both ship without ads, so both count as bought
-        if (context.resources.getBoolean(R.bool.DISABLE_TRACKING)) {
+        if (!Features.withAds) {
             preferences.setPurchased(true)
         }
 

--- a/app/src/main/java/app/opendocument/droid/nonfree/CrashManager.kt
+++ b/app/src/main/java/app/opendocument/droid/nonfree/CrashManager.kt
@@ -4,15 +4,13 @@ import android.net.Uri
 import android.util.Log
 import java.util.concurrent.TimeoutException
 
+/**
+ * Reporting a crash has been local logging only since the crashlytics integration was removed; the
+ * call sites are kept so a reporting backend can be wired back in here.
+ */
 class CrashManager {
 
-    private var enabled = false
-
     fun initialize() {
-        if (!enabled) {
-            return
-        }
-
         // mitigate TimeoutException on finalize
         // https://stackoverflow.com/a/55999687/198996
         val defaultUncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
@@ -25,34 +23,16 @@ class CrashManager {
         }
     }
 
-    fun setEnabled(enabled: Boolean) {
-        this.enabled = enabled
-    }
-
     fun log(message: String) {
-        if (!enabled) {
-            return
-        }
-
         Log.d(TAG, message)
     }
 
     fun log(error: Throwable, uri: Uri?) {
-        if (!enabled) {
-            return
-        }
-
         Log.d(TAG, "could not load document at: " + (uri?.toString() ?: "null"))
         log(error)
     }
 
     fun log(error: Throwable) {
-        error.printStackTrace()
-
-        if (!enabled) {
-            return
-        }
-
         Log.e(TAG, "Error reported", error)
     }
 

--- a/app/src/main/java/app/opendocument/droid/nonfree/Features.kt
+++ b/app/src/main/java/app/opendocument/droid/nonfree/Features.kt
@@ -1,0 +1,15 @@
+package app.opendocument.droid.nonfree
+
+/**
+ * What this build links, asked by name rather than by flavor.
+ *
+ * The answer comes from [LINKS_ADS], which the `ads` and `noAds` source sets define next to the
+ * classes it describes, so the flag and the code it stands for cannot disagree.
+ */
+object Features {
+
+    /**
+     * The ad banner, the consent form and the ad removal purchase: lite, and neither of the rest.
+     */
+    val withAds = LINKS_ADS
+}

--- a/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
@@ -211,7 +211,7 @@ class MainActivity : AppCompatActivity() {
         }
 
         printingManager = PrintingManager()
-        initializeProprietaryLibraries()
+        initializeManagers()
 
         // has to happen here rather than in LandingFragment: users upgrading from a version
         // with different alias defaults have to be corrected even when the app is launched
@@ -382,23 +382,20 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun initializeProprietaryLibraries() {
-        var useProprietaryLibraries = Features.withAds
-
-        if (useProprietaryLibraries) {
-            useProprietaryLibraries = PlayServices.isAvailableOrOffersFix(this, GOOGLE_REQUEST_CODE)
-        }
+    private fun initializeManagers() {
+        // the ad and consent sdks are the only thing left that needs play services on the device,
+        // and a flavor without them never asks - the dialog would offer a fix for nothing
+        val adsAvailable =
+            Features.withAds && PlayServices.isAvailableOrOffersFix(this, GOOGLE_REQUEST_CODE)
 
         crashManager = CrashManager()
-        crashManager.setEnabled(useProprietaryLibraries)
         crashManager.initialize()
 
         analyticsManager = AnalyticsManager()
-        analyticsManager.setEnabled(useProprietaryLibraries)
         analyticsManager.initialize(this)
 
         adManager = AdManager()
-        adManager.setEnabled(!IS_TESTING && useProprietaryLibraries)
+        adManager.setEnabled(!IS_TESTING && adsAvailable)
         adManager.setAdContainer(adContainer)
         // the landing screen is drawn long before the consent update comes back, and the privacy
         // options row only exists once it has
@@ -407,7 +404,7 @@ class MainActivity : AppCompatActivity() {
         adManager.initialize(this, analyticsManager, crashManager)
 
         billingManager = BillingManager()
-        billingManager.setEnabled(useProprietaryLibraries)
+        billingManager.setEnabled(adsAvailable)
         billingManager.initialize(this, adManager)
     }
 
@@ -435,7 +432,7 @@ class MainActivity : AppCompatActivity() {
         super.onActivityResult(requestCode, resultCode, intent)
 
         if (requestCode == GOOGLE_REQUEST_CODE) {
-            initializeProprietaryLibraries()
+            initializeManagers()
         }
     }
 
@@ -665,8 +662,8 @@ class MainActivity : AppCompatActivity() {
      * and not once it has been bought.
      *
      * The landing screen asks rather than being told, because billing is set up by
-     * [initializeProprietaryLibraries] - which can run a second time, after the play services
-     * dialog - and it is not something the ViewModel could read off disk itself.
+     * [initializeManagers] - which can run a second time, after the play services dialog - and it
+     * is not something the ViewModel could read off disk itself.
      */
     fun offersAdRemoval(): Boolean =
         ::billingManager.isInitialized && !billingManager.hasPurchased()

--- a/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
@@ -35,6 +35,7 @@ import app.opendocument.droid.nonfree.AnalyticsConstants
 import app.opendocument.droid.nonfree.AnalyticsManager
 import app.opendocument.droid.nonfree.BillingManager
 import app.opendocument.droid.nonfree.CrashManager
+import app.opendocument.droid.nonfree.Features
 import app.opendocument.droid.nonfree.InAppReview
 import app.opendocument.droid.nonfree.PlayServices
 import app.opendocument.droid.ui.EditActionModeCallback
@@ -382,7 +383,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun initializeProprietaryLibraries() {
-        var useProprietaryLibraries = !resources.getBoolean(R.bool.DISABLE_TRACKING)
+        var useProprietaryLibraries = Features.withAds
 
         if (useProprietaryLibraries) {
             useProprietaryLibraries = PlayServices.isAvailableOrOffersFix(this, GOOGLE_REQUEST_CODE)

--- a/app/src/noAds/java/app/opendocument/droid/nonfree/Linked.kt
+++ b/app/src/noAds/java/app/opendocument/droid/nonfree/Linked.kt
@@ -1,0 +1,4 @@
+package app.opendocument.droid.nonfree
+
+/** Read through [Features]. */
+internal const val LINKS_ADS = false

--- a/app/src/noAds/java/app/opendocument/droid/nonfree/PlayServices.kt
+++ b/app/src/noAds/java/app/opendocument/droid/nonfree/PlayServices.kt
@@ -1,12 +1,9 @@
 package app.opendocument.droid.nonfree
 
 import android.app.Activity
-import android.content.Context
 
 /** Play services, in a build that links none of them and so would never call them. */
 object PlayServices {
-
-    fun isAvailable(context: Context): Boolean = false
 
     fun isAvailableOrOffersFix(activity: Activity, requestCode: Int): Boolean = false
 }


### PR DESCRIPTION
`DISABLE_TRACKING` named a dependency that has left. `AnalyticsManager` and
`CrashManager` write to logcat and nowhere else since firebase went, so there is no
tracking for it to disable - what the bool actually decided is whether this build has
the ad and consent sdks. After #574 the `ads`/`noAds` source sets decide that too, so
one fact had two switches free to disagree.

## `Features.withAds`

The flag moves next to the code it stands for: `LINKS_ADS` in `src/ads` and
`src/noAds`, read through a `Features` object in `src/main`. A flavor cannot pick the
no-op classes and claim it has ads, because the answer ships in the same directory.

```kotlin
object Features {
    /** The ad banner, the consent form and the ad removal purchase: lite, and neither of the rest. */
    val withAds = LINKS_ADS
}
```

Three read sites change, the `!getBoolean(DISABLE_…)` double negative goes with them,
and `resValues` was on only for this so it goes back off. No behaviour changes in this
commit - the three flavors' values are what the resource bool said.

No `withGoogleServices` alongside it: `PlayServices` lives in `src/ads`, so it would be
`withAds` under a second name, and two names for one fact is what this is undoing.
`withInAppReview` is missing for the same reason - nothing asks, the no-op in
`src/noReview` is the whole mechanism.

## The logging was gated on the wrong thing

Second commit, and the only behaviour change. Those two managers took their `enabled`
from the same flag, narrowed by whether the device has play services - so pro and foss
logged nothing, and lite on a device without play services logged nothing either.
Neither manager reaches a network, so this withheld nothing from anyone; it only cost
the app its own logs, and made `CrashManager`'s finalizer watchdog mitigation a
lite-only fix. The field goes.

`log(error)` also drops the `printStackTrace()` that ran ahead of the guard - with the
`Log.e` below it now unconditional, it was the same trace twice.

What is left to gate is ads and billing, which `MainActivity.initializeManagers`
(renamed - it initializes more than proprietary libraries) now says in one line:
`Features.withAds` and then the device probe that gives the method its second run.
`LoaderService` needs neither, so it just constructs the two managers and its
`// copied from MainActivity, consider how to deduplicate` copy is gone, along with the
`PlayServices.isAvailable` overload it was the only caller of.

## Checked

`assembleDebug` (all three flavors), `spotlessCheck`, `lintProDebug` / `lintFossDebug`,
and unit tests per flavor - 26 tests, no failures. Instrumented tests left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)