### PR TITLE
Wait for what the flaky tests were asserting

### DIFF
--- a/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
@@ -80,6 +80,13 @@ class MainActivityTests {
         // Happens frequently on slow emulators.
         mainActivity.sendBroadcast(Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS))
 
+        // espresso picks its root by window focus and fails where it finds none, so wait for
+        // focus here rather than in the first onView of a test
+        Assert.assertTrue(
+            "the activity never took window focus",
+            waitForWindowFocus(mainActivity, WINDOW_FOCUS_TIMEOUT_MS),
+        )
+
         Intents.init()
     }
 
@@ -171,6 +178,8 @@ class MainActivityTests {
         val testFileUri = uriOf(requireTestFile("corrupt.odt"))
         InstrumentationRegistry.getInstrumentation().runOnMainSync { activity.loadUri(testFileUri) }
 
+        awaitViewWithText(R.string.dialog_broken_file)
+
         onView(withText(R.string.dialog_broken_file)).check(matches(isDisplayed()))
         onView(withText(R.string.action_contact)).check(matches(isDisplayed()))
     }
@@ -197,6 +206,9 @@ class MainActivityTests {
             "the page that failed was not given up on",
             waitFor(10000) { documentFragment.lastDocument == null },
         )
+
+        // the dialog is a step after the document was given up on, so the wait above is not it
+        awaitViewWithText(R.string.dialog_broken_file)
 
         onView(withText(R.string.dialog_broken_file)).check(matches(isDisplayed()))
         onView(withText(R.string.action_contact)).check(matches(isDisplayed()))
@@ -391,6 +403,34 @@ class MainActivityTests {
         return false
     }
 
+    private fun waitForWindowFocus(activity: Activity, timeoutMs: Long): Boolean =
+        waitFor(timeoutMs) {
+            val focused = AtomicReference(false)
+            InstrumentationRegistry.getInstrumentation().runOnMainSync {
+                focused.set(activity.window.decorView.hasWindowFocus())
+            }
+            focused.get()
+        }
+
+    /**
+     * Espresso matches once, and the broken-file dialog goes up after the idling resource is idle,
+     * so it has to be polled for. A timeout falls through to the caller's assertion, which reports
+     * better than a deadline.
+     */
+    private fun awaitViewWithText(textId: Int, timeoutMs: Long = DIALOG_TIMEOUT_MS) {
+        waitFor(timeoutMs) {
+            try {
+                onView(withText(textId)).check(matches(isDisplayed()))
+                true
+            } catch (e: RuntimeException) {
+                // no matching view yet, or no root focused yet - both mean "not up"
+                false
+            } catch (e: AssertionError) {
+                false
+            }
+        }
+    }
+
     private fun waitForDocumentFragment(
         activity: MainActivity,
         timeoutMs: Long,
@@ -458,7 +498,7 @@ class MainActivityTests {
                 " ' bodyLength=' + html.length + ' bodyEditable=' + !!(b && b.isContentEditable) +" +
                 " ' editableNodes=' + document.querySelectorAll('[contenteditable]').length +" +
                 " ' odr=' + (typeof odr);})()",
-        ) ?: "no result"
+        ) ?: "webview did not answer in ${JS_ANSWER_TIMEOUT_MS}ms"
 
     /**
      * What the loader published, fetched over http the way the webview fetches it: a document the
@@ -516,6 +556,10 @@ class MainActivityTests {
         return "true".equals(result.replace("\"", ""), ignoreCase = true)
     }
 
+    /**
+     * Null when the webview did not answer in time, which is not itself a failure: the caller's
+     * poll owns the deadline and asks again.
+     */
     private fun evaluateJavascript(pageView: PageView, script: String): String? {
         val result = AtomicReference<String>()
         val latch = CountDownLatch(1)
@@ -525,8 +569,8 @@ class MainActivityTests {
                 latch.countDown()
             }
         }
-        if (!latch.await(10, TimeUnit.SECONDS)) {
-            Assert.fail("Timed out waiting for JS evaluation result")
+        if (!latch.await(JS_ANSWER_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+            return null
         }
         return result.get()
     }
@@ -544,6 +588,13 @@ class MainActivityTests {
         // a cold CI emulator needs more than the 10s this used to wait. more than 30s does not
         // help: what still failed at 60s was the core server failing to bind its port
         private const val EDIT_MODE_TIMEOUT_MS = 30000L
+
+        // one round trip to the webview, not the state the test waits for: the poll owns that
+        private const val JS_ANSWER_TIMEOUT_MS = 10000L
+
+        private const val WINDOW_FOCUS_TIMEOUT_MS = 10000L
+
+        private const val DIALOG_TIMEOUT_MS = 10000L
 
         private val testFiles = mutableMapOf<String, File>()
 

--- a/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
@@ -80,14 +80,17 @@ class MainActivityTests {
         // Happens frequently on slow emulators.
         mainActivity.sendBroadcast(Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS))
 
+        // before the wait below, which can fail: tearDown releases unconditionally, and
+        // releasing what was never initialised would throw over that failure and skip the
+        // rest of the cleanup
+        Intents.init()
+
         // espresso picks its root by window focus and fails where it finds none, so wait for
         // focus here rather than in the first onView of a test
         Assert.assertTrue(
             "the activity never took window focus",
             waitForWindowFocus(mainActivity, WINDOW_FOCUS_TIMEOUT_MS),
         )
-
-        Intents.init()
     }
 
     @After


### PR DESCRIPTION
Three tests have been failing on CI without the app being wrong — `testDOCXEditMode`,
`testCorruptODTOffersContact` and `aPageTheServerCannotServeOffersContact`. Each turned out to be
waiting on something other than what it went on to assert.

### The webview timeout was fatal, and it ate the diagnosis

`evaluateJavascript` called `Assert.fail` when the webview missed its ten seconds. It is called from
`waitForEditableState`, which polls for thirty — so a renderer busy past one deadline ended a run
that had every reason to ask again.

Worse, `describeDom` calls it a second time on the way to reporting a failure. That is why CI kept
showing `Timed out waiting for JS evaluation result` instead of the message
`assertBecomesEditable` builds — the diagnostic threw over the failure it was called to describe.

It now returns null, and the caller decides: the poll retries, the failure path says the webview did
not answer.

### The broken-file dialog was asserted before it was up

`offerContact` runs after `giveUp` and after `endLoadIdling`, so espresso had nothing to block on and
matched against a screen the dialog had not reached yet. Both tests now poll for it. This is the
`NoMatchingViewException ... dialog_broken_file` seen on CI.

### Espresso's root needs window focus, which launch does not hand over immediately

Finding no focused root, espresso spends ten seconds and then fails whichever `onView` came first —
the `RootViewWithoutFocusException` seen on API 30. `setUp` waits for focus instead.

## Testing

- API 31 emulator: `MainActivityTests` three times, full suite twice — 69/69 each.
- API 34 is where these actually flake, and no local image covers it, so this PR's own CI run is the
  check that counts.

Context: these were investigated on #594 and confirmed pre-existing — the same tests fail on main at
odrcore 6.6.0, so they were never about that bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)