### PR TITLE
Take odrcore 6.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ users, one file per version code under
 `fastlane/metadata/android/en-US/changelogs/`, and pasted into the Play Console
 when the release is promoted.
 
+## Unreleased
+
+- PDFs look much closer to the original: text sits at the right place and size,
+  colours match, pages are trimmed the way a PDF viewer trims them, and more of
+  their images come through. Some PDFs that opened blank now open properly.
+- Text is shown in the font the document asks for. Slides whose writing was
+  there but invisible now show it, and spreadsheet cells are drawn in their own
+  font rather than the sheet's.
+- Documents built on a template keep their layout: a letter's address and date
+  land in their boxes, and the page keeps the margins its letterhead needs.
+- Images sit where the document puts them, centred if the file centres them, and
+  stay inside their frames instead of covering the page.
+- Blank lines survive being copied out of a document.
+- Large or unusually built documents open instead of crashing the app, and take
+  less memory while they do. A single unreadable character no longer costs you
+  the whole document.
+
 ## 4.14.0
 
 - The app opens on the documents you had open recently, instead of a welcome

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ googleJavaFormat = "1.35.0"
 ktfmt = "0.64"
 
 # odrcore's JNI bindings, java and native in one AAR, published from OpenDocument.core
-odrCore = "6.5.0"
+odrCore = "6.6.0"
 
 androidxAnnotation = "1.10.0"
 androidxAppcompat = "1.7.1"


### PR DESCRIPTION
The engine moves from 6.5.0 to 6.6.0, and nothing here has to move with it. The
only change to the bindings is `GraphicStyle` gaining `horizontal_position`,
which nothing in `app/src` reads, and the format table is untouched — so
`SupportedDocumentTypes` derives the same two sets and `STRICT_CATCH`'s
generated intent-filters still match them.

What it brings is rendering. The changelog entry is grouped by what a user would
notice rather than by upstream fix:

- **PDFs** place their text by their own font rather than the browser's default
  (small text was landing several points low), convert cmyk as Adobe converts it,
  clip to the crop box, and decode JPEG 2000 images. One whose content stream
  carries comments renders at all — `%` to end of line is white space wherever it
  stands, not the start of a token.
- **Fonts** come from the paragraph when a run names none, so slide text that was
  there but invisible now shows, and sheet cells are drawn in the font the file
  names for them.
- **Templates** hold their layout: a page-anchored frame sits where the page says
  and a document is laid out on the master page it names, which is a letter's
  address and date boxes landing in their fields and its letterhead margins
  surviving.
- **Images** stay inside their frames, and a frame that names a side instead of an
  offset is put on that side, so a centred image in an .odt is centred.
- An **empty paragraph** keeps the height its font implies, so a blank line
  survives being copied out.
- A deep `w:basedOn` / `style:parent-style-name` chain is walked onto a stack
  rather than recursed, so its length no longer takes the process down, and xml
  parts are read once instead of buffered twice on the way into the parser.

Upstream release: https://github.com/opendocument-app/OpenDocument.core/releases/tag/v6.6.0

## Testing

- `spotlessCheck assembleProDebug testProDebugUnitTest` — pass
- `connectedProDebugAndroidTest` on a Pixel_6_Pro AVD — 69/69 pass, including
  `SupportedFormatsTest`, which is what holds the manifest to the core's table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)