### PR TITLE
Say what the dark mode screenshot actually settled at

### DIFF
--- a/app/src/androidTest/java/app/opendocument/droid/test/DarkModeTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/DarkModeTests.kt
@@ -72,11 +72,14 @@ class DarkModeTests {
 
         openPageView("test.odt")
 
-        // the darkening lands while compositing, which the load callback does not wait for
-        Assert.assertTrue(
-            "the page stayed light - mean luminance ${meanLuminance()}",
-            waitFor(30000) { meanLuminance() < DARK_LUMINANCE },
-        )
+        // the darkening lands while compositing, which the load callback does not wait for, and
+        // an emulator painting through swiftshader has taken longer than the 30s the loads get.
+        // the last reading is kept for the message: an argument is evaluated before the call it
+        // is an argument to, so measuring it there would report the screen before the wait
+        var luminance = WHITE
+        val darkened = waitFor(60000) { meanLuminance().also { luminance = it } < DARK_LUMINANCE }
+
+        Assert.assertTrue("the page stayed light - mean luminance $luminance", darkened)
     }
 
     /** Printing holds the page light, and only the last job still reading it gives it back. */


### PR DESCRIPTION
A leftover from #596, which was merged while this was still on the branch.

`DarkModeTests.theDrawnPageIsDark` reported the wrong number on every failure:

```kotlin
Assert.assertTrue(
    "the page stayed light - mean luminance ${meanLuminance()}",
    waitFor(30000) { meanLuminance() < DARK_LUMINANCE },
)
```

An argument is evaluated before the call that takes it, so the message measured
the screen *before* the wait it describes. The `255` that the API 26, 29 and 30
failures printed was the page at load time, not after the 30 seconds of polling.
Those were real failures either way, but the number never said anything about
what the test was waiting on. The last reading is kept for the message now.

The wait is 60s. On #596 the API 34 job failed once, on the flavour that runs
first, and passed on the two flavours after it on the same emulator - one logging
`Failed to find ColorBuffer` throughout - and a rerun was green on all five API
levels. A screenshot arriving late is the likeliest reading of that, and a
failure will now say which it was.

## Verified

`spotlessCheck` and `DarkModeTests` green on a Pixel 9 Pro emulator; the full
73-test suite green there on foss and on an API 29 emulator on pro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4Tbjr2eTpVkBxDfdFnkgF