### PR TITLE
Make 4.14.0's store copy fit Play's limit

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/41400.txt
+++ b/fastlane/metadata/android/en-US/changelogs/41400.txt
@@ -1,11 +1,7 @@
-The app opens on the documents you had open recently, in a new look that follows your phone's light or dark setting, with what you can do to an open document moved down within reach of your thumb.
+The app now opens on your recent documents, in a new look that follows your phone's light or dark setting, with the document actions in reach of your thumb.
 
-Leaving a document with unsaved changes now asks first, and saving asks only once where to put the file.
+Leaving a document with unsaved changes asks first, and saving asks only once where to put the file.
 
-A .csv opens as a real spreadsheet, a .docx breaks onto the pages it was written for, and spreadsheets are drawn in a quieter grid under a row and column ruler that stays put while you scroll.
+A .csv opens as a real spreadsheet, a .docx breaks onto real pages, and more file types are recognised and shown.
 
-Documents that are not saved in UTF-8 come out readable, archives list their entries as files, embedded fonts in a PDF are shown correctly, and svg, ico, jxl, jp2, psd, wmf and emf are recognised as images.
-
-A file we cannot open is no longer offered for upload to our conversion service, so no document leaves your device.
-
-The paid app no longer carries Google's advertising code at all.
+Nothing is uploaded to our conversion service any more, so no document leaves your device.

--- a/fastlane/metadata/android/en-US/changelogs/README.md
+++ b/fastlane/metadata/android/en-US/changelogs/README.md
@@ -1,0 +1,22 @@
+# Release notes
+
+One file per version code, holding the "What's new" text for that release.
+Written for users of the app, not for this repository: the developer-facing
+record of the same release is in `CHANGELOG.md` at the root.
+
+Named by version code (`41400.txt` for 4.14.0), which is what Play keys a
+release on, and what `app/build.gradle` derives from the version name.
+
+**Play allows 500 characters, and refuses the release with "Release note for
+en-US is too long" until it fits.** The box is a single field per language and
+the count includes the blank lines between paragraphs.
+
+`supply` does not read this directory - the upload sets
+`skip_upload_changelogs: true`, because promoting a release is a deliberate step
+in the Play Console rather than something an upload does. The text here is
+pasted into the console at promotion, per language, inside the `<en-US>` tags
+the console's box comes prefilled with.
+
+Only en-US is kept here, and 4.14.0 was promoted with only the `<en-US>` block
+filled in; Play shows the release notes it has and falls back to the listing's
+own language elsewhere. Translations are outstanding.


### PR DESCRIPTION
`41400.txt` was 888 characters. Play allows 500 per language and blocks the
release with "Release note for en-US is too long" until it fits — every earlier
file in this directory is under 470, which is why it had never come up.

This is the copy 4.14.0 was actually promoted with, so the file now matches the
store, plus a README recording the limit, the naming, and that `supply` does not
read this directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)