### PR TITLE
Suggest the document's own name when saving it

### DIFF
--- a/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
@@ -1179,6 +1179,9 @@ class DocumentFragment : Fragment(), DocumentLoader.Listener {
     val lastFileType: String?
         get() = state.lastFile?.mimeType
 
+    val lastFilename: String?
+        get() = state.lastFile?.filename
+
     override fun onDestroyView() {
         super.onDestroyView()
 

--- a/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/MainActivity.kt
@@ -369,6 +369,10 @@ class MainActivity : AppCompatActivity() {
 
             intent.type = documentFragment.lastFileType
 
+            // the picker opens with an empty name field otherwise, and what the user wants to
+            // call the copy is almost always what the document is already called
+            documentFragment.lastFilename?.let { intent.putExtra(Intent.EXTRA_TITLE, it) }
+
             leftForOwnActivity = true
             createDocumentLauncher.launch(intent)
         } catch (e: ActivityNotFoundException) {


### PR DESCRIPTION
`ACTION_CREATE_DOCUMENT` was launched with a mime type but no `EXTRA_TITLE`, so the picker opened with an empty name field and every save began by typing a name from scratch. What the copy should be called is almost always what the document is already called.

The suggestion comes from `IdentifiedFile.filename` — the provider's own display name for the file that was opened — reached through a new `DocumentFragment.lastFilename` beside the existing `lastFileType`.

Only the first save of a document reaches the picker; a second one goes straight to `lastSaveUri` and never shows it.

Noticed while trying to reproduce #442, which does not reproduce on 4.17.0 — its 0-byte file was the pre-#561 write, and both issues are now closed.

## Testing

`spotlessCheck assembleDebug testProDebugUnitTest lintProDebug`, and by hand on a Pixel 6 Pro emulator: opening `doc.ods` and tapping Save now opens the picker with `doc.ods` in the field, and saving it writes 8567 bytes — byte-for-byte the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)