### PR TITLE
Take odrcore 6.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,34 @@ version code per locale under `fastlane/metadata/android/<locale>/changelogs/`,
 written by `scripts/store-copy.py` before the release and uploaded by it. Play
 takes 500 characters, so not everything here reaches the store.
 
+## Unreleased
+
+- Charts in OpenDocument files are drawn from the chart itself - bar, line,
+  area, scatter, pie and ring, with their titles, legends, axes and colours -
+  rather than from the flat picture saved beside it.
+- Shapes in OpenDocument drawings and presentations appear as the shapes they
+  are, and where the file puts them. Arrows, stars, callouts, curves,
+  connectors, ellipses and measures used to come out as plain rectangles or not
+  at all, and a rotated or mirrored one sat square.
+- Pictures and charts stored as Windows metafiles draw: their lines, curves,
+  gradients, bitmaps and labels, each in the encoding the file names. Such an
+  image used to be an empty frame, or a table's rules a row of floating numbers.
+- A floating picture in a Word document floats where it was anchored, with the
+  text wrapping around it, instead of sitting in the line.
+- A Word table's own borders are drawn, and at the thickness the file asks for
+  rather than four times it. A table cell's content starts at the top of the
+  cell, as Word and OpenDocument show it.
+- A manual page break starts a new page, on screen and in print.
+- Lines in a PDF are drawn at the width the file sets. A PDF from Canva had
+  every stroke at the same weight, whatever it was meant to be.
+- Spreadsheets open in about half the memory, and two more of them open at all:
+  a sheet whose repeated cells claimed billions of positions, and one with a
+  merged range naming more cells than the sheet has.
+- Pictures in a document load side by side rather than one after another: two
+  parts of the same file can be read at once now.
+- A password-protected document opens read-only. Saving it wrote the content
+  back out without the protection its author asked for, and said nothing.
+
 ## 4.18.0
 
 - A spreadsheet shows ten times as many rows: the cap rises from 10,000 to

--- a/app/src/androidTest/java/app/opendocument/droid/test/CoreTest.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/CoreTest.kt
@@ -182,6 +182,28 @@ class CoreTest {
     }
 
     /**
+     * A document only held decrypted is read only, so no Edit button appears over it. The same odt
+     * without a password is editable - see [testEditableFormats] - and saving this one would have
+     * written the content back out without the protection its author asked for.
+     */
+    @Test
+    fun testDecryptedDocumentIsNotEditable() {
+        coreLoader.host(
+            prefix = "password-test-editable",
+            inputPath = passwordTestFile.absolutePath,
+            cachePath = File(cacheDir(), "password_editable").path,
+            password = "passwort",
+            editable = true,
+            keepDocument = true,
+        )
+
+        Assert.assertFalse(
+            "a decrypted document should not be editable",
+            coreLoader.isDocumentEditable,
+        )
+    }
+
+    /**
      * An encrypted `.doc` says so rather than failing as a parse error, and odrcore has no way into
      * it, so [CoreLoader.host] refuses it instead of raising a prompt no password can close.
      */

--- a/app/src/main/java/app/opendocument/droid/background/CoreLoader.kt
+++ b/app/src/main/java/app/opendocument/droid/background/CoreLoader.kt
@@ -211,12 +211,15 @@ class CoreLoader(private val context: Context) {
     /**
      * What the document is *called*. Not [IdentifiedFile.mimeType]: `FileIdentifier` takes that
      * from `Odr.mimetype` wherever it answered, so it would be the same reading again.
+     *
+     * Only a name the core has a decoder for: html is named by the table and not opened by it, so
+     * calling a file `.html` answers nothing [openAs] could act on.
      */
     private fun declaredType(file: IdentifiedFile): FileType? {
         val extension = MimeTypeResolver.parseExtension(file.filename)?.lowercase() ?: return null
         val type = Odr.fileTypeByFileExtension(extension) ?: return null
 
-        return type.takeIf { it != FileType.UNKNOWN }
+        return type.takeIf { it != FileType.UNKNOWN && Odr.capabilitiesByFileType(it).open }
     }
 
     /**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ googleJavaFormat = "1.35.0"
 ktfmt = "0.64"
 
 # odrcore's JNI bindings, java and native in one AAR, published from OpenDocument.core
-odrCore = "6.11.0"
+odrCore = "6.13.0"
 
 androidxAnnotation = "1.10.0"
 androidxAppcompat = "1.8.0"

--- a/tools/render-sweep/render-sweep.sh
+++ b/tools/render-sweep/render-sweep.sh
@@ -34,7 +34,7 @@ INSTALL=0
 # because the tables live in libodr_jni and reading them needs a device - the
 # same reason SupportedDocumentTypesTest is an instrumented test. A format added
 # upstream and missing here just means this sweep skips it.
-CLAIMED='csv|doc|docm|docx|dot|dotm|dotx|fodg|fodp|fods|fodt|key|numbers|odg|odm|odp|ods|odt|otg|otm|otp|ots|ott|pages|pdf|pot|potm|potx|pps|ppsm|ppsx|ppt|pptm|pptx|rtf|text|txt|xlm|xls|xlsm|xlsx|xlt|xltm|xltx|zip'
+CLAIMED='csv|doc|docm|docx|dot|dotm|dotx|fodg|fodp|fods|fodt|key|markdown|md|numbers|odg|odm|odp|ods|odt|otg|otm|otp|ots|ott|pages|pdf|pot|potm|potx|pps|ppsm|ppsx|ppt|pptm|pptx|rtf|text|txt|xlm|xls|xlsm|xlsx|xlt|xltm|xltx|zip'
 
 usage() {
   cat <<'EOF'


### PR DESCRIPTION
Two engine releases in one: [6.12.0](https://github.com/opendocument-app/OpenDocument.core/releases/tag/v6.12.0) and [6.13.0](https://github.com/opendocument-app/OpenDocument.core/releases/tag/v6.13.0).

## What comes for free

Almost all of it. The format table is unchanged apart from html (below), so `SupportedDocumentTypes`, the manifest's generated filters and the store copy all stay as they are.

- **ODF drawings and presentations.** Charts are drawn from the chart part instead of the flat replacement image beside it; custom shapes from their `draw:enhanced-geometry` instead of their bounding box; `draw:path`, `polygon`, `polyline`, `regular-polygon`, `connector`, `ellipse`, `measure` and `caption` at all; and every shape where its `draw:transform` puts it.
- **StarView metafiles** - the format a lot of ODF charts and clip art are stored as - gained bitmaps, gradients, hatches, transparency, clipping, curves, the remaining primitives, correct map modes and text in the charset the file names. They used to come out as empty frames or a row of floating numbers.
- **Word**: a `wp:anchor` drawing floats at its offset with its wrap, table borders are drawn and no longer four times too thick, and a cell's content starts at the top.
- **PDF**: `gs` applies the `/ExtGState` stroke parameters, so a producer that only sets line width there - Canva - no longer draws everything at width 1.
- **Spreadsheets**: about half the decode memory, and two files that could not open before (an ods repeat count asking for three billion elements, an xlsx `mergeCell` naming 17 billion positions).
- A manual page break starts a new page box and prints as `break-before:page`.
- Two entries of the same zip can be read at once, so the WebView's image requests no longer serialise behind one lock.

## What the app had to answer for

**A decrypted document is read-only** (6.13.0, breaking). Every `save` overload now throws for a document decrypted from a password-protected package - it used to write the content back out with the protection stripped, silently. The app already asks `document.isEditable && document.isSavable` before holding one open, so the Edit button disappears on its own; `testDecryptedDocumentIsNotEditable` pins it.

**html is named but not decoded** (6.12.0). `FileType.HYPERTEXT_MARKUP_LANGUAGE` is classification only - no `open`, no `translate_html`, never detected from bytes. It is not claimed anywhere (`CORE_FILE_TYPES` filters on `translateHtml`), but `declaredType` started answering it for a `.html`, and `nameOutranksText` says a name outranks text when the core cannot detect the type from content - so every `.html`, read as text and shown correctly, was reopened as html, failed, and fell back. `declaredType` now answers only for a type the core has a decoder for.

**render-sweep** was missing `md` and `markdown` from its claimed extensions - stale since #636. The list now matches the manifest exactly.

## The one new API, and why it is not used

`DocumentFile.thumbnail()` (6.13.0) hands back the preview a package carries. The obvious home is the recent documents list. It is not worth it: on the core's own corpus, 27 of 33 ODF files carry a thumbnail and **0 of 33** OOXML files do - Word, Excel and PowerPoint only write one when the author ticks "Save Thumbnail". A recent list with a picture on the `.odt` rows and nothing on the `.docx` ones reads as broken. `Document.saveToMemory()` (6.12.0) is the other addition; the save path writes a file and copies it into the SAF uri, and a `byte[]` of a whole document is a worse trade on a phone.

## Verified

- `spotlessCheck`, `lintProDebug`, `testProDebugUnitTest`
- `connectedProDebugAndroidTest` on a Pixel 6 Pro AVD: 89/89, including the format tests that hold `SupportedDocumentTypes` against the manifest
- `render-sweep` over the corpus' drawings and presentations: 10/10 `ok`, no crash and no failed render. The `.odg` of dimension drawings now shows its measure lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)