### PR TITLE
Say what the lite app opens in its title

### DIFF
--- a/fastlane/metadata-lite/android/all/title.txt
+++ b/fastlane/metadata-lite/android/all/title.txt
@@ -1,1 +1,1 @@
-OpenDocument Reader
+OpenDocument Reader - view ODT

--- a/fastlane/metadata/README.md
+++ b/fastlane/metadata/README.md
@@ -36,15 +36,19 @@ changed in `LOCALES`.
 
 ## The two things the apps do not share
 
-**The title.** Play has served `OpenDocument Reader Pro` in every storefront for
-years, and lite `OpenDocument Reader`. Neither is translated: OpenDocument is the
-format's own name, and one name is one app people can pass to each other. Nothing
-is lost to search by it - play indexes the title, the short description and the
-full description alike, so `LibreOffice` and the local words live in the short
-description, where there is room for them.
+**The title.** Pro is `OpenDocument Reader Pro`, lite `OpenDocument Reader - view
+ODT`. Neither is translated: OpenDocument is the format's own name, and one name is
+one app people can pass to each other - lite says what it opens after the name, not
+instead of it.
 
-Play refuses a title over 30 characters. The ones that used to be checked in here
-were written when the limit was 50 and eleven of the fifteen were over it.
+**Play refuses a title over 30 characters, and lite's is exactly 30.** So a word
+added to it has to take one out, and pro has no room for the same tail at all:
+`OpenDocument Reader Pro - view ODT` is 34. `scripts/store-listing.py` measures
+both before an upload rather than letting Play refuse the release.
+
+The rest of what a search should find goes in the short description, which play
+indexes just as it does the title: `LibreOffice`, and each language's own words for
+a document, live there, where there is room for them.
 
 **Advertising.** Pro links no ad SDK and shows none, but every description said
 ads were shown, in all fifteen languages. Rather than keep two descriptions per


### PR DESCRIPTION
Lite's Play title becomes `OpenDocument Reader - view ODT` - exactly the 30 characters
play allows. The name still leads; what follows it is for someone reading a page of
search results rather than looking the app up by name.

Pro keeps `OpenDocument Reader Pro`: the same tail would make it 34 characters, and pro
is found by people who already know what they are buying.

The listing is uploaded from this repository now, so this **overwrites the title in the
Play Console** on the next release run - or immediately, with `fastlane android
listingLite`, which sends the text without a bundle.

`scripts/store-listing.py --version v4.16.0` passes: the title is measured against the
same 30 characters play refuses over, so a word added to it later has to take one out.
`fastlane/metadata/README.md` spelled both titles out by hand, so it is updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)