### PR TITLE
Set the password instead of typing it, so the dialog stays still

### DIFF
--- a/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
@@ -13,10 +13,9 @@ import androidx.core.content.FileProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.espresso.IdlingResource
-import androidx.test.espresso.action.ViewActions.clearText
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.closeSoftKeyboard
-import androidx.test.espresso.action.ViewActions.typeText
+import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents
@@ -158,18 +157,20 @@ class MainActivityTests {
         // stays busy until it is on screen - so this does not have to poll for it.
         onView(withText("This document is password-protected")).check(matches(isDisplayed()))
 
-        onView(withClassName(equalTo("android.widget.EditText"))).perform(typeText("wrongpassword"))
+        // replaceText rather than typeText: typing raises the keyboard, which lifts the dialog
+        // 519px up the screen, and closing it again drops the dialog back while the click is
+        // already being injected - the tap lands outside, which cancels the dialog
+        onView(withClassName(equalTo("android.widget.EditText")))
+            .perform(replaceText("wrongpassword"))
 
-        // typing leaves the keyboard up, and on a short screen it covers the dialog's buttons
-        onView(withId(android.R.id.button1)).perform(closeSoftKeyboard(), click())
+        onView(withId(android.R.id.button1)).perform(click())
 
         // Should show password dialog again for wrong password
         onView(withText("This document is password-protected")).check(matches(isDisplayed()))
 
-        onView(withClassName(equalTo("android.widget.EditText")))
-            .perform(clearText(), typeText("passwort"))
+        onView(withClassName(equalTo("android.widget.EditText"))).perform(replaceText("passwort"))
 
-        onView(withId(android.R.id.button1)).perform(closeSoftKeyboard(), click())
+        onView(withId(android.R.id.button1)).perform(click())
 
         // Check if the document buttons become available (indicating successful load)
         waitForDocumentActions()


### PR DESCRIPTION
`testPasswordProtectedODT` failed on API 36, and only there: it typed the wrong
password, clicked OK, and the dialog it expected back never came. The failure
moved around between runs - sometimes the assertion after the wrong password,
sometimes `waitForDocumentActions` at the end - which is what a race looks like
from the outside.

The keyboard is what moves. `typeText` raises it, and an `AlertDialog` sitting
above it is lifted off the bottom of the screen: 519px of it on a Pixel 9 Pro,
measured through `uiautomator dump`, with the OK button going from y=1533 to
y=1014. `closeSoftKeyboard()` drops the dialog back, and the click that follows
in the same `perform` is injected while the window is still travelling, so the
tap lands where the button was rather than where it is. That is outside the
dialog, and an `AlertDialog` cancels on a touch outside it - so the button's
listener never ran, the password was never read, and no reload was queued.

Reproduced by hand with `input tap` at the pre-keyboard coordinates: the dialog
vanished, the screen went blank, and `CoreLoader` logged `host file` once for
the whole session. Tapping where the button actually was gave the two `host
file` calls and the `WrongPassword` the test is written around, so nothing in
the app is at fault.

`replaceText` sets the text without raising a keyboard, so nothing moves and the
click has a still target. `ScreenshotTests` already reaches for it, for its own
reason - the find bar searching on every keystroke. `clearText` goes with it,
since replacing is what it was there for.

Three runs of the test and a full suite pass on API 36, where it failed reliably
before; the suite also passes on API 31. CI's matrix is 26/29/30/32/34, which is
why this was never caught - API 36 is only used by the release run, where the
store screenshots are taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)