### PR TITLE
Wait for the shell command before sending the next one

### DIFF
--- a/app/src/androidTest/java/app/opendocument/droid/test/ScreenshotTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/ScreenshotTests.kt
@@ -9,6 +9,7 @@ import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Build
 import android.os.LocaleList
+import android.os.ParcelFileDescriptor
 import android.os.SystemClock
 import android.view.View
 import android.view.ViewGroup
@@ -753,11 +754,24 @@ class ScreenshotTests {
         private fun argument(name: String): String? =
             InstrumentationRegistry.getArguments().getString(name)
 
+        /**
+         * Runs a shell command and waits for it to have finished.
+         *
+         * Waits by reading: the pipe reaches its end when the command exits, and closing it unread
+         * instead returns in a handful of milliseconds whatever the command was doing - five,
+         * measured, for a `sleep 2`. Which is how the store set came back with a status bar reading
+         * the real time: `demo enter` landed and the six commands after it, the clock and the
+         * battery among them, were fired into a device already busy with the next one. `am
+         * broadcast` answers `Broadcast completed` once its receiver has run, so waiting for it is
+         * also what puts them in order.
+         */
         private fun shell(command: String) {
-            InstrumentationRegistry.getInstrumentation()
-                .uiAutomation
-                .executeShellCommand(command)
-                .use { /* the command runs whether or not anything reads its output */ }
+            val pipe =
+                InstrumentationRegistry.getInstrumentation()
+                    .uiAutomation
+                    .executeShellCommand(command)
+
+            ParcelFileDescriptor.AutoCloseInputStream(pipe).use { it.readBytes() }
         }
 
         /**


### PR DESCRIPTION
The first full set of store screenshots off CI came back with this status bar, in
all fifteen locales of both devices:

> `6:54` … and a charging bolt in the battery

Not `9:41`, and not the battery `dressTheDevice` asks for - *"plugged false, or
the battery is drawn with a charging bolt in it, which says the picture was taken
on a desk rather than that the app was being used"*.

## What happened

Demo mode **did** enter: the clock is frozen at the same minute in the first
locale captured and the last, half an hour apart. It is the six commands behind
`enter` that never landed - the clock, the battery, the notifications, the radios.

`shell` closed the pipe without reading it:

```kotlin
.executeShellCommand(command)
.use { /* the command runs whether or not anything reads its output */ }
```

It does not. The pipe is what carries the command's end, so closing it unread
returns immediately and the next command is sent into a device still busy with
the one before. Measured on an emulator, three rounds of `sleep 2`:

| | closed unread | read to the end |
|---|---|---|
| round 1 | 16ms | 2004ms |
| round 2 | 5ms | 2035ms |
| round 3 | 12ms | 2015ms |

On this laptop they arrive anyway, which is why it has always been 9:41 here and
never there.

## The fix

Read the descriptor to its end. That waits, and for the demo commands it also
puts them in order: `am broadcast` answers `Broadcast completed: result=0` once
its receiver has run, so there is something to wait for.

```
broadcast said: Broadcasting: Intent { act=com.android.systemui.demo ... }
                Broadcast completed: result=0
```

The same helper writes `user_rotation`, `accelerometer_rotation`, the night mode
and the navigation bar overlay. None of those were being waited on either, so the
rotation loop and the theme change were racing the same way - the rotation just
had a 2.5s sleep behind it that covered for it.

## Checked

The mechanism is measured above rather than argued. Locally the set still comes
out `9:41` with a clean battery, so nothing regressed. The symptom itself only
shows on a slow emulator, so a dry run is going to confirm it on CI - I will note
the result here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)