### PR TITLE
Take odrcore 6.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ takes 500 characters, so not everything here reaches the store.
 - More of a PDF's writing shows: text the file places with nothing in between
   was dropped and now appears.
 - More PDFs open at all, including files whose writing nests brackets inside it.
+- Pictures in a Word or Excel document appear, instead of a broken-image mark
+  where each one should be.
 
 ## 4.16.0
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ googleJavaFormat = "1.35.0"
 ktfmt = "0.64"
 
 # odrcore's JNI bindings, java and native in one AAR, published from OpenDocument.core
-odrCore = "6.10.0"
+odrCore = "6.10.1"
 
 androidxAnnotation = "1.10.0"
 androidxAppcompat = "1.7.1"


### PR DESCRIPTION
One fix, and it is ours: a linked image in a docx or xlsx is now named relative
to the document, the way the odf engines always named theirs. The ooxml side
resolved the relationship into an absolute container path and the html layer
emitted it verbatim, so `src="/word/media/image1.jpeg"` resolved against the
server root rather than against `/file/odr/`, and every picture in a Word or
Excel document 404ed into the core's broken-image placeholder.

Nothing here has to move with it. The app already asks for linked images rather
than embedded ones - `embedImages = false` - which is the shape the fix is for,
and `relativeResourcePaths` is not the lever it looks like: it governs only the
*shipped* resources, core's own css and js, never a document's own. No file
type, extension or mime type changes either, so `SupportedDocumentTypes` derives
the same two sets and `SupportedFormatsTest` still holds.

Drafted ahead of the release: 6.10.1 is not on maven central yet, so the one
unresolved dependency in the tree is this one and CI cannot go green until the
core's release run publishes the AAR. Everything else resolves.

Not yet checked on a device for the same reason. `image-anchor.docx` and
`file-sample_100kB.docx` from the core's corpus are the two that showed it, and
both should come back with their pictures rather than the placeholder.

Closes #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)