### PR TITLE
Ask before dropping unsaved edits

### DIFF
--- a/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
@@ -989,6 +989,13 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener {
         return ::state.isInitialized && state.lastResult != null
     }
 
+    /**
+     * Whether the document on screen is in edit mode, and so may be carrying changes nothing has
+     * written down yet: the edits live in the page until a save asks it for a diff.
+     */
+    fun isEditing(): Boolean =
+        ::state.isInitialized && state.lastResult?.options?.translatable == true
+
     val lastFileType: String?
         get() = requireLastResult().options.fileType
 

--- a/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
@@ -989,10 +989,7 @@ class DocumentFragment : Fragment(), LoaderService.LoaderListener {
         return ::state.isInitialized && state.lastResult != null
     }
 
-    /**
-     * Whether the document on screen is in edit mode, and so may be carrying changes nothing has
-     * written down yet: the edits live in the page until a save asks it for a diff.
-     */
+    /** Whether the document is in edit mode, so its changes are still only in the page. */
     fun isEditing(): Boolean =
         ::state.isInitialized && state.lastResult?.options?.translatable == true
 

--- a/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
@@ -16,6 +16,7 @@ import android.view.View
 import android.widget.LinearLayout
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.ActionMode as SupportActionMode
 import androidx.core.view.ViewCompat
@@ -79,7 +80,7 @@ class MainActivity : AppCompatActivity() {
                 if (documentFragment != null && !documentOpenedExternally) {
                     analyticsManager.report("back_to_landing")
 
-                    closeDocument()
+                    confirmLeavingEdits { closeDocument() }
 
                     return
                 }
@@ -724,6 +725,44 @@ class MainActivity : AppCompatActivity() {
         analyticsManager.report("close_failed_document")
 
         closeDocument(keepMessage = true)
+    }
+
+    /**
+     * Asks before walking away from a document that is being edited, and runs [leave] once that is
+     * settled.
+     *
+     * Nothing is written until the user has named a file to save to, so leaving is exactly where
+     * unsaved work goes. It used to go silently. OpenDocument.ios asks the same question on its way
+     * out, under the same three event names.
+     *
+     * Saving does not also leave: the save opens the system's create-document picker, and closing
+     * the document out from under it would take the page the diff still has to come from.
+     */
+    private fun confirmLeavingEdits(leave: () -> Unit) {
+        val documentFragment = this.documentFragment
+        if (documentFragment == null || !documentFragment.isEditing()) {
+            leave()
+
+            return
+        }
+
+        analyticsManager.report("show_alert_unsaved_changes")
+
+        AlertDialog.Builder(this)
+            .setTitle(R.string.alert_unsaved_changes)
+            .setMessage(R.string.alert_save_now)
+            .setPositiveButton(R.string.action_edit_save) { _, _ ->
+                analyticsManager.report("alert_unsaved_changes_yes")
+
+                documentFragment.prepareSave({ requestSave() }, false)
+            }
+            .setNegativeButton(R.string.alert_discard_changes) { _, _ ->
+                analyticsManager.report("alert_unsaved_changes_no")
+
+                leave()
+            }
+            .setNeutralButton(android.R.string.cancel, null)
+            .show()
     }
 
     private fun closeDocument(keepMessage: Boolean = false) {

--- a/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
@@ -85,8 +85,8 @@ class MainActivity : AppCompatActivity() {
                     return
                 }
 
-                // an externally opened document leaves the app rather than the document, but
-                // it carries unsaved edits out just the same - so it asks first too
+                // an externally opened document leaves the app rather than the document, and
+                // carries unsaved edits out just the same
                 confirmLeavingEdits {
                     // fall through to the default behavior (close the activity)
                     isEnabled = false
@@ -732,15 +732,9 @@ class MainActivity : AppCompatActivity() {
     }
 
     /**
-     * Asks before walking away from a document that is being edited, and runs [leave] once that is
-     * settled.
-     *
-     * Nothing is written until the user has named a file to save to, so leaving is exactly where
-     * unsaved work goes. It used to go silently. OpenDocument.ios asks the same question on its way
-     * out, under the same three event names.
-     *
-     * Saving does not also leave: the save opens the system's create-document picker, and closing
-     * the document out from under it would take the page the diff still has to come from.
+     * Asks before walking away from a document being edited, then runs [leave]. Saving does not
+     * also leave: it opens the create-document picker, which still needs the page the diff comes
+     * from.
      */
     private fun confirmLeavingEdits(leave: () -> Unit) {
         val documentFragment = this.documentFragment

--- a/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
@@ -85,10 +85,14 @@ class MainActivity : AppCompatActivity() {
                     return
                 }
 
-                // fall through to the default behavior (close the activity)
-                isEnabled = false
-                onBackPressedDispatcher.onBackPressed()
-                isEnabled = true
+                // an externally opened document leaves the app rather than the document, but
+                // it carries unsaved edits out just the same - so it asks first too
+                confirmLeavingEdits {
+                    // fall through to the default behavior (close the activity)
+                    isEnabled = false
+                    onBackPressedDispatcher.onBackPressed()
+                    isEnabled = true
+                }
             }
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,5 +87,8 @@
     <!--  iOS -->
     <string name="ok">OK</string>
     <string name="cancel">Cancel</string>
+    <string name="alert_unsaved_changes">Unsaved changes</string>
+    <string name="alert_save_now">Do you want to save them now?</string>
+    <string name="alert_discard_changes">Discard</string>
 
 </resources>


### PR DESCRIPTION
Back out of a document that is being edited and the edits are gone, silently. Nothing is written until the user has named a save target, so leaving is exactly where the work goes — and `closeDocument()` takes the page the diff would have come from.

OpenDocument.ios has always asked this question on its way out. Same three analytics events (`show_alert_unsaved_changes`, `alert_unsaved_changes_yes`, `alert_unsaved_changes_no`), so the two are comparable.

Saving deliberately does not also leave: the save opens the system create-document picker, and closing the document out from under it would take the page the diff still has to come from. Cancel is a third button, which the iOS sheet effectively has as well.

Edit mode is read off `options.translatable`, which `reloadUri` already flips on the way in and out — no new state.

Not exercised by a test: it needs the activity, and the existing instrumentation suite has no edit-and-leave path. Worth a look on a device before merging.