### PR TITLE
Take odrcore 6.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ takes 500 characters, so not everything here reaches the store.
 ## Unreleased
 
 - Dark mode reaches the document again, not just the screen around it.
+- A large text file appears at once. A megabyte took the better part of a minute
+  to lay out and now takes under a second.
+- A text file of prose is read as text, not mistaken for a spreadsheet because
+  its sentences contain commas. Short comma-separated values still open as one.
+- Text reflowed to the screen keeps a small margin from the edge instead of
+  starting at the very first pixel.
 - PDFs that do not carry their own fonts read properly: the words no longer
   drift further right along each line, and Find lands on the word you looked for
   rather than the one beside it. Bold and italic writing is drawn bold and

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ googleJavaFormat = "1.35.0"
 ktfmt = "0.64"
 
 # odrcore's JNI bindings, java and native in one AAR, published from OpenDocument.core
-odrCore = "6.7.1"
+odrCore = "6.8.0"
 
 androidxAnnotation = "1.10.0"
 androidxAppcompat = "1.7.1"


### PR DESCRIPTION
The engine moves from 6.7.1 to 6.8.0, and nothing here has to move with it. The format table gains a `color_scheme` capability per row and nothing else — no type, extension or mime type changes — so `SupportedDocumentTypes` derives the same two sets and `STRICT_CATCH`'s generated intent-filters still match them, which `SupportedFormatsTest` confirms. `FileTypeCapabilities` and `HtmlConfig` gain a field each, both additive, and `CoreLoader` names the ones it sets.

6.8.0's headline is the one thing this app already answers itself. The core can now render a file in the dark, on `HtmlConfig.colorScheme`, which defaults to `LIGHT` and writes nothing at all in that case — no `color-scheme` declaration reaches the page, so the algorithmic darkening `PageView` turns on keeps working exactly as it did in #596. Handing that job to the core instead is worth doing, since it would let a document's own colours give way rather than be inverted, and it is a change of its own rather than part of taking the version.

What reaches a user is text this time. A megabyte of it took 38 seconds to lay out, because sizing the line numbers laid the page out once per line, and now takes under a second. Prose is no longer read as a csv: a separator every field follows with a space, in fields long enough to be sentences, is punctuation, while `a, b, c` with short values is still a table. And text reflowed to the viewport is inset 3mm from the screen edge rather than starting at its first pixel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)