### PR TITLE
Take odrcore 6.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@ version code per locale under `fastlane/metadata/android/<locale>/changelogs/`,
 written by `scripts/store-copy.py` before the release and uploaded by it. Play
 takes 500 characters, so not everything here reaches the store.
 
+## Unreleased
+
+- PDFs that do not carry their own fonts read properly: the words no longer
+  drift further right along each line, and Find lands on the word you looked for
+  rather than the one beside it. Bold and italic writing is drawn bold and
+  italic, instead of at the plain font's widths.
+- A PDF line that mixes fonts or sizes sits straight: subscripts and
+  superscripts land where the file puts them, and the text after a bullet stays
+  with the highlight that selects it.
+- Selecting or finding across words in a PDF covers the spaces between them
+  rather than leaving a sliver of white in every gap.
+- Tapping the text of a paged document reaches it, so selecting and copying work
+  where the page used to swallow the tap.
+
 ## 4.15.0
 
 - PDFs look much closer to the original: text sits at the right place and size,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ googleJavaFormat = "1.35.0"
 ktfmt = "0.64"
 
 # odrcore's JNI bindings, java and native in one AAR, published from OpenDocument.core
-odrCore = "6.6.0"
+odrCore = "6.7.1"
 
 androidxAnnotation = "1.10.0"
 androidxAppcompat = "1.7.1"


### PR DESCRIPTION
The engine moves from 6.6.0 to 6.7.1, and nothing here has to move with it. The
diff upstream is confined to `src/odr/internal/html` and its tests — the JNI
bindings are untouched, and so is the format table, so `SupportedDocumentTypes`
derives the same two sets and `STRICT_CATCH`'s generated intent-filters still
match them.

6.7.0 gives every text-rendering view `odr.search()`, shipped as `search.css` and
`search.js`. It needs no answer here twice over: the find bar drives the
WebView's own `findAllAsync`, and `CoreLoader` sets `embedShippedResources`, so
there is nothing for the local server to serve.

What reaches a user is the rendering, and it is pdf text this time:

- A **pdf that does not embed its fonts** had a recovered word break both written
  into the run and spanned by its offset, so every word drifted another space
  rightwards along the line and Find landed on the neighbour of the word asked
  for. Such a font is now also asked for by the name of its **bold or italic
  cut**, rather than faked at the regular one's widths.
- A **line mixing fonts or sizes** puts each run on its own baseline instead of
  on that of whichever run opened the line. That is where subscripts and
  superscripts sit, and why the text after a bullet no longer parts company with
  the highlight that selects it.
- A **selection or find hit running across words** covers the gaps between them
  instead of leaving a sliver of white in each. A gap wider than the text is left
  alone: it is a column of white, not a space.
- Off pdf, a **tap on a paged document** reaches the text — a negative `z-index`
  had painted the page in front of it, and it took every tap.

Upstream releases: [v6.7.0](https://github.com/opendocument-app/OpenDocument.core/releases/tag/v6.7.0), [v6.7.1](https://github.com/opendocument-app/OpenDocument.core/releases/tag/v6.7.1)

Both of those shipped with no `odr-core-android` aar: the publish job's conan
step was refused the uchardet tarball by freedesktop.org (`Error 418`) on each
run. Re-running it against 6.7.1 went through, and that is the artifact this
pins.

## Testing

- `spotlessCheck assembleProDebug testProDebugUnitTest` — pass
- `connectedProDebugAndroidTest` on a Pixel_6_Pro AVD — 69/69 pass, including
  `SupportedFormatsTest`, which is what holds the manifest to the core's table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)