### PR TITLE
Hold on to the document a reload or a switch interrupts

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -173,6 +173,7 @@ jobs:
         path: |
           app/build/reports/androidTests/
           app/build/outputs/androidTest-results/
+          app/build/outputs/connected_android_test_additional_output/
         if-no-files-found: warn
 
     - name: Upload test logs

--- a/app/src/androidTest/java/app/opendocument/droid/test/DarkModeTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/DarkModeTests.kt
@@ -6,6 +6,7 @@ package app.opendocument.droid.test
 import android.content.Context
 import android.content.res.Configuration
 import android.content.res.Resources
+import android.graphics.Bitmap
 import android.net.Uri
 import android.os.SystemClock
 import androidx.appcompat.app.AppCompatDelegate
@@ -27,6 +28,7 @@ import app.opendocument.droid.ui.widget.DocumentActions
 import app.opendocument.droid.ui.widget.PageView
 import java.io.File
 import java.io.FileOutputStream
+import java.io.IOException
 import java.io.InputStream
 import java.util.concurrent.atomic.AtomicReference
 import org.junit.After
@@ -128,7 +130,8 @@ class DarkModeTests {
         val darkened = waitFor(60000) { meanLuminance().also { luminance = it } < DARK_LUMINANCE }
 
         Assert.assertTrue(
-            "the page stayed light - mean luminance $luminance; ${darkeningDiagnosis()}",
+            "the page stayed light - mean luminance $luminance; ${darkeningDiagnosis()}" +
+                keptScreenshot(darkened, "theDrawnPageIsDark"),
             darkened,
         )
     }
@@ -166,7 +169,8 @@ class DarkModeTests {
         val darkened = waitFor(60000) { meanLuminance().also { luminance = it } < DARK_LUMINANCE }
 
         Assert.assertTrue(
-            "the page stayed light - mean luminance $luminance; ${darkeningDiagnosis()}",
+            "the page stayed light - mean luminance $luminance; ${darkeningDiagnosis()}" +
+                keptScreenshot(darkened, "theSwitchDarkensADayModeApp"),
             darkened,
         )
         Assert.assertEquals(
@@ -304,6 +308,39 @@ class DarkModeTests {
         screen.recycle()
 
         return if (counted == 0) WHITE else (total / counted).toInt()
+    }
+
+    /**
+     * The screen a failed reading was taken off, written where gradle collects it: a mean luminance
+     * cannot tell a page that drew light from one that never drew.
+     *
+     * `additionalTestOutputDir` is gradle's own, copied back before the apks go - see
+     * `ScreenshotTests`. A run started by hand is given none.
+     */
+    private fun keptScreenshot(darkened: Boolean, name: String): String {
+        if (darkened) {
+            return ""
+        }
+
+        val given =
+            InstrumentationRegistry.getArguments().getString("additionalTestOutputDir")
+                ?: return "; no additionalTestOutputDir to write the screen to"
+
+        return try {
+            val directory = File(given, "dark-mode").apply { mkdirs() }
+            val target = File(directory, "$name.png")
+
+            val screen =
+                InstrumentationRegistry.getInstrumentation().uiAutomation.takeScreenshot()
+                    ?: return "; the screen could not be photographed either"
+
+            FileOutputStream(target).use { screen.compress(Bitmap.CompressFormat.PNG, 100, it) }
+            screen.recycle()
+
+            "; the screen is in ${target.name}"
+        } catch (e: IOException) {
+            "; the screen could not be written: $e"
+        }
     }
 
     private fun openPageView(name: String): PageView {

--- a/app/src/main/java/app/opendocument/droid/background/CoreLoader.kt
+++ b/app/src/main/java/app/opendocument/droid/background/CoreLoader.kt
@@ -35,6 +35,9 @@ class CoreLoader(private val context: Context) {
     private var document: Document? = null
     private var lastInputPath: String? = null
 
+    /** Counts the renders, so each one publishes under a prefix of its own - see [render]. */
+    private var renderCount = 0
+
     /**
      * Whether the document [host] last opened is one [edit] can do something with - the core's own
      * answer, since [host] only keeps a document that reports itself editable and savable.
@@ -54,6 +57,9 @@ class CoreLoader(private val context: Context) {
     /**
      * Renders [file] and publishes it, replacing whatever was published before.
      *
+     * Under a prefix of its own, so a request the page it replaces still had in flight cannot be
+     * mistaken for one for the new page - `PageView.failPage` tells them apart by url.
+     *
      * Throws what odrcore threw: which failure it is decides which bar the user gets, so
      * [DocumentLoader] needs the exception itself.
      */
@@ -70,7 +76,7 @@ class CoreLoader(private val context: Context) {
 
         val views =
             host(
-                prefix = "odr",
+                prefix = "odr" + renderCount++,
                 inputPath = cachedFile.path,
                 cachePath = coreCacheDirectory.path,
                 password = request.password,

--- a/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
@@ -224,7 +224,7 @@ class DocumentFragment : Fragment(), DocumentLoader.Listener {
 
         initializePageView()
 
-        restore(savedInstanceState)
+        val pageRestored = restore(savedInstanceState)
 
         state.lastDocument?.let { lastDocument ->
             crashManager.log("restoring lastDocument")
@@ -234,6 +234,12 @@ class DocumentFragment : Fragment(), DocumentLoader.Listener {
 
             restoreTabs(lastDocument)
             prepareActions(lastDocument)
+
+            // a webview saves nothing until it has committed a page, and the night mode switch
+            // recreating this activity can come sooner than that. the tabs load a part themselves
+            if (!pageRestored && lastDocument.partUris.size == 1) {
+                loadData(lastDocument.partUris[0].toString())
+            }
         }
     }
 
@@ -245,8 +251,10 @@ class DocumentFragment : Fragment(), DocumentLoader.Listener {
      * classes this one no longer has, and [android.os.Bundle] reads its whole map on the first
      * access, so one stale entry takes the rest with it. Losing the reopened document beats
      * throwing on launch.
+     *
+     * Answers whether the page view got a page back out of it.
      */
-    private fun restore(savedInstanceState: Bundle) {
+    private fun restore(savedInstanceState: Bundle): Boolean {
         try {
             if (state.lastRequest == null) {
                 @Suppress("DEPRECATION") // the typed getParcelable overload needs API 33
@@ -262,9 +270,11 @@ class DocumentFragment : Fragment(), DocumentLoader.Listener {
                 state.currentHtmlDiff = savedInstanceState.getString(SAVED_KEY_CURRENT_HTML_DIFF)
             }
 
-            pageView?.restoreState(savedInstanceState)
+            return pageView?.restoreState(savedInstanceState) != null
         } catch (e: Throwable) {
             crashManager.log(e)
+
+            return false
         }
     }
 
@@ -320,6 +330,9 @@ class DocumentFragment : Fragment(), DocumentLoader.Listener {
     }
 
     private fun beforeLoad() {
+        // the page on screen is about to be published over - see expectNewPage
+        pageView?.expectNewPage()
+
         // whatever the last load had to say was about the last document. the offer to reopen is
         // indefinite, so without this it sits over the document that came after it
         SnackbarHelper.dismiss(requireActivity())

--- a/app/src/main/java/app/opendocument/droid/ui/widget/PageView.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/widget/PageView.kt
@@ -56,6 +56,9 @@ constructor(context: Context, attributeSet: AttributeSet?) :
     /** What [loadUrl] was last given: the only page whose failure is this document's. */
     private var loadedUrl: String? = null
 
+    /** Whether the page on screen is being replaced - see [expectNewPage]. */
+    private var isAwaitingNewPage = false
+
     private var isBridgeAttached = false
 
     init {
@@ -312,6 +315,22 @@ constructor(context: Context, attributeSet: AttributeSet?) :
         resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK ==
             Configuration.UI_MODE_NIGHT_YES
 
+    /**
+     * Stops answering for the page until the one replacing it is asked for.
+     *
+     * `CoreLoader` clears the server before connecting the new translation, so a request the page
+     * still has in flight is answered with a 404 in between - which is not the document failing.
+     * After [loadUrl] the url tells the two apart, each render having a prefix of its own.
+     */
+    fun expectNewPage() {
+        isAwaitingNewPage = true
+
+        stopLoading()
+
+        // the reload waiting in onPageFinished would load the old page back over the new one
+        buggyWebViewHandler.removeCallbacksAndMessages(null)
+    }
+
     override fun loadUrl(url: String) {
         wasCommitCalled = false
 
@@ -327,6 +346,7 @@ constructor(context: Context, attributeSet: AttributeSet?) :
             buggyWebViewHandler.removeCallbacksAndMessages(null)
 
             loadedUrl = url
+            isAwaitingNewPage = false
         }
 
         super.loadUrl(url)
@@ -354,6 +374,11 @@ constructor(context: Context, attributeSet: AttributeSet?) :
         // answered here, long after the page moved on, and the document on screen is not the one
         // that failed
         if (loadedUrl != null && url.toString() != loadedUrl) {
+            return
+        }
+
+        // nor the page that is being replaced right now, whose url is the one replacing it
+        if (isAwaitingNewPage) {
             return
         }
 


### PR DESCRIPTION
Every red `build_test` of the last seventeen was one of two flaky tests - no build or lint failure among them. Both turned out to be real bugs, read off the emulator logcat the failed runs upload.

| test | runs | api |
|---|---|---|
| `MainActivityTests.testDOCXEditMode` (and `testODTEditMode`, `testODT`) | 12 | 29, 32, 34 |
| `DarkModeTests.theSwitchDarkensADayModeApp` | 9 | 30, 34 |
| `DarkModeTests.theDrawnPageIsDark` | 3 | 34 |
| `LargeTextTests.aMegabyteOfTextOpensAndIsSearchable` | 2 | 30 |

### The page being replaced was given up on

```
CoreLoader: host file          <- edit mode renders it again
...
RuntimeException: serving http://localhost:29665/file/odr/document.html failed: 404 Not Found
        at PageView.onReceivedHttpError
smn: close_failed_document
```

`host()` calls `server.clear()` and only then opens, decodes and translates the file, which on a cold emulator is hundreds of milliseconds. A request the page on screen still had in flight is answered 404 in that window - and it carries the *same* url as the page that replaces it, since the document was always served under the one `odr` prefix. `failPage`'s existing guard compares urls, so it could not tell them apart, and the document the user had just asked to edit was reported as broken.

Each render now publishes under a prefix of its own, and `expectNewPage` - called from `beforeLoad`, which every load goes through - stops the page and holds the answer until `loadUrl` asks for the replacement. Either half alone leaves an ordering the other covers: the flag catches the 404 that arrives before the new `loadUrl`, the prefix the one that arrives after. `onPageStarted` looked like the natural place to clear the flag and is not - `onReceivedHttpError` can beat it, which `aPageTheServerCannotServeOffersContact` caught.

Nothing here is only a test's problem: pressing Edit, or the margins button, before the page has painted closes the document.

### A switch soon after opening left a blank page

```
smn: menu_night_mode_enter
ODR: onSaveInstanceState
ODR: restoring lastDocument
```
and then nothing for sixty seconds, screen white.

Switching night mode recreates the activity, and a webview saves nothing of a page it has not committed yet - so `restoreState` hands back null. `restoreTabs` loads a part only where there is more than one, so a single part document had nothing left to put it back. It now loads the part itself when the restore came up empty.

### `theDrawnPageIsDark` is still open

It fails on API 34 alone, reporting a page that *drew light*, and I could not reproduce it: on a local emulator the document draws properly dark, at the ci's 320x640 screen too, so the app's own logic is fine. That emulator ships webview 113 and there is no API 34 image on this machine to put beside it.

A mean luminance cannot say whether a page drew light or never drew at all, so the two pixel tests now keep the screen they measured in gradle's `additionalTestOutputDir`, and the test results artifact carries that directory. The next red run answers it.

Tested with `spotlessApply assembleDebug lintProDebug testProDebugUnitTest`, and `connectedProDebugAndroidTest` green four runs running. One run in between failed eight of `MainActivityTests` at once - the clean tree failed the same way on the same emulator straight after, so that was the machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)