### PR TITLE
Offer github sponsors where there is no pro to sell

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+github: opendocument-app
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
 ko_fi: # Replace with a single Ko-fi username

--- a/app/src/main/java/app/opendocument/droid/ui/activity/LandingFragment.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/LandingFragment.kt
@@ -14,6 +14,7 @@ import androidx.recyclerview.widget.RecyclerView
 import app.opendocument.droid.R
 import app.opendocument.droid.background.RecentDocumentList
 import app.opendocument.droid.nonfree.AnalyticsConstants
+import app.opendocument.droid.nonfree.Features
 import app.opendocument.droid.ui.SnackbarHelper
 import app.opendocument.droid.ui.widget.LandingAdapter
 import app.opendocument.droid.ui.widget.LandingItem
@@ -186,6 +187,18 @@ class LandingFragment : Fragment(), LandingAdapter.Listener {
                 )
             }
 
+            // the way to give something back where there is no pro left to sell. not offered in
+            // lite, whose one money row should stay the purchase that also drops the ads
+            if (!Features.withAds) {
+                items.add(
+                    LandingItem.Action(
+                        LandingItem.ACTION_SPONSOR,
+                        R.string.landing_sponsor,
+                        R.drawable.ic_favorite,
+                    )
+                )
+            }
+
             // the way back into the consent form, which the ump sdk requires an app to offer for
             // as long as it holds a decision that can be withdrawn. asked the same way as the ad
             // removal, and for the same reason: only the activity has been told
@@ -306,6 +319,12 @@ class LandingFragment : Fragment(), LandingAdapter.Listener {
                 mainActivity.analyticsManager.report("settings_remove_ads")
 
                 mainActivity.buyAdRemoval()
+            }
+
+            LandingItem.ACTION_SPONSOR -> {
+                mainActivity.analyticsManager.report("settings_sponsor")
+
+                mainActivity.openSponsorPage()
             }
 
             LandingItem.ACTION_PRIVACY_OPTIONS -> {

--- a/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
@@ -670,6 +670,15 @@ class MainActivity : AppCompatActivity() {
         )
     }
 
+    /** What [buyAdRemoval] is for a build with no ad removal to sell. */
+    fun openSponsorPage() {
+        analyticsManager.report(AnalyticsConstants.EVENT_ADD_TO_CART)
+
+        startActivity(
+            Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/sponsors/opendocument-app"))
+        )
+    }
+
     private fun leaveFullscreen() {
         if (!fullscreen) {
             return

--- a/app/src/main/java/app/opendocument/droid/ui/widget/LandingItem.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/widget/LandingItem.kt
@@ -61,6 +61,7 @@ sealed class LandingItem {
     companion object {
         const val ACTION_REMOVE_ADS: Int = 1
         const val ACTION_PRIVACY_OPTIONS: Int = 2
+        const val ACTION_SPONSOR: Int = 3
 
         const val SETTING_CATCH_ALL: Int = 1
         const val SETTING_PAGINATION: Int = 2

--- a/app/src/main/res/drawable/ic_favorite.xml
+++ b/app/src/main/res/drawable/ic_favorite.xml
@@ -1,0 +1,10 @@
+<vector android:height="24dp"
+        android:tint="?attr/colorControlNormal"
+        android:viewportHeight="24.0"
+        android:viewportWidth="24.0"
+        android:width="24dp"
+        xmlns:android="http://schemas.android.com/apk/res/android">
+    <path
+            android:fillColor="#FF000000"
+            android:pathData="M12,21.35l-1.45,-1.32C5.4,15.36 2,12.28 2,8.5 2,5.42 4.42,3 7.5,3c1.74,0 3.41,0.81 4.5,2.09C13.09,3.81 14.76,3 16.5,3 19.58,3 22,5.42 22,8.5c0,3.78 -3.4,6.86 -8.55,11.54L12,21.35z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,6 +59,7 @@
     <string name="landing_pagination_title">Show page borders</string>
     <string name="landing_pagination_body">Keep the side margins of a printed page instead of filling the screen.</string>
     <string name="landing_catch_all_title">Offer to open any file</string>
+    <string name="landing_sponsor">Support us on GitHub</string>
     <string name="landing_recent_removed">Removed from recent</string>
     <string name="landing_undo">Undo</string>
     <string name="landing_open_file">Open a file</string>


### PR DESCRIPTION
Pro and foss both hide the ad removal row, which leaves their settings section with no way to give anything back - and foss deliberately links nothing google, so the play listing was never an option there.

A new settings row, `ACTION_SPONSOR`, opens https://github.com/sponsors/opendocument-app. It is gated on `!Features.withAds`, so it appears in pro and foss and not in lite: lite's one money row should stay the purchase that also drops the ads, and unlike that row a sponsor row would never go away after a purchase.

The link buys nothing inside the app, so it stays a donation rather than an unbilled digital good on the two builds play distributes.

`.github/FUNDING.yml` names the sponsor account as well; the App Store and Play links stay.

Built and linted, not seen on a device: `spotlessApply assembleDebug lintProDebug` and `lintFossDebug` pass, and `assembleDebug` covers all three flavors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)