### PR TITLE
Hand the screenshot run its locales in something gradle keeps

### DIFF
--- a/app/src/androidTest/java/app/opendocument/droid/test/ScreenshotTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/ScreenshotTests.kt
@@ -86,8 +86,10 @@ import org.junit.runner.RunWith
  * ./gradlew connectedProDebugAndroidTest \
  *     -Pandroid.testInstrumentationRunnerArguments.class=app.opendocument.droid.test.ScreenshotTests \
  *     -Pandroid.testInstrumentationRunnerArguments.device=phone \
- *     -Pandroid.testInstrumentationRunnerArguments.locales=en-US,de-DE
+ *     -Pandroid.testInstrumentationRunnerArguments.locales=en-US+de-DE
  * ```
+ *
+ * A plus rather than a comma, for the reason [locales] gives.
  *
  * Wants android 15 or newer, and says so rather than photographing what an older one draws.
  */

--- a/app/src/androidTest/java/app/opendocument/droid/test/ScreenshotTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/ScreenshotTests.kt
@@ -89,8 +89,6 @@ import org.junit.runner.RunWith
  *     -Pandroid.testInstrumentationRunnerArguments.locales=en-US+de-DE
  * ```
  *
- * A plus rather than a comma, for the reason [locales] gives.
- *
  * Wants android 15 or newer, and says so rather than photographing what an older one draws.
  */
 @LargeTest
@@ -604,9 +602,7 @@ class ScreenshotTests {
     /**
      * The locales to photograph: every one the listing is written in, unless fewer were named.
      *
-     * Either separator, because gradle cannot be trusted with a comma: AGP 9.4.0 cuts a
-     * `-Pandroid.testInstrumentationRunnerArguments.<key>=a,b` at the first one, so the lane hands
-     * this a `+` and only a run driving `am instrument` itself still spells it with a comma.
+     * A plus separates them as well as a comma, which AGP 9.4.0 cuts such a property at.
      */
     private fun locales(spoken: JSONObject): List<String> {
         val known = spoken.keys().asSequence().sorted().toList()

--- a/app/src/androidTest/java/app/opendocument/droid/test/ScreenshotTests.kt
+++ b/app/src/androidTest/java/app/opendocument/droid/test/ScreenshotTests.kt
@@ -599,7 +599,13 @@ class ScreenshotTests {
 
     // --- what the run was asked for -----------------------------------------
 
-    /** The locales to photograph: every one the listing is written in, unless fewer were named. */
+    /**
+     * The locales to photograph: every one the listing is written in, unless fewer were named.
+     *
+     * Either separator, because gradle cannot be trusted with a comma: AGP 9.4.0 cuts a
+     * `-Pandroid.testInstrumentationRunnerArguments.<key>=a,b` at the first one, so the lane hands
+     * this a `+` and only a run driving `am instrument` itself still spells it with a comma.
+     */
     private fun locales(spoken: JSONObject): List<String> {
         val known = spoken.keys().asSequence().sorted().toList()
 
@@ -608,7 +614,7 @@ class ScreenshotTests {
             return known
         }
 
-        val wanted = given.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+        val wanted = given.split(',', '+').map { it.trim() }.filter { it.isNotEmpty() }
         val unknown = wanted.filterNot { it in known }
         Assert.assertTrue(
             "no such locale: ${unknown.joinToString()}. One of ${known.joinToString()}",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -330,12 +330,7 @@ platform :android do
         "android.testInstrumentationRunnerArguments.class" =>
           "app.opendocument.droid.test.ScreenshotTests",
         "android.testInstrumentationRunnerArguments.device" => device,
-        # joined with a plus rather than a comma: AGP 9.4.0 cuts one of these
-        # properties at the first comma, so `cs-CZ,de-DE,...` reached the runner
-        # as `cs-CZ` and 4.19.0 went to the store with one locale photographed.
-        # The same bug drops every class but the first from the documented
-        # `class=TestA,TestB`, so it is AGP's rather than ours - and the check
-        # below is here because that run still passed.
+        # a plus, not a comma: AGP 9.4.0 cuts one of these at the first comma
         "android.testInstrumentationRunnerArguments.locales" => languages.join("+")
       }
     )
@@ -348,12 +343,8 @@ platform :android do
       )
     end
 
-    # Every language this run asked for, or the run did less than it was told and
-    # said nothing: the test photographs the locales it was handed and passes on
-    # whatever that turned out to be, so a list mangled on the way in - which is
-    # what the plus above is for - looks exactly like a run that was asked for
-    # one language. Checked per language rather than as a full set, so it holds
-    # for the release's half a set too.
+    # a short list photographs as a complete run, so the count is what catches it.
+    # Per language rather than as a set, which a release runner does not have.
     missing = languages - taken.map { |path| File.basename(File.dirname(path)) }.uniq
     unless missing.empty?
       UI.user_error!(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -330,7 +330,13 @@ platform :android do
         "android.testInstrumentationRunnerArguments.class" =>
           "app.opendocument.droid.test.ScreenshotTests",
         "android.testInstrumentationRunnerArguments.device" => device,
-        "android.testInstrumentationRunnerArguments.locales" => languages.join(",")
+        # joined with a plus rather than a comma: AGP 9.4.0 cuts one of these
+        # properties at the first comma, so `cs-CZ,de-DE,...` reached the runner
+        # as `cs-CZ` and 4.19.0 went to the store with one locale photographed.
+        # The same bug drops every class but the first from the documented
+        # `class=TestA,TestB`, so it is AGP's rather than ours - and the check
+        # below is here because that run still passed.
+        "android.testInstrumentationRunnerArguments.locales" => languages.join("+")
       }
     )
 
@@ -339,6 +345,20 @@ platform :android do
       UI.user_error!(
         "the run wrote no screenshots. A run that photographed nothing and still passed is a " \
         "run that skipped the test - it needs one emulator on adb, running android 15 or newer."
+      )
+    end
+
+    # Every language this run asked for, or the run did less than it was told and
+    # said nothing: the test photographs the locales it was handed and passes on
+    # whatever that turned out to be, so a list mangled on the way in - which is
+    # what the plus above is for - looks exactly like a run that was asked for
+    # one language. Checked per language rather than as a full set, so it holds
+    # for the release's half a set too.
+    missing = languages - taken.map { |path| File.basename(File.dirname(path)) }.uniq
+    unless missing.empty?
+      UI.user_error!(
+        "the run photographed #{missing.length} of #{languages.length} languages: " \
+        "nothing came out for #{missing.join(', ')}"
       )
     end
 


### PR DESCRIPTION
The 4.19.0 release photographed one locale of fifteen, on both devices, and both `screenshots` jobs reported success. `screenshot-set` caught it and the store kept 4.18.0's pictures.

## What happens

AGP 9.4.0 cuts a `-Pandroid.testInstrumentationRunnerArguments.<key>` value at the first comma. Measured on this tree against one emulator, same command, same everything but the plugin:

| passed | reaches the runner |
|---|---|
| `locales=de-DE,en-US` under 9.3.2 | `args_map { key: "locales" value: "de-DE,en-US" }` |
| `locales=de-DE,en-US` under 9.4.0 | `-e locales de-DE` |
| `locales=de-DE+en-US` under 9.4.0 | `-e locales de-DE+en-US` |
| `class=A#doesNotExist,B` under 9.4.0 | `-e class A#doesNotExist` |
| `sizes=a b,c` under 9.4.0 | `-e sizes a b` |

A space survives and a comma does not, and the last row is the documented multi-class form, so this is AGP's rather than ours. Nothing in the 9.4.0 release notes mentions it.

## What changes

**The lane joins with a plus** and the test splits on either, so `am instrument` driven by hand still takes a comma.

**The lane checks that every language it asked for came out.** That is the part that let this reach the store: `ScreenshotTests` photographs the locales it is handed and passes, so a list mangled on the way in is indistinguishable from a run asked for one language - and `screenshots_narrowed?` skips the full-set check on a release runner, which is holding half a set by design. The new check is per language, so it holds for that half too.

## Checked

Against the API 36 AVD with the fifteen-locale list: `-e locales cs-CZ+de-DE+en-US+es-ES+et+fr-FR+hi-IN+it-IT+ja-JP+pl-PL+pt-BR+ru-RU+sv-SE+tr-TR+zh-CN` arrives whole. A full local capture is not part of this - the next release run is what exercises it end to end.

4.19.0's own pictures are not restored by this: `build/v4.19.0` is written, so the release run refuses that version. The store shows 4.18.0's until the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017zSYiEKUuTFhMy3jpee99C