### PR TITLE
Take odrcore 6.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,20 @@ takes 500 characters, so not everything here reaches the store.
   with the highlight that selects it.
 - Selecting or finding across words in a PDF covers the spaces between them
   rather than leaving a sliver of white in every gap.
+- A filled-in PDF form shows what was filled in, and a marked-up one shows its
+  notes and highlights.
+- A scanned PDF shows the scan rather than a blank page.
+- Justified writing in a PDF is spaced the way the file asks instead of falling
+  short of the margin, and a page written sideways is turned the right way up.
+- More PDFs come out right: writing set in a cut-down font shows the characters
+  it should, and files whose compressed parts end short open at all.
 - Tapping the text of a paged document reaches it, so selecting and copying work
   where the page used to swallow the tap.
+- A Word document is spaced the way Word spaces it: the gaps above and below
+  paragraphs, the height of a line, lists that stay tight, and table rows that
+  keep the height they were given.
+- A Word table follows the style it was built with, so its writing looks the way
+  the document sets it up.
 
 ## 4.15.0
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ googleJavaFormat = "1.35.0"
 ktfmt = "0.64"
 
 # odrcore's JNI bindings, java and native in one AAR, published from OpenDocument.core
-odrCore = "6.8.0"
+odrCore = "6.9.0"
 
 androidxAnnotation = "1.10.0"
 androidxAppcompat = "1.7.1"


### PR DESCRIPTION
The engine moves from 6.8.0 to 6.9.0, and nothing here has to move with it. No file
type, extension or mime type changes, so `SupportedDocumentTypes` derives the same two
sets and `STRICT_CATCH`'s generated intent-filters still match them, which
`SupportedFormatsTest` confirms.

The only binding change is subtractive: `HtmlConfig.embedOutline`, `noDrm`,
`backgroundImageFormat` and `backgroundImageDpi` are deprecated and inert. `CoreLoader`
sets none of the four - it names `embedImages`, `embedShippedResources`,
`relativeResourcePaths`, `textDocumentMargin`, `editable` and `colorScheme` - so there is
nothing to unset and no new API to take up. What 6.9.0 brings arrives in the rendering,
for free.

That rendering is pdf and docx. A filled-in form now shows what was filled in and a
marked-up pdf its markup, both painted from the annotation's own appearance stream;
hidden, no-view and popup annotations stay off the page. A scanned page decodes rather
than coming out blank, `JBIG2Decode` in house - MMR/Huffman, refinement and halftone
regions still skip the image. Justified text is spaced as the file asks, a page is turned
as its `/Rotate` says, a subset font naming its glyphs `gidNNNNN` reads correctly, and a
Flate stream that omits its ADLER32 trailer opens instead of failing.

A `.docx` is spaced the way word spaces it - paragraph spacing before and after, line
height, the contextual spacing that keeps a list tight, and table row heights as a
minimum - and a table follows the paragraph and text properties its `w:tblStyle` names.

## Drafted ahead of the release

6.9.0 is the version cliff will cut - three `feat:` commits since v6.8.0, nothing
breaking - but it is not on maven central yet. `:app:dependencies` resolves the whole
tree with exactly one failure, this one, so **CI cannot go green until the core's release
run publishes the AAR**. Mark it ready then; if the cut lands on a different number, the
one line in `gradle/libs.versions.toml` is the whole change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)