### PR TITLE
ci control (do not merge)

### DIFF
--- a/app/src/ads/java/app/opendocument/droid/nonfree/AdManager.kt
+++ b/app/src/ads/java/app/opendocument/droid/nonfree/AdManager.kt
@@ -23,6 +23,7 @@ import com.google.android.ump.FormError
 import com.google.android.ump.UserMessagingPlatform
 
 /** The banner in the lite flavor, behind the consent form the ump sdk puts in front of it. */
+// ci control: no-op comment, see PR 655
 class AdManager {
 
     private var enabled = false


### PR DESCRIPTION
Empty commit off the same base as #654, to tell an unrelated emulator failure from a real one. Close after reading.