### PR TITLE
Take the failed load and the hand-over copy off the main thread

### DIFF
--- a/app/src/main/java/app/opendocument/droid/background/DocumentLoader.kt
+++ b/app/src/main/java/app/opendocument/droid/background/DocumentLoader.kt
@@ -11,6 +11,7 @@ import app.opendocument.core.OdrException
 import app.opendocument.droid.nonfree.AnalyticsConstants
 import app.opendocument.droid.nonfree.AnalyticsManager
 import app.opendocument.droid.nonfree.CrashManager
+import java.io.File
 import java.io.IOException
 
 /**
@@ -75,6 +76,41 @@ class DocumentLoader(application: Application) : AndroidViewModel(application) {
 
     fun save(document: LoadedDocument, target: Uri, htmlDiff: String?) {
         backgroundHandler.post { saveSync(document, target, htmlDiff) }
+    }
+
+    /**
+     * Copies the cached document to a file named after it, for handing to another app, and answers
+     * on the main thread. Null where the copy failed.
+     *
+     * On the background thread because a copy is as long as the document is big - on the main one
+     * it holds the input dispatcher for the whole of it.
+     */
+    fun copyForHandover(file: IdentifiedFile, onCopied: (Uri?) -> Unit) {
+        backgroundHandler.post {
+            val handoverUri =
+                try {
+                    val cacheFile = checkNotNull(FileCache.getCacheFile(context, file.cacheUri))
+                    val handoverFile =
+                        File(
+                            FileCache.getCacheDirectory(cacheFile),
+                            "yourdocument." + file.extension,
+                        )
+
+                    // a document handed over and opened back into this app is already the
+                    // copy - copying it onto itself truncates it to nothing
+                    if (cacheFile != handoverFile) {
+                        StreamUtil.copy(cacheFile, handoverFile)
+                    }
+
+                    FileCache.getCacheFileUri(context, handoverFile)
+                } catch (e: Throwable) {
+                    crashManager.log(e)
+
+                    null
+                }
+
+            mainHandler.post { onCopied(handoverUri) }
+        }
     }
 
     private fun loadSync(request: DocumentRequest) {

--- a/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
@@ -5,6 +5,8 @@ import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.text.InputType
 import android.text.SpannableString
 import android.text.Spanned
@@ -27,13 +29,11 @@ import app.opendocument.droid.R
 import app.opendocument.droid.background.DocumentDarkening
 import app.opendocument.droid.background.DocumentLoader
 import app.opendocument.droid.background.DocumentRequest
-import app.opendocument.droid.background.FileCache
 import app.opendocument.droid.background.IdentifiedFile
 import app.opendocument.droid.background.LoadedDocument
 import app.opendocument.droid.background.NightModeSetting
 import app.opendocument.droid.background.PaginationSetting
 import app.opendocument.droid.background.ReviewInvitation
-import app.opendocument.droid.background.StreamUtil
 import app.opendocument.droid.background.SupportedDocumentTypes
 import app.opendocument.droid.nonfree.AnalyticsConstants
 import app.opendocument.droid.nonfree.AnalyticsManager
@@ -44,9 +44,7 @@ import app.opendocument.droid.ui.widget.DocumentActions
 import app.opendocument.droid.ui.widget.PageView
 import app.opendocument.droid.ui.widget.ProgressDialogFragment
 import com.google.android.material.tabs.TabLayout
-import java.io.File
 import java.io.FileNotFoundException
-import java.io.IOException
 
 class DocumentFragment : Fragment(), DocumentLoader.Listener {
 
@@ -75,6 +73,8 @@ class DocumentFragment : Fragment(), DocumentLoader.Listener {
 
     /** A loader callback that arrived while the activity was stopped, replayed by [onStart]. */
     private var replayOnStart: (() -> Unit)? = null
+
+    private val handler = Handler(Looper.getMainLooper())
 
     private var freshOpenPending = false
 
@@ -320,7 +320,9 @@ class DocumentFragment : Fragment(), DocumentLoader.Listener {
         val replay = replayOnStart ?: return
         replayOnStart = null
 
-        replay()
+        // posted: onStart runs inside the fragment manager's state dispatch, and a failure ends
+        // in closeFailedDocument's commitNow(), which throws while a dispatch is executing
+        handler.post(replay)
     }
 
     private fun load(request: DocumentRequest) {
@@ -973,46 +975,53 @@ class DocumentFragment : Fragment(), DocumentLoader.Listener {
         SnackbarHelper.show(
             activity,
             description,
-            { doReopen(activity, request, file, true, false) },
+            { doReopen(activity, request, file, share = false) },
             isIndefinite = isIndefinite,
             isError = false,
         )
     }
 
     fun openWith(activity: Activity) {
-        doReopen(activity, requireLastRequest(), state.lastFile, true, false)
+        doReopen(activity, requireLastRequest(), state.lastFile, share = false)
     }
 
     fun share(activity: Activity) {
-        doReopen(activity, requireLastRequest(), state.lastFile, true, true)
+        doReopen(activity, requireLastRequest(), state.lastFile, share = true)
     }
 
     private fun doReopen(
         activity: Activity,
         request: DocumentRequest,
         file: IdentifiedFile?,
+        share: Boolean,
+    ) {
+        // nothing was read whole, so there is no copy of ours to hand on
+        if (file == null) {
+            startReopen(activity, request.uri, null, true, share)
+
+            return
+        }
+
+        // having a file is having read it whole: what is handed on is our copy, under a name the
+        // receiving app can make sense of
+        documentLoader.copyForHandover(file) { handoverUri ->
+            // the reopen bar outlives the fragment, and the copy outlives the tap
+            if (activity.isFinishing || activity.isDestroyed) {
+                return@copyForHandover
+            }
+
+            startReopen(activity, handoverUri ?: request.uri, file.mimeType, true, share)
+        }
+    }
+
+    /** Puts the document in front of whatever else on the device can take it. */
+    private fun startReopen(
+        activity: Activity,
+        reopenUri: Uri,
+        fileType: String?,
         grantPermission: Boolean,
         share: Boolean,
     ) {
-        val fileType = file?.mimeType
-
-        var reopenUri = request.uri
-        // having a file is having read it whole: what is handed on is our copy, under a name the
-        // receiving app can make sense of
-        if (file != null) {
-            val cacheFile = FileCache.getCacheFile(activity, file.cacheUri)
-            val cacheDirectory = FileCache.getCacheDirectory(checkNotNull(cacheFile))
-
-            val reopenFile = File(cacheDirectory, "yourdocument." + file.extension)
-            try {
-                StreamUtil.copy(cacheFile, reopenFile)
-
-                reopenUri = FileCache.getCacheFileUri(activity, reopenFile)
-            } catch (e: IOException) {
-                crashManager.log(e)
-            }
-        }
-
         val intent = Intent()
 
         intent.action = if (share) Intent.ACTION_SEND else Intent.ACTION_VIEW
@@ -1055,7 +1064,7 @@ class DocumentFragment : Fragment(), DocumentLoader.Listener {
 
             if (grantPermission) {
                 // if we're trying to reopen the originalUri, the provider might decline the request
-                doReopen(activity, request, file, false, share)
+                startReopen(activity, reopenUri, fileType, false, share)
             }
         }
     }


### PR DESCRIPTION
Two of the ★ clusters the release reports have been carrying, both on the path a document takes when it leaves the app.

## `MainActivity.closeDocument` `IllegalStateException`

Five version codes, 41300 through 41700, and at its worst on the current release. The standing note has it as `commitNow()` raising *"Can not perform this action after onSaveInstanceState"*, with a saved-state guard as the fix. That guard has been there since before 4.13.0 — `isActivityReadyForOutcome` returns false on `activity == null || isStateSaved`, and every `giveUp()` path is behind it — so it was never the mechanism.

It is a different `IllegalStateException`. An outcome that arrives while the activity is stopped is held in `replayOnStart` and replayed by `DocumentFragment.onStart`, which runs inside `FragmentManager.dispatchStateChange` — `mExecutingActions` is true for the whole of it. A failure replayed there reaches `closeFailedDocument` and its `commitNow()`, and `ensureExecReady` throws **"FragmentManager is already executing transactions"** before it ever gets to the state-loss check. `commitNowAllowingStateLoss` throws the same one; `commit()` is not an option, since `closeDocument` needs the removal to have happened before it finishes the action mode.

Posting the replay puts it one message past the dispatch. If the fragment has stopped again by then, the guard re-arms it — the same self-healing it already had.

Reproduced on an emulator, on 4.17.0's code: open a 150 MB file that cannot be parsed, screen off while it caches, screen on when the failure has landed.

```
java.lang.IllegalStateException: FragmentManager is already executing transactions
	at androidx.fragment.app.FragmentManager.ensureExecReady(FragmentManager.java:1695)
	at androidx.fragment.app.BackStackRecord.commitNow(BackStackRecord.java:317)
	at app.opendocument.droid.ui.activity.MainActivity.closeDocument(MainActivity.kt:822)
	at app.opendocument.droid.ui.activity.MainActivity.closeFailedDocument(MainActivity.kt:766)
	at app.opendocument.droid.ui.activity.DocumentFragment.giveUp(DocumentFragment.kt:891)
	at app.opendocument.droid.ui.activity.DocumentFragment.onError(DocumentFragment.kt:750)
	at app.opendocument.droid.ui.activity.DocumentFragment.onStart(DocumentFragment.kt:323)
	at androidx.fragment.app.FragmentManager.dispatchStart(FragmentManager.java:2902)
```

With the change the same sequence goes back to the landing screen with the contact dialog, which is what the path is for.

## `StreamUtil.copy` ANR, *I/O in main thread*

`doReopen` copied the entire cached document where the tap arrived, so share, open-with and the reopen bar held the input dispatcher for as long as the file took to write. It scales with the document, which is why it found the users with the biggest ones.

The copy moves to `DocumentLoader.copyForHandover`, on the thread that already reads documents whole. Starting the chooser splits off into `startReopen`, so the retry without the read grant reuses the copy instead of making a second one. The callback drops out if the activity has gone — the reopen bar outlives the fragment, and now the copy outlives the tap.

The other three `StreamUtil.copy` sites were already off the main thread: `FileCache.store` and `DocumentSaver` are on the loader thread, `PageView.sendFile` on the WebView's bridge thread.

## The hand-over copy could truncate itself

Found while testing the above. Hand a document to another app, let the chooser hand it back to us, hand it over again: the cached document *is* `yourdocument.odt` by then, so the copy opens it for writing and reads back the file it just emptied. Zero bytes, and the reload fails — on the path in the first half of this PR. `copyForHandover` skips the copy when source and target are the same file.

## Testing

`spotlessCheck assembleDebug testProDebugUnitTest lintProDebug`, and by hand on a Pixel 6 Pro emulator: the crash reproduced and gone, share and open-with both reaching the chooser with an intact `yourdocument.odt`, and two hand-over rounds in a row staying at full size.

No automated test for the crash — it needs the activity stopped and restarted around a load, and the instrumented tests use `ActivityTestRule` with no lifecycle control (and no UiAutomator). The share and open-with paths have no instrumented coverage either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)