### PR TITLE
Do not let a page that was navigated away from fail the one that replaced it

### DIFF
--- a/app/src/main/java/app/opendocument/droid/ui/widget/PageView.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/widget/PageView.kt
@@ -53,6 +53,9 @@ constructor(context: Context, attributeSet: AttributeSet?) :
 
     private var wasCommitCalled = false
 
+    /** What [loadUrl] was last given: the only page whose failure is this document's. */
+    private var loadedUrl: String? = null
+
     private var isBridgeAttached = false
 
     init {
@@ -316,6 +319,14 @@ constructor(context: Context, attributeSet: AttributeSet?) :
         // the third party viewers an ONLINE result loads here. takes effect on the next load
         if (!url.startsWith(JAVASCRIPT_SCHEME)) {
             attachBridge(isOwnContent(url))
+
+            // a page that never committed left a retry waiting in onPageFinished. Now that another
+            // page has been asked for, that retry would load the old one back over it - and the
+            // document it belonged to has taken its server with it, so what it would find there is
+            // a 404 this page is then given up on for
+            buggyWebViewHandler.removeCallbacksAndMessages(null)
+
+            loadedUrl = url
         }
 
         super.loadUrl(url)
@@ -336,6 +347,13 @@ constructor(context: Context, attributeSet: AttributeSet?) :
         // only the document is the app's to give up on. a link shouldOverrideUrlLoading could not
         // hand to another app is left to the webview, and fails here as a main frame load too
         if (!isOwnContent(url.toString())) {
+            return
+        }
+
+        // and only the page being shown. A request made for a document already closed can still be
+        // answered here, long after the page moved on, and the document on screen is not the one
+        // that failed
+        if (loadedUrl != null && url.toString() != loadedUrl) {
             return
         }
 

--- a/app/src/main/java/app/opendocument/droid/ui/widget/PageView.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/widget/PageView.kt
@@ -82,7 +82,12 @@ constructor(context: Context, attributeSet: AttributeSet?) :
 
                     buggyWebViewHandler.postDelayed(
                         {
-                            if (!wasCommitCalled) {
+                            // [url] and not whatever is loaded now: this callback can arrive after
+                            // another page was asked for, which cancels the retries queued until
+                            // then but not the one queued here. wasCommitCalled is about the page
+                            // being waited on, so on its own it would answer for that other page
+                            // and put this one back over it
+                            if (!wasCommitCalled && url == loadedUrl) {
                                 crashManager.log(RuntimeException("commit was not called"))
 
                                 loadUrl(url)


### PR DESCRIPTION
Stacked on #600.

`testDOCXEditMode` and `testODTEditMode` have been failing an api level at a time all week — six reruns in one afternoon — always with:

```
DOCX should become editable after entering edit mode.
dom=webview did not answer in 10000ms document=no result
```

`document=no result` is the tell. `lastDocument` is only null once something called `unload`, so the document had not merely failed to become editable: it had been given up on.

## What logcat from a failing run says

```
13:47:24.025  serving http://localhost:29665/file/odr/document.html.missing failed: 404   <- the test before
13:47:25.801  started: testDOCXEditMode
13:47:26.079  loading document at: .../style-various-1.docx
13:47:26.292  serving http://localhost:29665/file/odr/document.html failed: 404 Not Found
              at PageView.failPage → onReceivedHttpError
13:47:26.358  RuntimeException: missing listener at DocumentLoader.deliver
```

A page that never commits leaves a reload scheduled 2.5s out — the workaround for a webview that reports progress 100 over a blank page — and nothing cancelled it when the next page was asked for. The previous test had deliberately loaded a page that 404s, so its retry fired *inside the next test*, went back to a server that had gone with the document that owned it, and got a 404. `onReceivedHttpError` reported that against whatever document was on screen by then.

The 404 arrives 200ms after the docx starts loading, which is far too soon to be that document's own page.

## The fix

- `loadUrl` cancels a retry the page before it left waiting, the way `destroy` already does when the whole view is replaced. Same handler, the gap was a new url in the *same* view.
- `failPage` answers only for the page it was last asked to load.

Nothing is loosened: `LandingTests.aDocumentThatFailsToOpenComesBackToTheList` holds the case that matters — a document whose page really is a 404 — and the whole instrumented suite, 80 tests, passes locally on API 29.

A flake fix cannot be proven by one green run; what can be shown is the mechanism, and that is in the log above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)