### PR TITLE
Say "É o primeiro" to Brazil, not "É&#39;o primeiro"

### DIFF
--- a/fastlane/metadata/android/pt-BR/short_description.txt
+++ b/fastlane/metadata/android/pt-BR/short_description.txt
@@ -1,1 +1,1 @@
-É&#39;o primeiro e melhor leitor de docs OpenOffice e LibreOffice para Android!
+É o primeiro e melhor leitor de docs OpenOffice e LibreOffice para Android!

--- a/scripts/store-listing.py
+++ b/scripts/store-listing.py
@@ -101,6 +101,14 @@ LIMITS = {
     "full_description.txt": 4000,
 }
 
+# Of the localised files, the ones play shows verbatim. An html entity in either
+# is a leftover from wherever the text was copied through and reaches the store
+# spelled out: pt-BR read "É&#39;o primeiro" for three releases before anyone
+# looked. `full_description.txt` is deliberately not here - play takes a subset
+# of html there, where `&amp;` is a spelling rather than a slip.
+PLAIN = ("title.txt", "short_description.txt")
+ENTITY = re.compile(r"&(#[0-9]+|#[xX][0-9a-fA-F]+|[a-zA-Z][a-zA-Z0-9]*);")
+
 # The names a `${...}` may have. Declared, so that a misspelt one is an error
 # rather than a sentence that quietly disappears from the store.
 FILL_INS = ("ads",)
@@ -246,6 +254,7 @@ def stage(texts, directory, code, app=None, metadata=METADATA):
         raise ValueError(f"no such app: {app} - one of {', '.join(APPS)}")
 
     oversized = []
+    escaped = []
     unsaid = []
 
     def write(folder, name, text, places):
@@ -255,6 +264,11 @@ def stage(texts, directory, code, app=None, metadata=METADATA):
             oversized.append(
                 f"{folder.name}/{name} is {len(text.strip())} characters, "
                 f"over play's {limit}"
+            )
+        if name in PLAIN:
+            escaped.extend(
+                f"{folder.name}/{name} says '&{entity};' where play shows no markup"
+                for entity in ENTITY.findall(text)
             )
         (folder / name).write_text(text, encoding="utf-8")
 
@@ -288,6 +302,11 @@ def stage(texts, directory, code, app=None, metadata=METADATA):
 
     if oversized:
         raise ValueError("play would refuse this listing:\n  " + "\n  ".join(oversized))
+
+    if escaped:
+        raise ValueError(
+            "play would show this listing's markup as text:\n  " + "\n  ".join(escaped)
+        )
 
     return directory
 


### PR DESCRIPTION
An html-escaped apostrophe leaked into `pt-BR/short_description.txt`, and since this repository became the listing's source of truth every release has pushed it to Play. What a Brazilian reader sees under the title today:

> É&#39;o primeiro e melhor leitor de docs OpenOffice e LibreOffice para Android!

The apostrophe was never right in Portuguese either — `É o primeiro` is the sentence — so the entity goes rather than being unescaped. 75 characters, inside Play's 80.

It is the only one in the tree; the other fourteen locales are clean.

## The guard

Play renders no markup in the title or the short description, so an entity in either can only be a leftover from wherever the text was copied through. `store-listing.py` now refuses one while staging, next to the length check and for the same reason — the `listing` job is the last place this is still cheap to find, and it runs before supply is handed anything.

`full_description.txt` is deliberately **not** checked: Play takes a subset of HTML there, where `&amp;` is a spelling rather than a slip.

Checked both ways — `pro` and `lite` stage clean on the fixed tree, and putting the old line back fails the stage with:

```
play would show this listing's markup as text:
  pt-BR/short_description.txt says '&#39;' where play shows no markup
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014jkqSYna19JpGFe6S7AkXi