### PR TITLE
Align the analytics event names with OpenDocument.ios

### DIFF
--- a/app/src/ads/java/app/opendocument/droid/nonfree/AdManager.kt
+++ b/app/src/ads/java/app/opendocument/droid/nonfree/AdManager.kt
@@ -326,6 +326,8 @@ class AdManager {
 
         crashManager.log("house ad " + houseAdIndex + " at " + adWidth + "dp")
 
+        analyticsManager.report("house_ad_shown")
+
         // the 90dp slot, which only tablets get
         val wide = adWidth >= WIDE_WIDTH
 
@@ -358,7 +360,7 @@ class AdManager {
         }
 
         houseAd.setOnClickListener {
-            analyticsManager.report("house_ad")
+            analyticsManager.report("house_ad_tapped")
 
             onPurchaseRequested?.invoke()
         }

--- a/app/src/main/java/app/opendocument/droid/ui/EditActionModeCallback.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/EditActionModeCallback.kt
@@ -47,8 +47,7 @@ class EditActionModeCallback(
             return false
         }
 
-        // saving from edit mode is its own thing, and the name OpenDocument.ios already
-        // reports it under - menu_save is the button on the document itself
+        // OpenDocument.ios' name for this; menu_save is the button on the document itself
         activity.analyticsManager.report("menu_edit_save")
 
         documentFragment.prepareSave({ activity.requestSave() }, false)

--- a/app/src/main/java/app/opendocument/droid/ui/EditActionModeCallback.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/EditActionModeCallback.kt
@@ -47,6 +47,10 @@ class EditActionModeCallback(
             return false
         }
 
+        // saving from edit mode is its own thing, and the name OpenDocument.ios already
+        // reports it under - menu_save is the button on the document itself
+        activity.analyticsManager.report("menu_edit_save")
+
         documentFragment.prepareSave({ activity.requestSave() }, false)
 
         return true


### PR DESCRIPTION
The two apps report the same user actions under different names, which makes the funnels uncomparable. OpenDocument.ios' `AnalyticsConstants` says outright that the identifiers exist to stay comparable with this repo, so this closes the gaps from the Android side:

| Action | ios | droid before | droid now |
|---|---|---|---|
| promotion tapped | `house_ad_tapped` | `house_ad` | `house_ad_tapped` |
| promotion shown | `house_ad_shown` | — | `house_ad_shown` |
| save from edit mode | `menu_edit_save` | — | `menu_edit_save` |

`house_ad_shown` is the one that was actually missing something: there was no way to tell a promotion that filled an empty slot from one nobody saw, so the tap rate had no denominator.

The other direction is opendocument-app/OpenDocument.ios#146, which adds `add_to_cart`, `menu_search`/`search` and the `in_app_review_*` names there.