### PR TITLE
Give the edit button a place of its own

### DIFF
--- a/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/MainActivityTests.kt
@@ -23,6 +23,7 @@ import androidx.test.espresso.intent.VerificationModes.times
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withClassName
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -124,9 +125,20 @@ class MainActivityTests {
         // the load itself and not just the picker round trip.
         waitForDocumentActions()
 
-        unfoldDocumentActions()
+        // nothing unfolded: Edit stands on its own where the core can write the document back
+        onView(withContentDescription(R.string.menu_edit)).check(matches(isDisplayed()))
 
-        onView(withText(R.string.menu_edit)).check(matches(isDisplayed()))
+        // and pressing it edits the document, which is the whole of why it stands on its own:
+        // the listener on the standing button reaches MainActivity and the page turns editable
+        onView(withContentDescription(R.string.menu_edit)).perform(click())
+
+        val activity = mainActivityActivityTestRule.activity
+        val documentFragment = waitForDocumentFragment(activity, 10000)
+        Assert.assertNotNull(documentFragment)
+
+        val pageView = documentFragment!!.pageView
+        Assert.assertNotNull(pageView)
+        assertBecomesEditable("ODT", pageView!!, documentFragment)
     }
 
     @Test
@@ -140,9 +152,9 @@ class MainActivityTests {
         // says the pdf opened - Edit is not, because the core does not write pdf back
         waitForDocumentActions()
 
-        unfoldDocumentActions()
-
-        onView(withText(R.string.menu_edit)).check(doesNotExist())
+        // no unfolding first: every unfolding row is in the hierarchy whether the column is
+        // open or not, and doesNotExist walks all of it
+        onView(withContentDescription(R.string.menu_edit)).check(doesNotExist())
     }
 
     @Test
@@ -464,10 +476,6 @@ class MainActivityTests {
     // is still what is on screen.
     private fun waitForDocumentActions() {
         onView(withId(R.id.document_actions_more)).check(matches(isDisplayed()))
-    }
-
-    private fun unfoldDocumentActions() {
-        onView(withId(R.id.document_actions_more)).perform(click())
     }
 
     private fun recreate(activity: MainActivity): MainActivity? {

--- a/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
@@ -464,7 +464,7 @@ class DocumentFragment : Fragment(), DocumentLoader.Listener {
 
         // guarded like resetTabs below: a load can fail before there is a view to put right
         if (::actions.isInitialized) {
-            actions.setActions(null, emptyList())
+            actions.setActions(emptyList(), emptyList())
         }
 
         resetTabs()
@@ -558,7 +558,6 @@ class DocumentFragment : Fragment(), DocumentLoader.Listener {
                     R.string.menu_fullscreen,
                     R.drawable.ic_fullscreen,
                 ),
-                edit,
                 DocumentActions.Action(
                     DocumentActions.ACTION_TTS,
                     R.string.menu_tts,
@@ -586,11 +585,16 @@ class DocumentFragment : Fragment(), DocumentLoader.Listener {
                 ),
             )
 
+        // Edit above Search, not below it: Search is offered for every document and Edit is not,
+        // so this is the order that keeps the button nearest the thumb the same one throughout
         actions.setActions(
-            DocumentActions.Action(
-                DocumentActions.ACTION_SEARCH,
-                R.string.menu_search,
-                R.drawable.ic_search,
+            listOfNotNull(
+                edit,
+                DocumentActions.Action(
+                    DocumentActions.ACTION_SEARCH,
+                    R.string.menu_search,
+                    R.drawable.ic_search,
+                ),
             ),
             unfolding,
         )

--- a/app/src/main/java/app/opendocument/droid/ui/widget/DocumentActions.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/widget/DocumentActions.kt
@@ -10,12 +10,13 @@ import android.widget.ScrollView
 import android.widget.TextView
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.appcompat.widget.TooltipCompat
 import app.opendocument.droid.R
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 
 /**
  * What can be done with the open document, as buttons over the bottom right corner of it: one for
- * the action worth its own button, and one that unfolds the rest.
+ * each action worth its own button, and one that unfolds the rest.
  *
  * This is what the toolbar menu used to be. A document is read with the phone in one hand, and the
  * top right corner of a modern screen is the one place a thumb cannot reach - so the actions sit
@@ -23,7 +24,8 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton
  * are.
  *
  * Material ships no speed dial component (the one it had was never brought over to Material 3), so
- * the rows are built here from [R.layout.item_document_action].
+ * the buttons are built here, from [R.layout.item_document_action_standing] and
+ * [R.layout.item_document_action].
  */
 class DocumentActions(context: Context, attributeSet: AttributeSet?) :
     FrameLayout(context, attributeSet) {
@@ -44,7 +46,7 @@ class DocumentActions(context: Context, attributeSet: AttributeSet?) :
     private val buttons: LinearLayout
     private val rowsScroll: ScrollView
     private val rows: LinearLayout
-    private val primaryButton: FloatingActionButton
+    private val standingButtons: LinearLayout
     private val moreButton: FloatingActionButton
 
     private val basePaddingBottom: Int
@@ -64,7 +66,7 @@ class DocumentActions(context: Context, attributeSet: AttributeSet?) :
         buttons = findViewById(R.id.document_actions_buttons)
         rowsScroll = findViewById(R.id.document_actions_rows_scroll)
         rows = findViewById(R.id.document_actions_rows)
-        primaryButton = findViewById(R.id.document_actions_primary)
+        standingButtons = findViewById(R.id.document_actions_standing)
         moreButton = findViewById(R.id.document_actions_more)
 
         basePaddingBottom = buttons.paddingBottom
@@ -72,7 +74,7 @@ class DocumentActions(context: Context, attributeSet: AttributeSet?) :
         scrim.setOnClickListener { collapse() }
         moreButton.setOnClickListener { if (isExpanded) collapse() else expand() }
 
-        setActions(null, emptyList())
+        setActions(emptyList(), emptyList())
     }
 
     /**
@@ -92,22 +94,21 @@ class DocumentActions(context: Context, attributeSet: AttributeSet?) :
     }
 
     /**
-     * What the document can do right now. [primary] gets a button of its own, the rest unfold out
-     * of the second one, the first of them closest to it - so the order is most wanted first.
+     * What the document can do right now. Each of [standing] keeps a button of its own whether the
+     * rest are folded up or not, read top to bottom, so its last entry is the one closest to the
+     * thumb; [unfolding] comes out of the button below them and reads outward from it, its first
+     * entry closest.
      *
-     * Nothing and an empty list take the buttons away entirely, which is what a document that
-     * failed to load leaves behind.
+     * Two empty lists take the buttons away entirely, which is what a document that failed to load
+     * leaves behind.
      */
-    fun setActions(primary: Action?, unfolding: List<Action>) {
+    fun setActions(standing: List<Action>, unfolding: List<Action>) {
         collapse()
 
-        if (primary == null) {
-            primaryButton.visibility = View.GONE
-        } else {
-            primaryButton.visibility = View.VISIBLE
-            primaryButton.setImageResource(primary.icon)
-            primaryButton.contentDescription = context.getString(primary.label)
-            primaryButton.setOnClickListener { listener?.onDocumentActionClicked(primary.id) }
+        standingButtons.removeAllViews()
+
+        for (action in standing) {
+            standingButtons.addView(newStandingButton(action))
         }
 
         rows.removeAllViews()
@@ -119,6 +120,23 @@ class DocumentActions(context: Context, attributeSet: AttributeSet?) :
         }
 
         moreButton.visibility = if (unfolding.isEmpty()) View.GONE else View.VISIBLE
+    }
+
+    private fun newStandingButton(action: Action): View {
+        val button =
+            LayoutInflater.from(context)
+                .inflate(R.layout.item_document_action_standing, standingButtons, false)
+                as FloatingActionButton
+
+        button.setImageResource(action.icon)
+        button.contentDescription = context.getString(action.label)
+
+        // no label plate beside it, so the name is what a long press turns up
+        TooltipCompat.setTooltipText(button, context.getString(action.label))
+
+        button.setOnClickListener { listener?.onDocumentActionClicked(action.id) }
+
+        return button
     }
 
     private fun newRow(action: Action): View {

--- a/app/src/main/res/layout/item_document_action_standing.xml
+++ b/app/src/main/res/layout/item_document_action_standing.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- one action that stands on its own, folded up or not - see DocumentActions -->
+<com.google.android.material.floatingactionbutton.FloatingActionButton xmlns:android="http://schemas.android.com/apk/res/android"
+        style="@style/Widget.Material3.FloatingActionButton.Secondary"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end"
+        android:layout_marginBottom="16dp" />

--- a/app/src/main/res/layout/view_document_actions.xml
+++ b/app/src/main/res/layout/view_document_actions.xml
@@ -59,13 +59,16 @@
                     android:orientation="vertical" />
         </ScrollView>
 
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/document_actions_primary"
-                style="@style/Widget.Material3.FloatingActionButton.Secondary"
+        <!-- the actions that do not fold away, above the button the rest unfold from -->
+        <LinearLayout
+                android:id="@+id/document_actions_standing"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="end"
-                android:layout_marginBottom="16dp" />
+                android:clipChildren="false"
+                android:clipToPadding="false"
+                android:gravity="end"
+                android:orientation="vertical" />
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
                 android:id="@+id/document_actions_more"


### PR DESCRIPTION
A reader on F-Droid 4.16.0 wrote in: they had been editing LibreOffice documents for a while, and now found "keine Tastatur, keine Option, den Edit-Modus zu aktivieren".

Nothing is broken. I built `assembleFossDebug` at `v4.16.0` and opened an `.odt`: "Edit document" is there and works, keyboard and all. It is just very hard to find. Until 4.13 it was a pencil in the toolbar with `showAsAction="always"`; since the redesign in 4.14 it is the fifth of nine rows behind the unlabeled ⋮ button, below three rows that are all about how the page looks — so the fold-out reads as a display menu, and the pencil is four rows past where anyone stops looking.

So the pencil gets a standing button again. `DocumentActions.setActions` now takes a list of standing actions instead of one primary, and `DocumentFragment` passes `listOfNotNull(edit, search)`.

**Edit above Search, not below.** Search is offered for every document and Edit only where the core writes the format back, so this order keeps the button nearest the thumb the same one whatever is open. A PDF simply has one fewer button, and Search does not move.

Also: the standing buttons get a tooltip, since they have no label plate beside them.

| editable, folded up | editable, unfolded | pdf |
|---|---|---|
| pencil, search, more | edit is gone from the list | search, more — search unmoved |

`testODT` now asserts the button is displayed **without unfolding anything**, which is the whole point of the change; `testPDF` still asserts it does not exist. Both match on content description now that the standing button has no label text. Verified on a Pixel 9 Pro API 36 emulator: both tests pass, and one tap on the pencil goes straight into edit mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)