### PR TITLE
Trim the comments the reopen work left, and log it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ version code per locale under `fastlane/metadata/android/<locale>/changelogs/`,
 written by `scripts/store-copy.py` before the release and uploaded by it. Play
 takes 500 characters, so not everything here reaches the store.
 
+## Unreleased
+
+- A document that fails to open while the app is in the background no longer
+  crashes it on the way back.
+- Sharing a document, or opening it in another app, no longer freezes the app
+  while its copy is written. A large document could freeze it long enough for
+  Android to offer to close it.
+- Handing the same document on twice no longer empties the copy.
+
 ## 4.17.0
 
 - A PDF saved straight out of a browser opens. The web server's response was

--- a/app/src/main/java/app/opendocument/droid/background/DocumentLoader.kt
+++ b/app/src/main/java/app/opendocument/droid/background/DocumentLoader.kt
@@ -82,8 +82,7 @@ class DocumentLoader(application: Application) : AndroidViewModel(application) {
      * Copies the cached document to a file named after it, for handing to another app, and answers
      * on the main thread. Null where the copy failed.
      *
-     * On the background thread because a copy is as long as the document is big - on the main one
-     * it holds the input dispatcher for the whole of it.
+     * On the background thread: a copy is as long as the document is big.
      */
     fun copyForHandover(file: IdentifiedFile, onCopied: (Uri?) -> Unit) {
         backgroundHandler.post {
@@ -96,8 +95,8 @@ class DocumentLoader(application: Application) : AndroidViewModel(application) {
                             "yourdocument." + file.extension,
                         )
 
-                    // a document handed over and opened back into this app is already the
-                    // copy - copying it onto itself truncates it to nothing
+                    // a document opened back into this app is already the copy, and
+                    // copying it onto itself empties it
                     if (cacheFile != handoverFile) {
                         StreamUtil.copy(cacheFile, handoverFile)
                     }

--- a/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
+++ b/app/src/main/java/app/opendocument/droid/ui/activity/DocumentFragment.kt
@@ -320,8 +320,8 @@ class DocumentFragment : Fragment(), DocumentLoader.Listener {
         val replay = replayOnStart ?: return
         replayOnStart = null
 
-        // posted: onStart runs inside the fragment manager's state dispatch, and a failure ends
-        // in closeFailedDocument's commitNow(), which throws while a dispatch is executing
+        // posted: onStart runs inside the fragment manager's dispatch, where the commitNow()
+        // that closeFailedDocument ends in throws
         handler.post(replay)
     }
 
@@ -1014,7 +1014,6 @@ class DocumentFragment : Fragment(), DocumentLoader.Listener {
         }
     }
 
-    /** Puts the document in front of whatever else on the device can take it. */
     private fun startReopen(
         activity: Activity,
         reopenUri: Uri,


### PR DESCRIPTION
#631 landed without changelog entries, which the file says belong in the pull request that makes the change. Adds them, and cuts its comments back to what the code cannot show.

- `copyForHandover`'s second paragraph retold the ANR; the reason it is off the main thread is that a copy is as long as the document is big.
- `startReopen`'s KDoc restated its own name.
- The rest keep their *why* — a `commitNow()` inside the fragment manager's dispatch, and a copy onto itself — in fewer words.

🤖 Generated with [Claude Code](https://claude.com/claude-code)