### PR TITLE
Run the save callback once per tap

### DIFF
--- a/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
@@ -199,12 +199,7 @@ class MainActivityTests {
         assertBecomesEditable("DOCX", pageView!!, documentFragment)
     }
 
-    /**
-     * A full save copies the file on disk, so it has no use for a diff. It used to ask the page for
-     * one anyway and save again when the answer arrived, which put a second create-document picker
-     * over the first - harmless only while `odr.generateDiff()` was absent outside edit mode, which
-     * it no longer is.
-     */
+    /** A full save needs no diff from the page, and must not ask for one and then save twice. */
     @Test
     fun testSaveOpensOneCreateDocumentPicker() {
         val activity = mainActivityActivityTestRule.activity
@@ -218,8 +213,8 @@ class MainActivityTests {
             activity.onDocumentAction(DocumentActions.ACTION_SAVE)
         }
 
-        // a plain wait, because this asserts that something does not happen: the second picker
-        // only arrived once the web view had answered, which is a round trip nothing idles on
+        // a plain wait: this asserts something does not happen, after a web view round trip
+        // that nothing idles on
         SystemClock.sleep(3000)
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
 

--- a/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
@@ -20,6 +20,7 @@ import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.VerificationModes.times
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withClassName
@@ -36,6 +37,7 @@ import app.opendocument.droid.ui.EditActionModeCallback
 import app.opendocument.droid.ui.OpenFileIdling
 import app.opendocument.droid.ui.activity.DocumentFragment
 import app.opendocument.droid.ui.activity.MainActivity
+import app.opendocument.droid.ui.widget.DocumentActions
 import app.opendocument.droid.ui.widget.PageView
 import java.io.File
 import java.io.FileOutputStream
@@ -195,6 +197,33 @@ class MainActivityTests {
         Assert.assertNotNull(pageView)
 
         assertBecomesEditable("DOCX", pageView!!, documentFragment)
+    }
+
+    /**
+     * A full save copies the file on disk, so it has no use for a diff. It used to ask the page for
+     * one anyway and save again when the answer arrived, which put a second create-document picker
+     * over the first - harmless only while `odr.generateDiff()` was absent outside edit mode, which
+     * it no longer is.
+     */
+    @Test
+    fun testSaveOpensOneCreateDocumentPicker() {
+        val activity = mainActivityActivityTestRule.activity
+        loadDocument(activity, requireTestFile("test.odt"))
+
+        // cancelled: how many pickers were opened is the whole question, not what came back
+        Intents.intending(hasAction(Intent.ACTION_CREATE_DOCUMENT))
+            .respondWith(Instrumentation.ActivityResult(Activity.RESULT_CANCELED, null))
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            activity.onDocumentAction(DocumentActions.ACTION_SAVE)
+        }
+
+        // a plain wait, because this asserts that something does not happen: the second picker
+        // only arrived once the web view had answered, which is a round trip nothing idles on
+        SystemClock.sleep(3000)
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        Intents.intended(hasAction(Intent.ACTION_CREATE_DOCUMENT), times(1))
     }
 
     @Test

--- a/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
@@ -319,16 +319,29 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener {
         loadWithType(lastResult.loaderType, lastResult.options)
     }
 
+    /**
+     * Collects whatever the save needs and then runs [callback] - exactly once, whichever way it
+     * got there.
+     *
+     * A full save writes the file as it is on disk, so there is no diff to ask the page for. It
+     * used to ask anyway and run [callback] a second time when the answer came back. That was
+     * harmless only while `odr.generateDiff()` existed in edit mode alone: odrcore writes its
+     * script into every document now, so the call succeeds while merely reading one, and the second
+     * run opened a second create-document picker and turned a plain copy into a retranslation of an
+     * empty diff - which fails outright for a document the core cannot write back.
+     */
     fun prepareSave(callback: Runnable, fullSave: Boolean) {
-        if (fullSave) {
+        val pageView = this.pageView
+
+        if (fullSave || pageView == null) {
             state.currentHtmlDiff = null
 
             callback.run()
+
+            return
         }
 
-        // a full save runs the callback twice, so a second requestSave() would open the
-        // create-document picker twice - masked only by odr.generateDiff() existing in edit mode
-        pageView?.requestHtml { htmlDiff ->
+        pageView.requestHtml { htmlDiff ->
             state.currentHtmlDiff = htmlDiff
 
             callback.run()

--- a/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
@@ -320,15 +320,8 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener {
     }
 
     /**
-     * Collects whatever the save needs and then runs [callback] - exactly once, whichever way it
-     * got there.
-     *
-     * A full save writes the file as it is on disk, so there is no diff to ask the page for. It
-     * used to ask anyway and run [callback] a second time when the answer came back. That was
-     * harmless only while `odr.generateDiff()` existed in edit mode alone: odrcore writes its
-     * script into every document now, so the call succeeds while merely reading one, and the second
-     * run opened a second create-document picker and turned a plain copy into a retranslation of an
-     * empty diff - which fails outright for a document the core cannot write back.
+     * Collects whatever the save needs and runs [callback] - exactly once. A full save writes the
+     * file as it is on disk, so it has no diff to ask the page for.
      */
     fun prepareSave(callback: Runnable, fullSave: Boolean) {
         val pageView = this.pageView


### PR DESCRIPTION
Reported as "saving is broken". Tapping **Save** opens the create-document picker twice, and the save that follows takes the wrong path.

`prepareSave(callback, fullSave = true)` runs `callback` immediately and *then* asks the page for a diff, running `callback` a second time when the answer arrives. Its own comment named the reason that was survivable:

> masked only by `odr.generateDiff()` existing in edit mode

That has not been true since odrcore 6.2.0, which `main` is on: `write_document_script` is called unconditionally (`html/document.cpp`), so `odr.generateDiff()` answers while merely reading a document. The second run therefore happens, and it:

- opens a second `ACTION_CREATE_DOCUMENT` picker over the first, and
- leaves `currentHtmlDiff` set to `{"modifiedText":{}}`, so `saveSync` retranslates instead of copying the cached file — which throws `no editable document is open` for anything the core renders but cannot write back, e.g. a PDF or a legacy `.doc`.

A full save copies the file on disk and has no use for a diff, so it no longer asks for one. The null-`pageView` case now runs the callback too, instead of dropping the save silently.

Adds an instrumentation test that counts the pickers; it fails on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)