### PR TITLE
Cut the heading to 4.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ users, one file per version code under
 `fastlane/metadata/android/en-US/changelogs/`, and pasted into the Play Console
 when the release is promoted.
 
-## Unreleased
+## 4.15.0
 
 - PDFs look much closer to the original: text sits at the right place and size,
   colours match, pages are trimmed the way a PDF viewer trims them, and more of


### PR DESCRIPTION
`Unreleased` is not a version, and the release run reads the section under
`## 4.15.0` twice — once before building, so missing release copy costs seconds
rather than a version, and again in the record job, where it becomes the body of
the drafted GitHub release. So the heading has to name the version before
`v4.15.0` is dispatched.

Nothing under it changes: 4.15.0 is odrcore 6.6.0 (#590) and nothing else.

Both release scripts accept it as of this commit:

- `changelog-section.py --version v4.15.0` prints the six bullets
- `resolve-version.py --input v4.15.0` resolves to `building v4.15.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)