### PR TITLE
Write down the rest of 4.14.0, and cut the heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ listed here too.
 Entries go under `Unreleased` as the change lands, in the same pull request. That
 heading is cut to the version when the version is dispatched to the release
 workflow, which refuses a version without a section and makes it the body of the
-GitHub release. It is not the store copy - Play's "What's new" is written in the
-Play Console when the release is promoted.
+GitHub release. It is not the store copy: Play's "What's new" is written for
+users, one file per version code under
+`fastlane/metadata/android/en-US/changelogs/`, and pasted into the Play Console
+when the release is promoted.
 
 ## 4.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,15 @@ workflow, which refuses a version without a section and makes it the body of the
 GitHub release. It is not the store copy - Play's "What's new" is written in the
 Play Console when the release is promoted.
 
-## Unreleased
+## 4.14.0
 
+- The app opens on the documents you had open recently, instead of a welcome
+  screen there was nothing to do on.
+- A new look throughout, following your phone's light or dark setting, with what
+  you can do to an open document moved down within reach of your thumb.
+- Leaving a document with unsaved changes now asks first, instead of dropping
+  them.
+- Saving asks only once where to put the file.
 - A .csv now opens as a real spreadsheet: the separator is worked out from the
   file, quoted fields stay whole, and a value that only looks like a number is
   left as text. It used to be listed line by line.
@@ -25,9 +32,14 @@ Play Console when the release is promoted.
 - Embedded fonts in a PDF no longer come out as boxes or as the wrong letters.
 - svg, ico, jxl, jp2, psd, wmf and emf are recognised and shown as images.
 - An .xml file opens properly laid out instead of as one long line.
-- Smaller fixes to plain text and to the margin documents open with.
 - A file the app cannot open is no longer offered for upload to our conversion
   service, so no document leaves your device. This affected .rtf and WordPerfect.
+- The paid app no longer carries Google's advertising code at all, and there is
+  now a build with nothing proprietary in it for F-Droid.
+- Turning down the consent form in the free app leaves a limited ad, which
+  carries no identifiers, rather than an empty space.
+- Smaller fixes to plain text, to the margin documents open with, and to the
+  promotion in the free app, which varies again from one launch to the next.
 
 ## 4.13.0
 

--- a/fastlane/metadata/android/en-US/changelogs/41400.txt
+++ b/fastlane/metadata/android/en-US/changelogs/41400.txt
@@ -1,0 +1,11 @@
+The app opens on the documents you had open recently, in a new look that follows your phone's light or dark setting, with what you can do to an open document moved down within reach of your thumb.
+
+Leaving a document with unsaved changes now asks first, and saving asks only once where to put the file.
+
+A .csv opens as a real spreadsheet, a .docx breaks onto the pages it was written for, and spreadsheets are drawn in a quieter grid under a row and column ruler that stays put while you scroll.
+
+Documents that are not saved in UTF-8 come out readable, archives list their entries as files, embedded fonts in a PDF are shown correctly, and svg, ico, jxl, jp2, psd, wmf and emf are recognised as images.
+
+A file we cannot open is no longer offered for upload to our conversion service, so no document leaves your device.
+
+The paid app no longer carries Google's advertising code at all.


### PR DESCRIPTION
Nine of the eighteen pull requests since 4.13.0 left no changelog entry, the
redesign (#547) among them. Adds what a user would notice — the recent-documents
landing screen and the new look, the prompt before unsaved edits are dropped
(#580), saving asking once rather than twice (#577), Pro without the ad SDK and
the new foss build (#574), and limited ads for whoever declines consent (#569).

The `Unreleased` heading is cut to `4.14.0` in the same change: the release
workflow refuses a version with no section of its own, so this is what unblocks

    gh workflow run release.yml -f version=v4.14.0

Play's "What's new" for the version goes in `changelogs/41400.txt`, beside the
other version codes, and is pasted into the console at promotion. The header said
only that it is written in the console, which is how the file was missed here in
the first place; it now names the directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)