### PR TITLE
Let the document follow the app into night mode again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ takes 500 characters, so not everything here reaches the store.
 
 ## Unreleased
 
+- Dark mode reaches the document again, not just the screen around it.
 - PDFs that do not carry their own fonts read properly: the words no longer
   drift further right along each line, and Find lands on the word you looked for
   rather than the one beside it. Bold and italic writing is drawn bold and

--- a/app/src/androidTest/java/app/opendocument/droid/test/DarkModeTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/DarkModeTests.kt
@@ -1,0 +1,198 @@
+// ActivityTestRule instead of ActivityScenario, for the reason MainActivityTests gives.
+@file:Suppress("DEPRECATION")
+
+package app.opendocument.droid.test
+
+import android.net.Uri
+import android.os.SystemClock
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.content.FileProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.ActivityTestRule
+import androidx.webkit.WebSettingsCompat
+import androidx.webkit.WebViewFeature
+import app.opendocument.droid.ui.activity.DocumentFragment
+import app.opendocument.droid.ui.activity.MainActivity
+import app.opendocument.droid.ui.widget.PageView
+import java.io.File
+import java.io.FileOutputStream
+import java.io.InputStream
+import java.util.concurrent.atomic.AtomicReference
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * The document follows the app into night mode.
+ *
+ * A webview darkens a page algorithmically and only while the app theme reports itself dark, so
+ * every test here puts the app in night mode first - in day mode nothing below would fail.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+class DarkModeTests {
+
+    @get:Rule
+    val mainActivityActivityTestRule = ActivityTestRule(MainActivity::class.java, false, false)
+
+    @Before
+    fun enterNightMode() {
+        setNightMode(AppCompatDelegate.MODE_NIGHT_YES)
+    }
+
+    @After
+    fun leaveNightMode() {
+        setNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
+    }
+
+    @Test
+    fun aDocumentIsDarkened() {
+        assertDarkened(openPageView("test.odt"))
+    }
+
+    /** Every format, pdf included - see [PageView.setDarkeningAllowed]. */
+    @Test
+    fun aPdfIsDarkenedToo() {
+        assertDarkened(openPageView("dummy.pdf"))
+    }
+
+    /** What is drawn, not only the flag: a webview ignoring the setting passes the flag check. */
+    @Test
+    fun theDrawnPageIsDark() {
+        openPageView("test.odt")
+
+        // the darkening lands while compositing, which the load callback does not wait for
+        Assert.assertTrue(
+            "the page stayed light - mean luminance ${meanLuminance()}",
+            waitFor(30000) { meanLuminance() < DARK_LUMINANCE },
+        )
+    }
+
+    private fun assertDarkened(pageView: PageView) {
+        Assert.assertTrue("the page was not allowed to darken", pageView.isDarkeningAllowed)
+
+        if (!WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)) {
+            return
+        }
+
+        val allowed = AtomicReference(false)
+        onMainThread {
+            allowed.set(WebSettingsCompat.isAlgorithmicDarkeningAllowed(pageView.settings))
+        }
+
+        Assert.assertTrue("the webview was not told to darken the page", allowed.get())
+    }
+
+    /**
+     * What the middle of the screen draws, averaged - 0 is black and 255 white.
+     *
+     * A screenshot rather than `pageView.draw()`: the WebView renders on the compositor, so drawing
+     * it into a bitmap of our own hands back an empty layer whatever the page looks like. The
+     * middle, so the bars and the buttons over the page do not count towards the answer.
+     */
+    private fun meanLuminance(): Int {
+        val screen =
+            InstrumentationRegistry.getInstrumentation().uiAutomation.takeScreenshot()
+                ?: return WHITE
+
+        val left = screen.width / 4
+        val right = screen.width * 3 / 4
+        val top = screen.height / 3
+        val bottom = screen.height * 2 / 3
+
+        var total = 0L
+        var counted = 0
+        // a sample, not every pixel: this is polled, and the answer is an average anyway
+        for (x in left until right step SAMPLE_STEP) {
+            for (y in top until bottom step SAMPLE_STEP) {
+                val pixel = screen.getPixel(x, y)
+                total += ((pixel shr 16 and 0xff) + (pixel shr 8 and 0xff) + (pixel and 0xff)) / 3
+                counted++
+            }
+        }
+        screen.recycle()
+
+        return if (counted == 0) WHITE else (total / counted).toInt()
+    }
+
+    private fun openPageView(name: String): PageView {
+        // the activity first: a freshly installed app has never run, so its cache directory -
+        // where the document has to be for the app's own FileProvider to hand it back - is only
+        // there once the app process has started
+        val activity = mainActivityActivityTestRule.launchActivity(null)
+        val uri = uriOf(extract(name))
+
+        onMainThread { activity.loadUri(uri) }
+
+        val fragment = checkNotNull(waitForFragment(activity)) { "no document fragment" }
+        Assert.assertTrue(
+            "$name never loaded",
+            waitFor(30000) { fragment.lastDocument?.request?.uri == uri },
+        )
+
+        return checkNotNull(fragment.pageView) { "no page view" }
+    }
+
+    private fun waitForFragment(activity: MainActivity): DocumentFragment? {
+        var fragment: DocumentFragment? = null
+        waitFor(30000) {
+            fragment =
+                activity.supportFragmentManager.findFragmentByTag("document_fragment")
+                    as DocumentFragment?
+            fragment != null
+        }
+        return fragment
+    }
+
+    private fun waitFor(timeoutMs: Long, condition: () -> Boolean): Boolean {
+        val startMs = SystemClock.elapsedRealtime()
+        do {
+            if (condition()) {
+                return true
+            }
+            SystemClock.sleep(250)
+        } while (SystemClock.elapsedRealtime() - startMs < timeoutMs)
+        return false
+    }
+
+    /** Everything touching a WebView, its settings included, has to run where it was made. */
+    private fun onMainThread(block: () -> Unit) {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(block)
+    }
+
+    private fun setNightMode(mode: Int) {
+        onMainThread { AppCompatDelegate.setDefaultNightMode(mode) }
+    }
+
+    private fun uriOf(file: File): Uri {
+        val appCtx = InstrumentationRegistry.getInstrumentation().targetContext
+
+        return FileProvider.getUriForFile(appCtx, appCtx.packageName + ".provider", file)
+    }
+
+    /** The asset [name], copied where the app can read it back through its FileProvider. */
+    private fun extract(name: String): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val target = File(instrumentation.targetContext.cacheDir, "dark-mode-$name")
+
+        instrumentation.context.assets.open(name).use { input: InputStream ->
+            FileOutputStream(target).use { output -> input.copyTo(output) }
+        }
+
+        return target
+    }
+
+    private companion object {
+        /** Below this the page is dark rather than the white a document is authored on. */
+        private const val DARK_LUMINANCE = 128
+
+        private const val WHITE = 255
+
+        private const val SAMPLE_STEP = 8
+    }
+}

--- a/app/src/androidTest/java/app/opendocument/droid/test/DarkModeTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/DarkModeTests.kt
@@ -22,6 +22,7 @@ import java.io.InputStream
 import java.util.concurrent.atomic.AtomicReference
 import org.junit.After
 import org.junit.Assert
+import org.junit.Assume
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -64,6 +65,11 @@ class DarkModeTests {
     /** What is drawn, not only the flag: a webview ignoring the setting passes the flag check. */
     @Test
     fun theDrawnPageIsDark() {
+        Assume.assumeTrue(
+            "this webview has no darkening api at all - nothing the app sets could reach it",
+            canDarken(),
+        )
+
         openPageView("test.odt")
 
         // the darkening lands while compositing, which the load callback does not wait for
@@ -73,20 +79,62 @@ class DarkModeTests {
         )
     }
 
+    /** Printing holds the page light, and only the last job still reading it gives it back. */
+    @Test
+    fun printingGivesTheDarkeningBack() {
+        val pageView = openPageView("test.odt")
+
+        onMainThread {
+            pageView.suspendDarkening()
+            pageView.suspendDarkening()
+        }
+        assertNotDarkened(pageView)
+
+        onMainThread { pageView.resumeDarkening() }
+        assertNotDarkened(pageView)
+
+        onMainThread { pageView.resumeDarkening() }
+        assertDarkened(pageView)
+    }
+
     private fun assertDarkened(pageView: PageView) {
         Assert.assertTrue("the page was not allowed to darken", pageView.isDarkeningAllowed)
 
-        if (!WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)) {
-            return
-        }
+        val darkening = darkeningSetting(pageView) ?: return
 
-        val allowed = AtomicReference(false)
-        onMainThread {
-            allowed.set(WebSettingsCompat.isAlgorithmicDarkeningAllowed(pageView.settings))
-        }
-
-        Assert.assertTrue("the webview was not told to darken the page", allowed.get())
+        Assert.assertTrue("the webview was not told to darken the page", darkening)
     }
+
+    private fun assertNotDarkened(pageView: PageView) {
+        val darkening = darkeningSetting(pageView) ?: return
+
+        Assert.assertFalse("the webview was still told to darken the page", darkening)
+    }
+
+    /**
+     * What the webview was actually given, or null where it has neither api to ask - an old webview
+     * cannot darken a page whatever the app asks of it.
+     */
+    private fun darkeningSetting(pageView: PageView): Boolean? {
+        val darkening = AtomicReference<Boolean?>(null)
+
+        onMainThread {
+            if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)) {
+                darkening.set(WebSettingsCompat.isAlgorithmicDarkeningAllowed(pageView.settings))
+            } else if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
+                darkening.set(
+                    WebSettingsCompat.getForceDark(pageView.settings) !=
+                        WebSettingsCompat.FORCE_DARK_OFF
+                )
+            }
+        }
+
+        return darkening.get()
+    }
+
+    private fun canDarken() =
+        WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING) ||
+            WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)
 
     /**
      * What the middle of the screen draws, averaged - 0 is black and 255 white.

--- a/app/src/main/java/app/opendocument/droid/background/PrintingManager.kt
+++ b/app/src/main/java/app/opendocument/droid/background/PrintingManager.kt
@@ -1,8 +1,12 @@
 package app.opendocument.droid.background
 
 import android.content.Context
+import android.os.Bundle
+import android.os.CancellationSignal
 import android.os.Handler
 import android.os.HandlerThread
+import android.os.ParcelFileDescriptor
+import android.print.PageRange
 import android.print.PrintAttributes
 import android.print.PrintDocumentAdapter
 import android.print.PrintManager
@@ -12,6 +16,7 @@ import app.opendocument.droid.ui.SnackbarHelper
 import app.opendocument.droid.ui.activity.MainActivity
 import com.commonsware.android.print.PdfDocumentAdapter
 import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
 
 class PrintingManager {
 
@@ -21,9 +26,9 @@ class PrintingManager {
     private val backgroundHandler = Handler(backgroundThread.looper)
 
     /**
-     * [onFinished] runs on the main thread once the job is over, whether it printed or not. The
-     * adapter is laid out and written by the print framework long after this returns, so anything
-     * the WebView had to be put into for printing can only be undone from there.
+     * [onFinished] runs on the main thread once, when the print framework lets go of the adapter.
+     * The adapter is laid out and written long after this returns, so anything the WebView had to
+     * be put into for printing can only be undone from there.
      */
     @Suppress("DEPRECATION")
     fun print(activity: MainActivity, webView: WebView, onFinished: () -> Unit) {
@@ -41,7 +46,29 @@ class PrintingManager {
     ) {
         val printManager = activity.getSystemService(Context.PRINT_SERVICE) as PrintManager
 
-        val printJob = printManager.print(JOB_NAME, printAdapter, PrintAttributes.Builder().build())
+        // the adapter is done well before the job is: a printer that is off leaves the job queued
+        // or blocked for as long as it takes the user to notice, and the page is free either way.
+        // the job is still watched as the backstop, for the adapter that is dropped without a
+        // last call - whichever comes first wins, which is why this only runs once
+        val finishedOnce = AtomicBoolean(false)
+        val finish = {
+            if (finishedOnce.compareAndSet(false, true)) {
+                // the destroyed check belongs on the main thread, which is where it happens:
+                // there is nothing left to restore then, and the webview may be gone
+                activity.runOnUiThread {
+                    if (!activity.isFinishing && !activity.isDestroyed) {
+                        onFinished()
+                    }
+                }
+            }
+        }
+
+        val printJob =
+            printManager.print(
+                JOB_NAME,
+                FinishReportingAdapter(printAdapter, finish),
+                PrintAttributes.Builder().build(),
+            )
 
         val checkPrintJob =
             object : Runnable {
@@ -54,7 +81,7 @@ class PrintingManager {
                     // cancelled and failed are ends too - waiting only for isCompleted polls
                     // forever on the job the user dismissed
                     if (printJob.isCompleted || printJob.isCancelled || printJob.isFailed) {
-                        activity.runOnUiThread(onFinished)
+                        finish()
 
                         return
                     }
@@ -76,6 +103,36 @@ class PrintingManager {
 
     fun close() {
         backgroundThread.quit()
+    }
+
+    /** [delegate] with a note taken of [PrintDocumentAdapter.onFinish], the framework's goodbye. */
+    private class FinishReportingAdapter(
+        private val delegate: PrintDocumentAdapter,
+        private val onFinished: () -> Unit,
+    ) : PrintDocumentAdapter() {
+
+        override fun onStart() = delegate.onStart()
+
+        override fun onLayout(
+            oldAttributes: PrintAttributes?,
+            newAttributes: PrintAttributes?,
+            cancellationSignal: CancellationSignal?,
+            callback: LayoutResultCallback?,
+            extras: Bundle?,
+        ) = delegate.onLayout(oldAttributes, newAttributes, cancellationSignal, callback, extras)
+
+        override fun onWrite(
+            pages: Array<out PageRange>?,
+            destination: ParcelFileDescriptor?,
+            cancellationSignal: CancellationSignal?,
+            callback: WriteResultCallback?,
+        ) = delegate.onWrite(pages, destination, cancellationSignal, callback)
+
+        override fun onFinish() {
+            delegate.onFinish()
+
+            onFinished()
+        }
     }
 
     private companion object {

--- a/app/src/main/java/app/opendocument/droid/background/PrintingManager.kt
+++ b/app/src/main/java/app/opendocument/droid/background/PrintingManager.kt
@@ -20,16 +20,25 @@ class PrintingManager {
 
     private val backgroundHandler = Handler(backgroundThread.looper)
 
+    /**
+     * [onFinished] runs on the main thread once the job is over, whether it printed or not. The
+     * adapter is laid out and written by the print framework long after this returns, so anything
+     * the WebView had to be put into for printing can only be undone from there.
+     */
     @Suppress("DEPRECATION")
-    fun print(activity: MainActivity, webView: WebView) {
-        print(activity, webView.createPrintDocumentAdapter())
+    fun print(activity: MainActivity, webView: WebView, onFinished: () -> Unit) {
+        print(activity, webView.createPrintDocumentAdapter(), onFinished)
     }
 
     fun print(activity: MainActivity, pdfFile: File) {
-        print(activity, PdfDocumentAdapter(activity, JOB_NAME, pdfFile))
+        print(activity, PdfDocumentAdapter(activity, JOB_NAME, pdfFile)) {}
     }
 
-    private fun print(activity: MainActivity, printAdapter: PrintDocumentAdapter) {
+    private fun print(
+        activity: MainActivity,
+        printAdapter: PrintDocumentAdapter,
+        onFinished: () -> Unit,
+    ) {
         val printManager = activity.getSystemService(Context.PRINT_SERVICE) as PrintManager
 
         val printJob = printManager.print(JOB_NAME, printAdapter, PrintAttributes.Builder().build())
@@ -37,6 +46,7 @@ class PrintingManager {
         val checkPrintJob =
             object : Runnable {
                 override fun run() {
+                    // nothing left to restore, and the webview it would touch may be gone
                     if (activity.isFinishing || activity.isDestroyed) {
                         return
                     }
@@ -44,6 +54,8 @@ class PrintingManager {
                     // cancelled and failed are ends too - waiting only for isCompleted polls
                     // forever on the job the user dismissed
                     if (printJob.isCompleted || printJob.isCancelled || printJob.isFailed) {
+                        activity.runOnUiThread(onFinished)
+
                         return
                     }
 

--- a/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
@@ -160,10 +160,9 @@ class DocumentFragment : Fragment(), DocumentLoader.Listener {
 
             pageView.setDocumentFragment(this)
 
-            // a property of the page, not of the buttons over it - this used to be the last line
-            // of prepareActions(), which reached every new PageView only because the two are set
-            // up together. every one of them passes through here
-            pageView.disableDarkening()
+            // every format, pdf included. the one place that is decided, and every new PageView
+            // passes through here
+            pageView.setDarkeningAllowed(true)
         } catch (t: Throwable) {
             // crashManager is not set yet: onViewCreated has not run
 

--- a/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
@@ -537,14 +537,15 @@ class MainActivity : AppCompatActivity() {
                 analyticsManager.report("menu_print")
 
                 documentFragment?.pageView?.let { pageView ->
-                    // printing a dark page wastes ink, but the setting has to come back
-                    // afterwards or the rest of the document is read in light mode. only once
-                    // the job is over: the print framework reads the page well after print()
-                    val wasDark = pageView.isDarkeningAllowed
+                    // printing a dark page wastes ink, so the page is held light for as long as
+                    // the framework is reading it - which is long after print() returns. what it
+                    // is given back to is looked up again: a document closed meanwhile took its
+                    // WebView with it, and the one that replaced it was never suspended
+                    pageView.suspendDarkening()
 
-                    pageView.setDarkeningAllowed(false)
-
-                    printingManager.print(this, pageView) { pageView.setDarkeningAllowed(wasDark) }
+                    printingManager.print(this, pageView) {
+                        documentFragment?.pageView?.resumeDarkening()
+                    }
                 }
             }
 

--- a/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
@@ -537,9 +537,14 @@ class MainActivity : AppCompatActivity() {
                 analyticsManager.report("menu_print")
 
                 documentFragment?.pageView?.let { pageView ->
-                    pageView.disableDarkening()
+                    // printing a dark page wastes ink, but the setting has to come back
+                    // afterwards or the rest of the document is read in light mode. only once
+                    // the job is over: the print framework reads the page well after print()
+                    val wasDark = pageView.isDarkeningAllowed
 
-                    printingManager.print(this, pageView)
+                    pageView.setDarkeningAllowed(false)
+
+                    printingManager.print(this, pageView) { pageView.setDarkeningAllowed(wasDark) }
                 }
             }
 

--- a/app/src/main/java/app/opendocument/droid/ui/widget/PageView.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/widget/PageView.kt
@@ -156,30 +156,35 @@ constructor(context: Context, attributeSet: AttributeSet?) :
         }
     }
 
+    /** What [setDarkeningAllowed] was last set to, so printing can turn it off and put it back. */
+    var isDarkeningAllowed = false
+        private set
+
     /**
-     * Keeps the document on the background it was authored against, whatever the app theme is.
+     * Whether the document follows the app into night mode, which is only ever a question while the
+     * app is in it: the webview darkens a page algorithmically, and at targetSdk 33 and up only
+     * once the app theme reports itself as dark.
      *
-     * The app shell follows night mode, the page does not: inverting a document is a rendering
-     * decision the reader has not asked for, and it goes badly on the tables, coloured text and
-     * images a real odt or docx is full of. Note this only became a live question when the theme
-     * moved to Material3.DayNight - at targetSdk 33 and up the webview only darkens when the app
-     * theme reports itself as dark, so under the old AppCompat.Light theme none of this ever fired.
-     *
-     * There is no parameter to this any more. It used to take an `isDarkModeSupported` that nothing
-     * in here ever read - both callers reached the same three lines - while [DocumentFragment] went
-     * to the trouble of working out that a pdf is not worth inverting. A user facing "dark
-     * documents" setting can grow the argument back when there is something on the other end of it.
+     * [DocumentFragment] decides which documents get it.
      */
     @Suppress("DEPRECATION") // setForceDarkAllowed and setForceDark are the pre-webkit-1.6 api
-    fun disableDarkening() {
+    fun setDarkeningAllowed(allowed: Boolean) {
+        isDarkeningAllowed = allowed
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            isForceDarkAllowed = false
+            isForceDarkAllowed = allowed
         }
 
         if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)) {
-            WebSettingsCompat.setAlgorithmicDarkeningAllowed(settings, false)
+            WebSettingsCompat.setAlgorithmicDarkeningAllowed(settings, allowed)
         } else if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
-            WebSettingsCompat.setForceDark(settings, WebSettingsCompat.FORCE_DARK_OFF)
+            // AUTO rather than ON: the pre-webkit-1.6 api darkens unconditionally otherwise,
+            // which would invert the page in a light themed app too
+            WebSettingsCompat.setForceDark(
+                settings,
+                if (allowed) WebSettingsCompat.FORCE_DARK_AUTO
+                else WebSettingsCompat.FORCE_DARK_OFF,
+            )
         }
     }
 

--- a/app/src/main/java/app/opendocument/droid/ui/widget/PageView.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/widget/PageView.kt
@@ -3,6 +3,7 @@ package app.opendocument.droid.ui.widget
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
 import android.net.Uri
 import android.os.Build
 import android.os.Handler
@@ -156,9 +157,16 @@ constructor(context: Context, attributeSet: AttributeSet?) :
         }
     }
 
-    /** What [setDarkeningAllowed] was last set to, so printing can turn it off and put it back. */
+    /** What [setDarkeningAllowed] was last set to, whether or not printing has it suspended. */
     var isDarkeningAllowed = false
         private set
+
+    /**
+     * How many print jobs are still reading the page. Counted rather than a flag: the framework
+     * keeps reading well after `print()` returns, so a second job can start while the first is
+     * still spooling, and the page may only darken again once the last of them is done.
+     */
+    private var darkeningSuspensions = 0
 
     /**
      * Whether the document follows the app into night mode, which is only ever a question while the
@@ -167,26 +175,56 @@ constructor(context: Context, attributeSet: AttributeSet?) :
      *
      * [DocumentFragment] decides which documents get it.
      */
-    @Suppress("DEPRECATION") // setForceDarkAllowed and setForceDark are the pre-webkit-1.6 api
     fun setDarkeningAllowed(allowed: Boolean) {
         isDarkeningAllowed = allowed
 
+        applyDarkening()
+    }
+
+    /**
+     * Holds the page light while the print framework reads it - printing a darkened document wastes
+     * ink. Every call has to be matched by a [resumeDarkening], or the rest of the document is read
+     * in light mode.
+     */
+    fun suspendDarkening() {
+        darkeningSuspensions++
+
+        applyDarkening()
+    }
+
+    fun resumeDarkening() {
+        if (darkeningSuspensions > 0) {
+            darkeningSuspensions--
+        }
+
+        applyDarkening()
+    }
+
+    @Suppress("DEPRECATION") // setForceDarkAllowed and setForceDark are the pre-webkit-1.6 api
+    private fun applyDarkening() {
+        val darken = isDarkeningAllowed && darkeningSuspensions == 0
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            isForceDarkAllowed = allowed
+            isForceDarkAllowed = darken
         }
 
         if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)) {
-            WebSettingsCompat.setAlgorithmicDarkeningAllowed(settings, allowed)
+            WebSettingsCompat.setAlgorithmicDarkeningAllowed(settings, darken)
         } else if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
-            // AUTO rather than ON: the pre-webkit-1.6 api darkens unconditionally otherwise,
-            // which would invert the page in a light themed app too
+            // ON rather than AUTO on the pre-webkit-1.6 api: AUTO is the platform's smart dark,
+            // which an app declaring a dark theme is deliberately left out of, so it never fires
+            // here. Asking the app whether it is in night mode is what AUTO cannot do for us
             WebSettingsCompat.setForceDark(
                 settings,
-                if (allowed) WebSettingsCompat.FORCE_DARK_AUTO
+                if (darken && isInNightMode()) WebSettingsCompat.FORCE_DARK_ON
                 else WebSettingsCompat.FORCE_DARK_OFF,
             )
         }
     }
+
+    private fun isInNightMode() =
+        resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK ==
+            Configuration.UI_MODE_NIGHT_YES
 
     override fun loadUrl(url: String) {
         wasCommitCalled = false


### PR DESCRIPTION
From user feedback: *"Kein Dark Mode mehr wie vorher?"*

The redesign (#547) replaced `PageView.toggleDarkMode(enabled)` with `disableDarkening()`, called on every page. The shell kept following night mode; only the document stayed white. In night mode the app was a dark frame around a white page.

## The change

`setDarkeningAllowed(allowed)`, called once per `PageView` in `DocumentFragment.initializePageView()`. It is on for **every** format, pdf included — the pre-redesign code excluded pdf, but rather than guess which formats invert badly we can look at a spread of real documents in the simulator and cut it back from that one line.

Darkening only ever does anything while the app itself is in night mode: at targetSdk 33+ the WebView darkens algorithmically and only once the app theme reports itself dark.

`PrintingManager` takes its `onFinished` callback back, so printing can turn darkening off and put it back once the job ends — the print framework reads the page long after `print()` returns, so it cannot be restored inline.

## Tests

`DarkModeTests` puts the app in night mode and checks three things, weakest to strongest:

1. the flag this app kept
2. the setting the WebView was actually given (`WebSettingsCompat.isAlgorithmicDarkeningAllowed`)
3. **what is drawn** — a screenshot of the middle of the screen, asserting mean luminance is below half

The third is the one that matters: a WebView that ignored the setting would pass the first two. It has to be a screenshot rather than `pageView.draw()` into a bitmap — the WebView renders on the compositor, so drawing it into a bitmap of our own hands back an empty layer whatever the page looks like. That version passed against the broken behaviour, which is how it was caught.

All three fail against the old behaviour, the screenshot one with `the page stayed light - mean luminance 255`.

## Verified

`spotlessCheck`, `testProDebugUnitTest`, `lintProDebug`, `assembleDebug`, and the full instrumented suite (72 tests) green on a Pixel 9 Pro emulator.

On a short landscape AVD (`ODR_Screenshots`, 1216x535) `MainActivityTests.testPasswordProtectedODT` fails — it does so 3/3 on `main` as well, so it is that AVD and not this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)