### PR TITLE
Replace the banner on a width change instead of resizing it

### DIFF
--- a/app/src/ads/java/app/opendocument/droid/nonfree/AdManager.kt
+++ b/app/src/ads/java/app/opendocument/droid/nonfree/AdManager.kt
@@ -317,14 +317,23 @@ class AdManager {
             return
         }
 
-        val adView = this.adView ?: addAdView().also { this.adView = it }
-
         // an anchored banner keeps the size it was asked at, so a real width change needs a new
         // one - but a keyboard opening, or a rotation back, does not
-        if (adWidth == requestedWidth) {
+        val previous = this.adView
+        if (previous != null && adWidth == requestedWidth) {
             return
         }
         requestedWidth = adWidth
+
+        // AdView.setAdSize throws once the view has a size, so a width change replaces the banner
+        // rather than resizing it, and the ad that was up goes with it
+        if (previous != null) {
+            destroyAdView()
+            adContainer.removeView(previous)
+            hasAd = false
+        }
+
+        val adView = addAdView().also { this.adView = it }
 
         adView.setAdSize(adSize)
 


### PR DESCRIPTION
`AdView.setAdSize` throws `IllegalStateException: The ad size can only be set
once on AdView`, and #643 made the `AdView` long-lived, so `refreshAds` reached
`setAdSize` a second time on the first rotation that actually changed the banner
width. The free app crashed out of `MainActivity.onConfigurationChanged`.

A width change now destroys the banner and adds a new one, which is what the
comment above it already said was needed. `hasAd` resets with it, so a new view
that fails to fill still falls back to the house ad and retries.

Found by Play's pre-launch report while promoting 4.19.0 — that release is held
and unsubmitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)